### PR TITLE
fix(auth): scope:'local' on signOut to eliminate race condition

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -34,7 +34,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    await supabase?.auth.signOut();
+    // scope:'local' clears the token from storage without a network round-trip,
+    // avoiding lock contention with concurrent getSession / onAuthStateChange calls.
+    await supabase?.auth.signOut({ scope: 'local' });
     setSession(null); // immediate UI reset — don't wait for onAuthStateChange
   }, []);
 


### PR DESCRIPTION
## Motivation

Le logout semblait parfois bloqué — `signOut()` sans `scope` fait un aller-retour réseau vers Supabase qui peut entrer en contention avec les appels `getSession` / `onAuthStateChange` en cours.

## Change

`supabase.auth.signOut()` → `supabase.auth.signOut({ scope: 'local' })`

Efface le token de storage immédiatement sans requête réseau. Le `setSession(null)` déjà présent gère la mise à jour de l'UI.

Note : le refresh token reste valide côté serveur — acceptable pour ce projet (pas d'exigence de révocation stricte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Corrections de bugs :
- Empêche certains blocages occasionnels lors de la déconnexion en utilisant une déconnexion Supabase à portée locale qui n’entraîne pas d’aller-retour réseau.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent occasional logout hangs by using a local-scope Supabase sign-out that does not trigger a network round-trip.

</details>