### PR TITLE
perf(routes): lazy-load all routes — React.lazy() + Suspense (THI-33)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -88,13 +88,16 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 
 ### 🔄 Phase 5 — Curriculum Expansion (EN COURS — démarré 9 avril 2026)
 
-#### ✅ Livré (PR #36 + PR #37 + PR #38)
+#### ✅ Livré (PR #36 + PR #37 + PR #38 + PR #40 + PR #43)
 - Module 7 — Variables & Scripts (6 leçons) : `export`, `$PATH`, `.env`, shell config, scripts bash, `cron`
 - Enrichissement modules 4–6 : permissions (chown, sudo, security), processus (top, bg/fg), redirection (stderr, tee)
 - CommandReference entièrement env-aware : filtres par env, syntaxe + exemples par env, badge environnement
 - LessonPage : rendu env-aware (`contentByEnv`, `labelByEnv`), prompt `PS>` en cyan
 - TerminalPreview : `text-left` + env-aware (prompt, barre de titre, séquences de commandes)
 - 242 tests unitaires + 176 tests Playwright E2E — 32 leçons, 7 modules
+- README entièrement réécrit pour 3 audiences (débutants, devs, sponsors) — PR #40 (THI-32)
+- Route-level code splitting : `React.lazy()` + `Suspense` + `PageLoader` — chaque route = chunk dédié — PR #43 (THI-33)
+- Script `generate-demo-gif.cjs` : capture GIF de l'animation env-switching via Playwright — `npm run generate-demo`
 
 #### 🔜 Modules planifiés (THI-27 à THI-30)
 - **Module 8 — Réseau & SSH** (THI-27) : `ping`, `curl`, `wget`, `ssh`, `scp`, DNS

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
 >
   <url>
     <loc>https://terminal-learning.vercel.app/</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -17,154 +17,154 @@
 
   <url>
     <loc>https://terminal-learning.vercel.app/app</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/reference</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/privacy</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/navigation/pwd</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/navigation/ls</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/navigation/ls-la</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/navigation/cd</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/fichiers/mkdir</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/fichiers/touch</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/fichiers/cp</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/fichiers/mv</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/fichiers/rm</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/lecture/cat</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/lecture/head-tail</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/lecture/grep</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/lecture/wc</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/permissions/comprendre-permissions</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/permissions/chmod</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/processus/ps</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/processus/kill</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/redirection/redirection-sortie</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminal-learning.vercel.app/app/learn/redirection/pipes</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { RouterProvider } from 'react-router';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
@@ -6,6 +7,7 @@ import { router } from './routes';
 import { AuthProvider } from './context/AuthContext';
 import { ProgressProvider } from './context/ProgressContext';
 import { EnvironmentProvider } from './context/EnvironmentContext';
+import { PageLoader } from './components/PageLoader';
 
 function FallbackUI() {
   return (
@@ -29,7 +31,9 @@ export default function App() {
       <AuthProvider>
         <EnvironmentProvider>
           <ProgressProvider>
-            <RouterProvider router={router} />
+            <Suspense fallback={<PageLoader />}>
+              <RouterProvider router={router} />
+            </Suspense>
             <Analytics />
             <SpeedInsights />
           </ProgressProvider>

--- a/src/app/components/PageLoader.tsx
+++ b/src/app/components/PageLoader.tsx
@@ -1,0 +1,11 @@
+export function PageLoader() {
+  return (
+    <div
+      className="min-h-screen bg-[#0d1117] flex items-center justify-center"
+      role="status"
+      aria-label="Chargement en cours"
+    >
+      <div className="w-8 h-8 border-2 border-emerald-500/30 border-t-emerald-400 rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,12 +1,31 @@
+import { lazy } from 'react';
 import { createBrowserRouter, redirect } from 'react-router';
+
+// Route-level code splitting — each route loads its own JS chunk on demand.
+// Layout stays eager: it's the /app shell and renders before any child route.
 import { Layout } from './components/Layout';
-import { Dashboard } from './components/Dashboard';
-import { LessonPage } from './components/LessonPage';
-import { CommandReference } from './components/CommandReference';
-import { Landing } from './components/Landing';
-import { PrivacyPolicy } from './components/PrivacyPolicy';
-import { NotFound } from './components/NotFound';
-import { AuthCallback } from './components/auth/AuthCallback';
+
+const Landing = lazy(() =>
+  import('./components/Landing').then(({ Landing }) => ({ default: Landing }))
+);
+const PrivacyPolicy = lazy(() =>
+  import('./components/PrivacyPolicy').then(({ PrivacyPolicy }) => ({ default: PrivacyPolicy }))
+);
+const AuthCallback = lazy(() =>
+  import('./components/auth/AuthCallback').then(({ AuthCallback }) => ({ default: AuthCallback }))
+);
+const Dashboard = lazy(() =>
+  import('./components/Dashboard').then(({ Dashboard }) => ({ default: Dashboard }))
+);
+const LessonPage = lazy(() =>
+  import('./components/LessonPage').then(({ LessonPage }) => ({ default: LessonPage }))
+);
+const CommandReference = lazy(() =>
+  import('./components/CommandReference').then(({ CommandReference }) => ({ default: CommandReference }))
+);
+const NotFound = lazy(() =>
+  import('./components/NotFound').then(({ NotFound }) => ({ default: NotFound }))
+);
 
 export const router = createBrowserRouter([
   // Public pages


### PR DESCRIPTION
## Summary

- All route components converted to `React.lazy()` dynamic imports — each route now ships its own JS chunk on demand
- `<Suspense fallback={<PageLoader />}>` added in `App.tsx` around `RouterProvider`
- New `PageLoader` component: accessible dark-theme spinner (`role=status`, `aria-label`)
- `Layout` kept as eager import (it's the `/app` shell and must render before children)

## Build output — confirmed chunks

| Chunk | Size (gzip) |
|---|---|
| `AuthCallback` | 0.58 kB (0.42 kB gz) |
| `NotFound` | 5.65 kB (2.08 kB gz) |
| `PrivacyPolicy` | 7.53 kB (2.28 kB gz) |
| `Dashboard` | 7.57 kB (2.31 kB gz) |
| `CommandReference` | 28.47 kB (8.18 kB gz) |
| `LessonPage` | 61.34 kB (17.67 kB gz) |
| `Landing` | 84.09 kB (23.11 kB gz) |

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run build` — all chunks present, no errors
- [x] `npm run test` — 242/242 passed

Closes THI-33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Introduction du découpage de code au niveau des routes avec des routes chargées paresseusement et une expérience de chargement de page basée sur `Suspense`.

Améliorations :
- Charger paresseusement tous les composants de route avec `React.lazy` afin que chaque page soit découpée en son propre chunk.
- Envelopper le routeur dans une frontière `Suspense` avec un chargeur plein écran pour gérer les états de chargement des routes paresseuses.
- Ajouter un composant `PageLoader` accessible avec un thème sombre, affiché pendant le chargement des chunks de route.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce route-level code splitting with lazy-loaded routes and a suspense-based page loading experience.

Enhancements:
- Lazy-load all route components using React.lazy so each page is code-split into its own chunk.
- Wrap the router in a Suspense boundary with a full-page loader to handle lazy route loading states.
- Add an accessible dark-themed PageLoader component to display while route chunks are loading.

</details>