### PR TITLE
feat(sidebar): UserMenu + home link in app sidebar

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -3,8 +3,9 @@ import { NavLink, useNavigate } from 'react-router';
 import {
   Terminal, LayoutDashboard, BookOpen, Compass, FolderOpen,
   FileText, Shield, Cpu, GitMerge, ChevronDown, ChevronRight,
-  CheckCircle2, Circle, X, Menu,
+  CheckCircle2, Circle, X, Menu, Home,
 } from 'lucide-react';
+import { UserMenu } from './auth/UserMenu';
 import { curriculum } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
 
@@ -19,7 +20,7 @@ interface SidebarProps {
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const navigate = useNavigate();
-  const { isLessonCompleted, getModuleProgress, overallProgress } = useProgress();
+  const { isLessonCompleted, getModuleProgress, overallProgress, syncStatus } = useProgress();
   const [expandedModules, setExpandedModules] = useState<Record<string, boolean>>(() => {
     const init: Record<string, boolean> = {};
     curriculum.forEach((m) => { init[m.id] = true; });
@@ -170,10 +171,16 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 border-t border-[#30363d] px-4 py-3">
-          <p className="text-[10px] text-[#8b949e] text-center font-mono">
-            Terminal Master · v2.0
-          </p>
+        <div className="shrink-0 border-t border-[#30363d] px-3 py-3 space-y-2">
+          <UserMenu syncStatus={syncStatus} placement="top" />
+          <NavLink
+            to="/"
+            onClick={onClose}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22] transition-colors font-mono"
+          >
+            <Home size={14} aria-hidden="true" />
+            Accueil
+          </NavLink>
         </div>
       </aside>
     </>

--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../context/AuthContext';
 
 interface UserMenuProps {
   syncStatus: 'local' | 'synced' | 'syncing' | 'error';
+  placement?: 'bottom' | 'top';
 }
 
 const SYNC_LABELS: Record<UserMenuProps['syncStatus'], { label: string; color: string }> = {
@@ -13,7 +14,7 @@ const SYNC_LABELS: Record<UserMenuProps['syncStatus'], { label: string; color: s
   error:   { label: 'erreur',  color: 'text-[#f85149]' },
 };
 
-export function UserMenu({ syncStatus }: UserMenuProps) {
+export function UserMenu({ syncStatus, placement = 'bottom' }: UserMenuProps) {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -65,7 +66,7 @@ export function UserMenu({ syncStatus }: UserMenuProps) {
       {open && (
         <>
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full mt-1 z-20 w-48 bg-[#161b22] border border-[#30363d] rounded-lg shadow-xl overflow-hidden">
+          <div className={`absolute right-0 z-20 w-48 bg-[#161b22] border border-[#30363d] rounded-lg shadow-xl overflow-hidden ${placement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
             <div className="px-3 py-2 border-b border-[#30363d]">
               <p className="text-xs text-[#8b949e] font-mono truncate">{user.email}</p>
             </div>


### PR DESCRIPTION
## Motivation

Une fois dans l'app (/app), l'utilisateur n'avait aucun moyen de voir s'il était connecté ni de revenir à la landing page. Le sidebar footer affichait juste \"Terminal Master · v2.0\".

## Changes

- **UserMenu dans le footer du Sidebar** : affiche avatar, email, statut de sync et bouton déconnexion pour les utilisateurs connectés
- **Lien \"Accueil\"** : NavLink vers `/` toujours visible pour retourner à la landing
- **`placement=\"top\"` prop sur UserMenu** : le dropdown s'ouvre vers le haut quand le composant est en bas d'écran (évite le débordement)

## Security

- Avatar OAuth (GitHub/Google) : URLs HTTPS, couvertes par `img-src 'self' data: https:` dans le CSP ✅
- Noms d'affichage : texte JSX auto-échappé, zéro XSS ✅
- Lien retour `/` : chemin relatif, pas d'open redirect ✅
- Signout : délégué à AuthContext (inchangé) ✅

## Test plan

- [ ] Tester sur [terminal-learning.vercel.app/app](https://terminal-learning.vercel.app/app) — vérifier que le UserMenu apparaît dans le footer du sidebar
- [ ] Vérifier que le dropdown s'ouvre vers le haut (pas coupé)
- [ ] Cliquer \"Déconnexion\" depuis le sidebar → redirige vers `/`
- [ ] Cliquer \"Accueil\" → retour landing
- [ ] Vérifier en non-connecté → seul \"Accueil\" visible dans le footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter un menu de compte utilisateur et un lien de navigation vers l'accueil dans le pied de page de la barre latérale de l'application.

Nouvelles fonctionnalités :
- Afficher un `UserMenu` dans le pied de page de la barre latérale présentant les informations du compte, l'état de synchronisation et la déconnexion pour les utilisateurs authentifiés.
- Ajouter un lien de navigation vers la page d'accueil, persistant dans le pied de page de la barre latérale, pour revenir à la page d’atterrissage.

Améliorations :
- Permettre au menu déroulant `UserMenu` d’être positionné au-dessus ou en dessous grâce à une nouvelle prop `placement` afin d’éviter le dépassement de la fenêtre d’affichage.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a user account menu and home navigation link to the app sidebar footer.

New Features:
- Display a UserMenu in the sidebar footer showing account info, sync status, and sign-out for authenticated users.
- Add a persistent home navigation link in the sidebar footer to return to the landing page.

Enhancements:
- Allow the UserMenu dropdown to be positioned above or below via a new placement prop to avoid viewport overflow.

</details>