### PR TITLE
fix(security): add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pnpm-debug.log*
 .env
 .env.*
 
+# Claude Code local settings (permissions, not for repo)
+.claude/
+


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` — prevents `settings.local.json` (Claude Code permissions) from being accidentally committed to the public repo

## Why
`.claude/settings.local.json` was untracked but not explicitly excluded. A `git add .` could have committed it, leaking which MCP tools and CLI permissions are configured locally.

The file contains no secrets but should not be in a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build :
- Ajouter le répertoire `.claude/` au fichier `.gitignore` pour éviter les commits accidentels des paramètres locaux de Claude

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add .claude/ directory to .gitignore to prevent accidental commits of local Claude settings

</details>