### PR TITLE
docs: sync all docs to Phase 3 complete state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,14 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 0 ✅ Vercel live
 - Phase 1 ✅ Landing + routing + RGPD + SEO + CI
 - Phase 2 ✅ Analytics (Vercel Analytics + Sentry)
-- Phase 3 🔜 Supabase Auth + DB (projet: `jdnukbpkjyyyjpuwgxhv`, region: eu-west-1)
-- Phase 4 🔮 Admin panel
+- Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
+- Phase 4 🔮 Admin panel (attendre signal trafic)
+
+## Tech debt Phase 3 (post-merge)
+- `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
+  → à terme : déplacer vers `src/types/database.ts`
+- OAuth GitHub + Google : non configurés dans Supabase dashboard (email only pour l'instant)
 
 ## Décisions en attente
 - GitHub Sponsors + Ko-fi — activation suspendue jusqu'à l'accord de la mutuelle RIZIV/INAMI
+- OAuth GitHub + Google — à configurer ensemble quand prêt (Supabase dashboard → Authentication → Providers)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,15 @@
 ```
 src/
 ├── lib/
+│   ├── supabase.ts               # Typed Supabase client (null-safe, fallback to localStorage)
 │   └── sentry.ts                 # Sentry init + error boundary
 ├── app/
-│   ├── App.tsx                   # Root component + providers
+│   ├── App.tsx                   # Root: ErrorBoundary > AuthProvider > ProgressProvider
 │   ├── components/
+│   │   ├── auth/
+│   │   │   ├── LoginModal.tsx    # Email/password + OAuth modal (Zod validation)
+│   │   │   ├── UserMenu.tsx      # Avatar + sync status badge + logout
+│   │   │   └── AuthCallback.tsx  # /auth/callback PKCE handler
 │   │   ├── Landing.tsx           # Public landing page (/)
 │   │   ├── Layout.tsx            # App shell with sidebar (/app)
 │   │   ├── Sidebar.tsx           # Navigation sidebar
@@ -64,7 +69,12 @@ src/
 │   │   ├── NotFound.tsx          # 404 page
 │   │   └── ui/                   # shadcn/ui component library
 │   ├── context/
-│   │   └── ProgressContext.tsx   # Progress state (localStorage)
+│   │   ├── AuthContext.tsx       # Session, user, signOut
+│   │   └── ProgressContext.tsx   # Progress state (local + Supabase sync)
+│   ├── lib/
+│   │   └── progressSync.ts       # mergeProgress() + getDelta() utilities
+│   ├── types/
+│   │   └── database.ts           # Supabase DB types
 │   ├── data/
 │   │   ├── curriculum.ts         # All lessons and modules content
 │   │   └── terminalEngine.ts     # Terminal command interpreter
