### PR TITLE
fix(auth): explicit early-return + expand signOut comment

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -34,9 +34,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    // scope:'local' clears the token from storage without a network round-trip,
-    // avoiding lock contention with concurrent getSession / onAuthStateChange calls.
-    await supabase?.auth.signOut({ scope: 'local' });
+    if (!supabase) return;
+    // scope:'local' clears the session from storage without a server round-trip,
+    // avoiding race conditions with concurrent getSession / onAuthStateChange calls.
+    // The refresh token is NOT revoked server-side — acceptable here because this app
+    // has no cross-device logout requirement and sessions expire naturally via Supabase's
+    // default token rotation policy.
+    // See: https://supabase.com/docs/reference/javascript/auth-signout
+    await supabase.auth.signOut({ scope: 'local' });
     setSession(null); // immediate UI reset — don't wait for onAuthStateChange
   }, []);
 


### PR DESCRIPTION
Addresses Sourcery review comments on PR #21.

## Changes

- `if (!supabase) return;` — early-return explicite quand Supabase n'est pas configuré (flow de contrôle clair, plus de no-op silencieux)
- Commentaire étendu : explique pourquoi `scope:'local'` est acceptable (pas de besoin de déconnexion multi-appareils, expiration naturelle via token rotation) + lien vers la doc Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Clarifier et renforcer le flux de déconnexion (sign-out) d’authentification dans le contexte `AuthProvider`.

Améliorations :
- Ajouter un retour anticipé explicite dans le gestionnaire `signOut` lorsque Supabase n’est pas configuré, afin d’éviter des appels inutiles.
- Développer et clarifier la documentation en ligne concernant l’utilisation de `scope:'local'` pour `signOut`, en incluant la justification et un lien vers la documentation Supabase.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and harden the auth sign-out flow in the AuthProvider context.

Enhancements:
- Add an explicit early return in the signOut handler when Supabase is not configured to avoid unnecessary calls.
- Expand and clarify the inline documentation around using scope:'local' for signOut, including rationale and link to Supabase documentation.

</details>