### PR TITLE
feat(terminal): show auth username in terminal prompt

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -10,18 +10,9 @@ import {
 } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
 import { useAuth } from '../context/AuthContext';
+import { toUnixUsername } from '../../lib/username';
 import { TerminalState } from '../data/terminalEngine';
 import { TerminalEmulator } from './TerminalEmulator';
-
-function toUnixUsername(user: { email?: string | null; user_metadata?: Record<string, unknown> } | null): string | undefined {
-  if (!user) return undefined;
-  const raw =
-    (user.user_metadata?.user_name as string | undefined) ??
-    (user.user_metadata?.preferred_username as string | undefined) ??
-    user.email?.split('@')[0];
-  if (!raw) return undefined;
-  return raw.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 16) || undefined;
-}
 
 function BlockRenderer({ block }: { block: ContentBlock }) {
   const renderText = (text: string) => {

--- a/src/app/components/TerminalEmulator.tsx
+++ b/src/app/components/TerminalEmulator.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { TerminalState, OutputLine, processCommand, getPrompt, getTabCompletions, createInitialState } from '../data/terminalEngine';
 
 interface TerminalLine {
@@ -12,6 +12,7 @@ interface TerminalEmulatorProps {
   onCommand?: (command: string, state: TerminalState) => void;
   welcomeMessage?: string[];
   className?: string;
+  /** Unix username to show in prompt. Defaults to 'user' when not authenticated. */
   username?: string;
 }
 
@@ -19,10 +20,7 @@ let lineCounter = 0;
 const nextId = () => ++lineCounter;
 
 export function TerminalEmulator({ onCommand, welcomeMessage, className = '', username }: TerminalEmulatorProps) {
-  const [termState, setTermState] = useState<TerminalState>(() => {
-    const s = createInitialState();
-    return username ? { ...s, user: username } : s;
-  });
+  const [termState, setTermState] = useState<TerminalState>(createInitialState);
   const [lines, setLines] = useState<TerminalLine[]>(() => {
     const welcome = welcomeMessage ?? [
       "Bienvenue dans Terminal Lab ! Tapez 'help' pour la liste des commandes.",
@@ -41,18 +39,25 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
 
   const focusInput = () => inputRef.current?.focus();
 
+  // Derive active state from the username prop so auth changes (login/logout)
+  // are reflected immediately without a setState round-trip.
+  const activeState = useMemo<TerminalState>(
+    () => (username ? { ...termState, user: username } : termState),
+    [termState, username]
+  );
+
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
       const trimmed = input.trim();
-      const prompt = getPrompt(termState);
+      const prompt = getPrompt(activeState);
 
       if (!trimmed) {
         setLines((prev) => [...prev, { id: nextId(), type: 'prompt', text: '', prompt }]);
         return;
       }
 
-      const result = processCommand(termState, trimmed);
+      const result = processCommand(activeState, trimmed);
 
       if (result.clear) {
         setLines([]);
@@ -77,11 +82,11 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
       setInput('');
       setHistoryIndex(-1);
     },
-    [input, termState, onCommand]
+    [input, activeState, onCommand]
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const history = termState.commandHistory;
+    const history = activeState.commandHistory;
     if (e.key === 'ArrowUp') {
       e.preventDefault();
       const newIndex = Math.min(historyIndex + 1, history.length - 1);
@@ -94,11 +99,11 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
       setInput(newIndex === -1 ? '' : history[history.length - 1 - newIndex] ?? '');
     } else if (e.key === 'Tab') {
       e.preventDefault();
-      const completions = getTabCompletions(input, termState);
+      const completions = getTabCompletions(input, activeState);
       if (completions.length === 1) {
         setInput(completions[0]);
       } else if (completions.length > 1) {
-        const prompt = getPrompt(termState);
+        const prompt = getPrompt(activeState);
         setLines((prev) => [
           ...prev,
           { id: nextId(), type: 'prompt', text: input, prompt },
@@ -109,7 +114,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
       e.preventDefault();
       setLines((prev) => [
         ...prev,
-        { id: nextId(), type: 'prompt', text: input + '^C', prompt: getPrompt(termState) },
+        { id: nextId(), type: 'prompt', text: input + '^C', prompt: getPrompt(activeState) },
       ]);
       setInput('');
       setHistoryIndex(-1);
@@ -119,7 +124,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
     }
   };
 
-  const prompt = getPrompt(termState);
+  const prompt = getPrompt(activeState);
 
   return (
     <div
@@ -134,7 +139,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
           <div className="w-3 h-3 rounded-full bg-[#28ca42]" />
         </div>
         <span className="ml-2 text-[#8b949e] text-xs font-mono">
-          {termState.user}@{termState.hostname}
+          {activeState.user}@{activeState.hostname}
         </span>
       </div>
 

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -1,0 +1,33 @@
+import type { User } from '@supabase/supabase-js';
+
+const MAX_USERNAME_LENGTH = 16;
+
+/**
+ * Derives a safe Unix username from a Supabase user.
+ *
+ * Priority: GitHub `user_name` → `preferred_username` (other OAuth) → email prefix.
+ * Normalization: lowercase, non-alphanumeric chars replaced with hyphens,
+ * consecutive/leading/trailing hyphens collapsed, truncated to MAX_USERNAME_LENGTH.
+ *
+ * Returns undefined if no usable identifier is found (unauthenticated → keeps default 'user').
+ */
+export function toUnixUsername(user: User | null): string | undefined {
+  if (!user) return undefined;
+
+  // Prefer OAuth provider username, fall back to email prefix
+  const raw =
+    (user.user_metadata?.user_name as string | undefined) ??
+    (user.user_metadata?.preferred_username as string | undefined) ??
+    user.email?.split('@')[0];
+
+  if (!raw) return undefined;
+
+  const normalized = raw
+    .toLowerCase()                      // Unix usernames are lowercase
+    .replace(/[^a-z0-9-]/g, '-')       // replace invalid chars with hyphens
+    .replace(/-+/g, '-')               // collapse consecutive hyphens
+    .replace(/^-|-$/g, '')             // strip leading/trailing hyphens
+    .slice(0, MAX_USERNAME_LENGTH);    // enforce max length
+
+  return normalized || undefined;
+}


### PR DESCRIPTION
## Summary
- Derive a Unix-safe username from OAuth metadata (`user_name`, `preferred_username`, or email prefix)
- Inject it into `TerminalEmulator` initial state so the prompt and title bar show the real username
- Unauthenticated users fall back to `user` — no regression

## Changes
- `LessonPage.tsx` — `toUnixUsername()` helper + `useAuth()` + passes `username` to `<TerminalEmulator>`
- `TerminalEmulator.tsx` — accepts `username?: string` prop, overrides initial state's `user` field

## Test plan
- [ ] Log in with GitHub OAuth → terminal shows GitHub username (e.g. `thierryvm@terminal-lab:~$`)
- [ ] Log in with Google OAuth → terminal shows email prefix, sanitized
- [ ] Not logged in → terminal shows `user@terminal-lab:~$` (unchanged)
- [ ] All 66 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Afficher le nom d’utilisateur compatible Unix de l’utilisateur authentifié dans l’invite de terminal et la barre de titre lorsqu’il est disponible, tout en préservant le comportement existant pour les utilisateurs non authentifiés.

Nouvelles fonctionnalités :
- Dériver un nom d’utilisateur de style Unix nettoyé à partir des métadonnées OAuth de l’utilisateur ou de son email et le transmettre au terminal de la leçon.
- Permettre à l’émulateur de terminal d’accepter une prop `username` optionnelle et d’initialiser son état avec cette valeur pour l’affichage de l’invite.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show the authenticated user’s Unix-safe username in the terminal prompt and title bar when available, while preserving the existing behavior for unauthenticated users.

New Features:
- Derive a sanitized Unix-style username from OAuth user metadata or email and pass it into the lesson terminal.
- Allow the terminal emulator to accept an optional username prop and initialize its state with that username for the prompt display.

</details>