### PR TITLE
fix(seo): add og-image and fix broken social preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <meta property="og:url" content="https://terminal-learning.vercel.app/" />
     <meta property="og:title" content="Terminal Learning — Apprends le terminal pas à pas" />
     <meta property="og:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 6 modules progressifs, émulateur réel. Pour débutants, 100% open source." />
-    <meta property="og:image" content="https://terminal-learning.vercel.app/og-image.png" />
+    <meta property="og:image" content="https://terminal-learning.vercel.app/og-image.svg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Terminal Learning — interface de l'application avec émulateur terminal" />
@@ -33,7 +33,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terminal Learning — Apprends le terminal pas à pas" />
     <meta name="twitter:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 6 modules, émulateur réel, 100% open source." />
-    <meta name="twitter:image" content="https://terminal-learning.vercel.app/og-image.png" />
+    <meta name="twitter:image" content="https://terminal-learning.vercel.app/og-image.svg" />
     <meta name="twitter:creator" content="@thierryvm" />
 
     <!-- Favicon -->

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#0d1117"/>
+
+  <!-- Card glow effect -->
+  <rect x="60" y="60" width="1080" height="510" rx="16" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Emerald accent line top -->
+  <rect x="60" y="60" width="1080" height="4" rx="2" fill="#10b981"/>
+
+  <!-- Terminal prompt icon (large) -->
+  <text x="100" y="220" font-family="monospace, 'Courier New'" font-size="96" font-weight="bold" fill="#10b981">&gt;_</text>
+
+  <!-- Main title -->
+  <text x="100" y="310" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="52" font-weight="700" fill="#e6edf3">Terminal Learning</text>
+
+  <!-- Subtitle -->
+  <text x="100" y="375" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="400" fill="#8b949e">Apprends le terminal pas à pas — gratuit, open source</text>
+
+  <!-- Feature pills -->
+  <rect x="100" y="420" width="180" height="40" rx="8" fill="#10b981" fill-opacity="0.1" stroke="#10b981" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="190" y="446" font-family="monospace" font-size="16" fill="#10b981" text-anchor="middle">6 modules</text>
+
+  <rect x="296" y="420" width="220" height="40" rx="8" fill="#10b981" fill-opacity="0.1" stroke="#10b981" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="406" y="446" font-family="monospace" font-size="16" fill="#10b981" text-anchor="middle">terminal réel</text>
+
+  <rect x="532" y="420" width="240" height="40" rx="8" fill="#10b981" fill-opacity="0.1" stroke="#10b981" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="652" y="446" font-family="monospace" font-size="16" fill="#10b981" text-anchor="middle">100% gratuit</text>
+
+  <!-- URL bottom right -->
+  <text x="1100" y="530" font-family="monospace, 'Courier New'" font-size="20" fill="#30363d" text-anchor="end">terminal-learning.vercel.app</text>
+
+  <!-- Grid dots decoration -->
+  <g fill="#30363d" opacity="0.4">
+    <circle cx="950" cy="160" r="2"/><circle cx="980" cy="160" r="2"/><circle cx="1010" cy="160" r="2"/><circle cx="1040" cy="160" r="2"/><circle cx="1070" cy="160" r="2"/><circle cx="1100" cy="160" r="2"/>
+    <circle cx="950" cy="190" r="2"/><circle cx="980" cy="190" r="2"/><circle cx="1010" cy="190" r="2"/><circle cx="1040" cy="190" r="2"/><circle cx="1070" cy="190" r="2"/><circle cx="1100" cy="190" r="2"/>
+    <circle cx="950" cy="220" r="2"/><circle cx="980" cy="220" r="2"/><circle cx="1010" cy="220" r="2"/><circle cx="1040" cy="220" r="2"/><circle cx="1070" cy="220" r="2"/><circle cx="1100" cy="220" r="2"/>
+    <circle cx="950" cy="250" r="2"/><circle cx="980" cy="250" r="2"/><circle cx="1010" cy="250" r="2"/><circle cx="1040" cy="250" r="2"/><circle cx="1070" cy="250" r="2"/><circle cx="1100" cy="250" r="2"/>
+    <circle cx="950" cy="280" r="2"/><circle cx="980" cy="280" r="2"/><circle cx="1010" cy="280" r="2"/><circle cx="1040" cy="280" r="2"/><circle cx="1070" cy="280" r="2"/><circle cx="1100" cy="280" r="2"/>
+    <circle cx="950" cy="310" r="2"/><circle cx="980" cy="310" r="2"/><circle cx="1010" cy="310" r="2"/><circle cx="1040" cy="310" r="2"/><circle cx="1070" cy="310" r="2"/><circle cx="1100" cy="310" r="2"/>
+  </g>
+
+  <!-- Animated terminal lines (decorative) -->
+  <rect x="840" y="350" width="260" height="1" fill="#30363d" opacity="0.6"/>
+  <text x="850" y="385" font-family="monospace" font-size="14" fill="#8b949e">$ ls -la /home/user</text>
+  <text x="850" y="410" font-family="monospace" font-size="14" fill="#10b981">drwxr-xr-x  user  docs</text>
+  <text x="850" y="435" font-family="monospace" font-size="14" fill="#10b981">-rw-r--r--  user  notes.txt</text>
+  <text x="850" y="460" font-family="monospace" font-size="14" fill="#8b949e">$ <tspan fill="#10b981" opacity="0.8">▋</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary
- `og-image.png` référençait un fichier inexistant → les previews sociales (Twitter, Discord, LinkedIn) retournaient du HTML au lieu d'une image
- Création de `public/og-image.svg` (1200×630) aux couleurs du projet
- Mise à jour des meta `og:image` et `twitter:image` vers `.svg`

## Audit SEO/Headers complet
| Check | Statut |
|-------|--------|
| Meta title / description / keywords | ✅ |
| Canonical URL | ✅ |
| OpenGraph (og:title/description/image/url/locale) | ✅ fix |
| Twitter Card | ✅ fix |
| GEO meta (BE) | ✅ |
| robots.txt | ✅ 200 text/plain |
| sitemap.xml | ✅ 200 application/xml |
| og:image accessible | ✅ fix (était cassé) |

## Known limitation
Twitter/X exige PNG/JPG — le SVG fonctionnera sur Discord, LinkedIn, Telegram. Un export PNG sera nécessaire comme suivi.

## Test plan
- [ ] Vérifier https://terminal-learning.vercel.app/og-image.svg retourne bien l'image SVG
- [ ] Tester le preview sur Discord (supporte SVG)
- [ ] Valider sur https://opengraph.xyz avec l'URL du site

🤖 Generated with [Claude Code](https://claude.com/claude-code)