### PR TITLE
fix(a11y): aria-disabled on sponsor cards + grammar fix in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **Live** : https://terminal-learning.vercel.app
 - **Repo** : https://github.com/thierryvm/TerminalLearning
 - **Vercel** : https://vercel.com/thierry-vanmeeterens-projects/terminal-learning
-- **Ko-fi** : https://ko-fi.com/thierryvm (dons suspendus dans l'UI — attente accord mutuelle Solidaris RIZIV/INAMI)
-- **GitHub Sponsors** : https://github.com/sponsors/thierryvm (compte activé le 9 avril 2026 — dons suspendus dans l'UI, même attente)
+- **Ko-fi** : https://ko-fi.com/thierryvm (dons suspendus dans l'UI — en attente de l'accord de la mutuelle Solidaris (RIZIV/INAMI))
+- **GitHub Sponsors** : https://github.com/sponsors/thierryvm (compte activé le 9 avril 2026 — dons suspendus dans l'UI, en attente de l'accord de la mutuelle Solidaris (RIZIV/INAMI))
 
 ## Règles Git — NON NÉGOCIABLES
 - **Jamais de commit direct sur `main`** — toujours `feature/xxx` ou `fix/xxx`
@@ -51,5 +51,5 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - `Dashboard.tsx` lignes 51 + 204 : `navigate('/learn/...')` → `navigate('/app/learn/...')` (redirect actif mais incohérent)
 
 ## Décisions en attente
-- **Ko-fi + GitHub Sponsors** — dons suspendus dans l'UI jusqu'à l'accord mutuelle Solidaris (RIZIV/INAMI). GitHub Sponsors est activé sur la plateforme (9 avril 2026) mais les boutons dans l'app restent désactivés. Quand l'accord arrive : réactiver les cartes dans `Landing.tsx`, le lien footer, et mettre à jour le `donate` dans `terminalEngine.ts`.
+- **Ko-fi + GitHub Sponsors** — dons suspendus dans l'UI jusqu'à l'accord de la mutuelle Solidaris (RIZIV/INAMI). GitHub Sponsors est activé sur la plateforme (9 avril 2026) mais les boutons dans l'app restent désactivés. Quand l'accord arrive : réactiver les cartes dans `Landing.tsx`, le lien footer, et mettre à jour le `donate` dans `terminalEngine.ts`.
 - **Playwright** — e2e/ ajouté (3 suites : accessibility, mobile, seo). Exclure de vitest (`exclude: ['node_modules/**', 'e2e/**']` dans vitest.config.ts — ne jamais retirer).

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -652,9 +652,11 @@ export function Landing() {
           <div className="space-y-4">
             {/* Ko-fi — on hold pending Solidaris authorization */}
             <div
+              role="group"
+              aria-disabled="true"
+              aria-label="Ko-fi — bientôt disponible (en attente d'accord de la mutuelle Solidaris)"
               className="p-5 rounded-xl border border-[#30363d] bg-[#161b22] opacity-60 cursor-not-allowed"
-              title="En attente d'accord mutuelle Solidaris (RIZIV/INAMI)"
-              aria-label="Ko-fi — bientôt disponible"
+              title="En attente de l'accord de la mutuelle Solidaris (RIZIV/INAMI)"
             >
               <div className="flex items-start gap-3 mb-4">
                 <div className="p-2 rounded-lg bg-[#0d1117] border border-[#30363d] shrink-0">
@@ -680,9 +682,11 @@ export function Landing() {
 
             {/* GitHub Sponsors — on hold pending Solidaris authorization */}
             <div
+              role="group"
+              aria-disabled="true"
+              aria-label="GitHub Sponsors — bientôt disponible (en attente d'accord de la mutuelle Solidaris)"
               className="p-5 rounded-xl border border-[#30363d] bg-[#161b22] opacity-60 cursor-not-allowed"
-              title="En attente d'accord mutuelle Solidaris (RIZIV/INAMI)"
-              aria-label="GitHub Sponsors — bientôt disponible"
+              title="En attente de l'accord de la mutuelle Solidaris (RIZIV/INAMI)"
             >
               <div className="flex items-start gap-3 mb-4">
                 <div className="p-2 rounded-lg bg-[#0d1117] border border-[#30363d] shrink-0">


### PR DESCRIPTION
## Summary

Addresses Sourcery review comments on PR #41:

- **Accessibility**: Ko-fi and GitHub Sponsors on-hold cards now have `role="group"` + `aria-disabled="true"` so assistive technologies can discover them as future actions (not just rely on opacity/cursor)
- **Grammar**: Fixed French prepositions in CLAUDE.md — "attente accord mutuelle" → "en attente de l'accord de la mutuelle Solidaris"
- **Centralisation** (Sourcery suggestion): Noted but intentionally not implemented — only 2 files use these strings and they change once when authorization arrives. A config module would be over-engineering.

## Test plan

- [x] `npx vitest run` → 242 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Améliorer l’accessibilité et clarifier les messages pour les dons Ko-fi et GitHub Sponsors suspendus pendant que l’autorisation Solidaris est en attente.

Corrections de bugs :
- Exposer les cartes Ko-fi et GitHub Sponsors en attente en tant que groupes désactivés pour les technologies d’assistance, en utilisant les rôles et attributs ARIA appropriés.

Documentation :
- Clarifier et corriger la formulation française concernant l’autorisation en attente de la mutuelle Solidaris dans `CLAUDE.md`, y compris les liens et les notes de décision.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and clarify messaging for suspended Ko-fi and GitHub Sponsors donations while the Solidaris authorization is pending.

Bug Fixes:
- Expose the on-hold Ko-fi and GitHub Sponsors cards as disabled groups to assistive technologies using appropriate ARIA roles and attributes.

Documentation:
- Clarify and correct French phrasing around the pending Solidaris mutual insurance authorization in CLAUDE.md, including links and decision notes.

</details>