### PR TITLE
docs: sync CLAUDE.md and plan.md to Phase 3.5 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 ## Stack
 - Vite 6 + React 18 + React Router v7 + TypeScript strict
 - Tailwind CSS v4 + shadcn/ui + Motion
-- Supabase (Auth + PostgreSQL + RLS) — Phase 3
-- Vitest (tests unitaires) — pas de Playwright encore (Phase 3+)
+- Supabase (Auth + PostgreSQL + RLS + OAuth GitHub + Google)
+- Vitest (tests unitaires) — pas de Playwright encore
 - Vercel (déploiement auto sur push main)
 
 ## Fichiers critiques — toucher avec précaution
@@ -33,19 +33,21 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Zéro secret côté client
 - Zéro `any` TypeScript
 - CSP configuré dans `vercel.json` — mettre à jour si nouveaux domaines externes ajoutés
+- HSTS activé : `max-age=63072000; includeSubDomains; preload`
+- Avatars OAuth (GitHub/Google) : couverts par `img-src 'self' data: https:`
 
 ## Phases
 - Phase 0 ✅ Vercel live
 - Phase 1 ✅ Landing + routing + RGPD + SEO + CI
 - Phase 2 ✅ Analytics (Vercel Analytics + Sentry)
 - Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
+- Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 🔮 Admin panel (attendre signal trafic)
 
-## Tech debt Phase 3 (post-merge)
+## Tech debt
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
   → à terme : déplacer vers `src/types/database.ts`
-- OAuth GitHub + Google : non configurés dans Supabase dashboard (email only pour l'instant)
+- `Dashboard.tsx` lignes 51 + 204 : `navigate('/learn/...')` → `navigate('/app/learn/...')` (redirect actif mais incohérent)
 
 ## Décisions en attente
 - GitHub Sponsors + Ko-fi — activation suspendue jusqu'à l'accord de la mutuelle RIZIV/INAMI
-- OAuth GitHub + Google — à configurer ensemble quand prêt (Supabase dashboard → Authentication → Providers)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,8 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 3 avril 2026
-> Statut global : **Phase 3 TERMINÉE** — en production depuis le 2 avril 2026  
-> Travail en cours : `feat/landing-upgrade` (non mergé — en attente de validation visuelle)
+> Statut global : **Phase 3.5 TERMINÉE** — OAuth GitHub + Google + sidebar auth en prod depuis le 3 avril 2026
 
 ---
 
@@ -58,7 +57,7 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 - [x] `src/app/context/AuthContext.tsx` — session, user, signOut
 - [x] `src/app/context/ProgressContext.tsx` — étendu avec syncStatus + upsert Supabase
 - [x] `src/app/lib/progressSync.ts` — mergeProgress() + getDelta()
-- [x] `src/app/components/auth/LoginModal.tsx` — email/password (OAuth GitHub+Google prêt mais non activé)
+- [x] `src/app/components/auth/LoginModal.tsx` — email/password + OAuth GitHub + Google (activés le 3 avril 2026)
 - [x] `src/app/components/auth/UserMenu.tsx` — avatar + sync badge + logout
 - [x] `src/app/components/auth/AuthCallback.tsx` — handler /auth/callback PKCE
 - [x] `/auth/callback` route ajoutée dans `routes.ts`
@@ -68,11 +67,11 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 - [x] `.env.local` créé localement (non commité)
 - [x] Sentry projet `terminal-learning` créé et connecté à Vercel
 
-#### À faire (post-Phase 3)
-- [ ] Tester login/logout/email en local avec `.env.local`
-- [ ] Vérifier sync local→remote après connexion
-- [ ] Activer GitHub OAuth dans Supabase dashboard (quand prêt)
-- [ ] Activer Google OAuth dans Supabase dashboard (quand prêt)
+#### Complété post-Phase 3 (3 avril 2026)
+- [x] OAuth GitHub activé — App créée sur github.com/settings/developers
+- [x] OAuth Google activé — Projet Google Cloud Console "Terminal Learning"
+- [x] Supabase URL Configuration : Site URL + Redirect URLs prod + localhost
+- [x] Sidebar : UserMenu + lien Accueil dans le footer (PR #19)
 
 #### Tech debt noté
 → Voir `CLAUDE.md § Tech debt Phase 3` (source de vérité unique)
@@ -141,7 +140,6 @@ Fichiers : `public/logo.svg` ✅, `public/favicon.svg` ✅, `public/og-image.png
 
 - **GitHub Sponsors** : activation suspendue jusqu'à l'accord de la mutuelle RIZIV/INAMI
 - **Ko-fi** : compte créé (https://ko-fi.com/thierryvm), même risque RIZIV — en attente d'autorisation
-- **OAuth GitHub + Google** : à configurer dans Supabase dashboard quand prêt
 
 ---
 


### PR DESCRIPTION
## Motivation

Mise à jour des docs pour refléter l'état réel du projet après les PR #18 et #19.

## Changes

- **CLAUDE.md** : Phase 3.5 ✅, OAuth GitHub+Google activés, tech debt `Dashboard.tsx` ajouté, section Phases dédoublonnée, HSTS + CSP avatars documentés
- **docs/plan.md** : entête mis à jour (Phase 3.5 terminée en prod), OAuth coché, sidebar auth documentée, item OAuth supprimé des décisions en attente

## Nettoyage
- 7 branches locales obsolètes supprimées (chore/update-project-state, docs/restructure-project, docs/sync-state-phase3-complete, docs/update-readme, feat/supabase-phase3-auth, feature/ci-github-actions, fix/gitignore-claude-settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Mettre à jour la documentation du projet pour refléter l’achèvement de la Phase 3.5, les fournisseurs OAuth activés, ainsi que la dette technique et les décisions en attente actuelles.

Documentation :
- Actualiser `docs/plan.md` pour indiquer que la Phase 3.5 est terminée avec OAuth GitHub/Google et l’authentification via la barre latérale en production, et retirer OAuth des décisions en attente.
- Mettre à jour `CLAUDE.md` pour documenter la prise en charge d’OAuth, les en-têtes de sécurité, l’état de la phase 3.5 du projet et les éléments révisés de dette technique.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project documentation to reflect Phase 3.5 completion, enabled OAuth providers, and current tech debt and pending decisions.

Documentation:
- Refresh docs/plan.md to mark Phase 3.5 as complete with OAuth GitHub/Google and sidebar auth live in production, and remove OAuth from pending decisions.
- Update CLAUDE.md to document OAuth support, security headers, project phase 3.5 status, and revised tech debt items.

</details>