@@ -80,8 +90,6 @@ public/
 └── robots.txt                    # SEO crawl rules
 vercel.json                       # SPA routing + security headers (CSP)
 ```
-
-> Phase 3 (PR #11 in progress) will add `src/lib/supabase.ts`, `src/app/components/auth/`, `src/app/context/AuthContext.tsx`, and `src/app/lib/progressSync.ts`.
 
 Full architecture details in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
@@ -121,8 +129,8 @@ Security is built into every layer from day one:
 
 - **HTTP Headers** — `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy` via `vercel.json`
 - **Content Security Policy** — strict CSP, no `unsafe-eval`
-- **Auth** — Supabase Auth with PKCE flow, JWT rotation, rate limiting *(Phase 3 — PR #11)*
-- **Database** — Row Level Security (RLS) on all tables, anon key only client-side *(Phase 3 — PR #11)*
+- **Auth** — Supabase Auth with PKCE flow, JWT rotation, rate limiting
+- **Database** — Row Level Security (RLS) on all tables, anon key only client-side
 - **No secrets client-side** — environment variables only
 - **GDPR compliant** — cookieless analytics, privacy page at `/privacy`
 - **Dependency auditing** — `npm audit` in CI + GitHub Dependabot
@@ -138,7 +146,7 @@ See [SECURITY.md](SECURITY.md) for the full security policy and vulnerability re
 | **Phase 0** | ✅ Done | Initial deployment on Vercel |
 | **Phase 1** | ✅ Done | Landing page, routing, SEO/OpenGraph, GDPR |
 | **Phase 2** | ✅ Done | Vercel Analytics + Sentry error monitoring |
-| **Phase 3** | 🔜 In progress | Supabase Auth + user progress sync |
+| **Phase 3** | ✅ Done | Supabase Auth + user progress sync |
 | **Phase 4** | 🔮 Planned | Hyper-secure admin panel — RBAC, 2FA, audit log, analytics |
 
 Full details in [docs/plan.md](docs/plan.md).

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 2 avril 2026
-> Statut global : **Phase 3 en cours** (Supabase Auth implémenté — PR #11 ouverte)
+> Statut global : **Phase 3 TERMINÉE** — en production depuis le 2 avril 2026
 
 ---
 
@@ -28,23 +28,6 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 
 ---
 
-## PRs ouvertes (2 avril 2026)
-
-| PR | Branche | Contenu | Statut |
-|----|---------|---------|--------|
-| #10 | `chore/update-project-state` | CLAUDE.md ✅, og-image.png, Sourcery fixes | CI ✅ — prêt à merger |
-| #11 | `feat/supabase-phase3-auth` | Phase 3 complète (Auth + DB + ProgressSync) | ⚠️ Configurer env vars Vercel avant merge |
-| #12 | `docs/restructure-project` | /docs structure, zombie hook supprimé, docs à jour | CI en attente |
-
-**Ordre de merge recommandé : #10 → #12 → #11**
-
-**Avant de merger #11 :**
-1. Supabase dashboard → Authentication → Providers → activer GitHub OAuth
-2. Supabase dashboard → Authentication → Providers → activer Google OAuth
-3. Vercel → Settings → Environment Variables → ajouter `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY`
-
----
-
 ## Statut des phases
 
 ### ✅ Phase 0 — Déploiement (TERMINÉ)
@@ -62,11 +45,11 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 
 ### ✅ Phase 2 — Analytics + Monitoring (TERMINÉ)
 - [x] Vercel Analytics (GDPR-friendly, sans cookies)
-- [x] Sentry free tier erreurs front (PR #9)
+- [x] Sentry free tier — projet `terminal-learning`, DSN configuré dans Vercel env vars
 
-### 🔜 Phase 3 — Supabase Auth (EN COURS — PR #11)
+### ✅ Phase 3 — Supabase Auth (TERMINÉ — en production)
 
-#### Implémenté (PR #11, pas encore mergé)
+#### Implémenté et mergé
 - [x] Supabase project `jdnukbpkjyyyjpuwgxhv` — `ACTIVE_HEALTHY`, eu-west-1
 - [x] Migration SQL appliquée : `profiles` + `progress` + RLS
 - [x] `src/lib/supabase.ts` — client typé, null-safe (fallback localStorage)
@@ -74,21 +57,23 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 - [x] `src/app/context/AuthContext.tsx` — session, user, signOut
 - [x] `src/app/context/ProgressContext.tsx` — étendu avec syncStatus + upsert Supabase
 - [x] `src/app/lib/progressSync.ts` — mergeProgress() + getDelta()
-- [x] `src/app/components/auth/LoginModal.tsx` — email + GitHub + Google OAuth
+- [x] `src/app/components/auth/LoginModal.tsx` — email/password (OAuth GitHub+Google prêt mais non activé)
 - [x] `src/app/components/auth/UserMenu.tsx` — avatar + sync badge + logout
 - [x] `src/app/components/auth/AuthCallback.tsx` — handler /auth/callback PKCE
 - [x] `/auth/callback` route ajoutée dans `routes.ts`
-- [x] `vercel.json` CSP : connect-src += *.supabase.co
+- [x] `vercel.json` CSP : connect-src += *.supabase.co + *.supabase.io
 - [x] 10 nouveaux tests (progressSync) — total 42/42
+- [x] Variables Vercel configurées : `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` + `VITE_SENTRY_DSN`
+- [x] `.env.local` créé localement (non commité)
+- [x] Sentry projet `terminal-learning` créé et connecté à Vercel
 
-#### À faire avant mise en production
-- [ ] Activer GitHub OAuth dans Supabase dashboard
-- [ ] Activer Google OAuth dans Supabase dashboard
-- [ ] Ajouter VITE_SUPABASE_URL + VITE_SUPABASE_ANON_KEY dans Vercel env vars
-- [ ] Tester login/logout/OAuth en local avec .env.local
+#### À faire (post-Phase 3)
+- [ ] Tester login/logout/email en local avec `.env.local`
 - [ ] Vérifier sync local→remote après connexion
+- [ ] Activer GitHub OAuth dans Supabase dashboard (quand prêt)
+- [ ] Activer Google OAuth dans Supabase dashboard (quand prêt)
 
-#### Tech debt noté (post-merge)
+#### Tech debt noté
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
   → à terme : déplacer vers `src/types/database.ts`
 
@@ -155,4 +140,4 @@ Fichiers : `public/logo.svg` ✅, `public/favicon.svg` ✅, `public/og-image.png
 ## Décisions en attente
 
 - **GitHub Sponsors + Ko-fi** : activation suspendue jusqu'à l'accord de la mutuelle RIZIV/INAMI
-- **og:image compte social** : compte perso (@thierryvm) vs compte projet — pas encore décidé
+- **OAuth GitHub + Google** : à configurer dans Supabase dashboard quand prêt


### PR DESCRIPTION
## Summary
- `docs/plan.md` — Phase 3 marquée TERMINÉE, PRs closes, tech debt et TODO post-merge documentés
- `CLAUDE.md` — Phase 3 ✅, tech debt noté, OAuth en attente ajouté aux décisions
- `README.md` — architecture tree mis à jour (auth/, lib/, types/ présents), Phase 3 ✅, claims sécurité sans mention PR pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Marquer la Phase 3 comme terminée dans toute la documentation du projet et aligner les documents d’architecture et de sécurité avec l’état actuel de la production.

Documentation :
- Mettre à jour le plan de lancement pour marquer la Phase 3 comme terminée, documenter la configuration déployée de l’auth/DB, et consigner les tâches restantes après la Phase 3 ainsi que la dette technique.
- Actualiser l’arborescence d’architecture et la section sécurité du README pour refléter la stack d’authentification Supabase, les nouveaux composants d’auth, et l’état actuel de la phase.
- Aligner CLAUDE.md avec l’état de Phase 3 complétée, y compris les notes de dette technique et les décisions en attente concernant la configuration OAuth.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mark Phase 3 as complete across project documentation and align architecture and security docs with the current production state.

Documentation:
- Update launch plan to mark Phase 3 as finished, document deployed auth/DB setup, and record remaining post-Phase-3 tasks and tech debt.
- Refresh README architecture tree and security section to reflect the Supabase auth stack, new auth components, and current phase status.
- Align CLAUDE.md with the completed Phase 3 state, including tech debt notes and pending OAuth configuration decisions.

</details>