### PR TITLE
feat(curriculum): Module 8 — Réseau & SSH (THI-27)

### DIFF
--- a/src/app/data/curriculum.ts
+++ b/src/app/data/curriculum.ts
@@ -1812,6 +1812,329 @@ export const curriculum: Module[] = [
       },
     ],
   },
+  {
+    id: 'reseau',
+    title: 'Réseau & SSH',
+    description: 'Testez la connectivité, effectuez des requêtes HTTP et connectez-vous à des serveurs distants',
+    iconName: 'Globe',
+    color: '#06b6d4',
+    level: 3,
+    prerequisites: ['variables'],
+    unlocks: [],
+    lessons: [
+      {
+        id: 'ping',
+        title: 'ping — Tester la connectivité',
+        description: 'Vérifiez si un hôte est accessible sur le réseau',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`ping` envoie des paquets ICMP à un hôte pour tester s\'il est accessible et mesurer le temps de réponse (latence). C\'est le premier réflexe pour diagnostiquer un problème réseau.',
+          },
+          {
+            type: 'code',
+            content: '$ ping google.com\nPING google.com: 56 data bytes\n64 bytes from google.com: icmp_seq=0 ttl=54 time=12.3 ms\n64 bytes from google.com: icmp_seq=1 ttl=54 time=11.8 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 received, 0% packet loss',
+            label: 'Exemple (Linux/macOS)',
+            labelByEnv: {
+              windows: 'Exemple (Windows)',
+            },
+            contentByEnv: {
+              windows: 'PS> ping google.com\nPinging google.com [142.250.74.46] with 32 bytes of data:\nReply from 142.250.74.46: bytes=32 time=12ms TTL=54\nReply from 142.250.74.46: bytes=32 time=11ms TTL=54\n\nPing statistics for 142.250.74.46:\n    Packets: Sent = 4, Received = 4, Lost = 0 (0% loss)',
+            },
+          },
+          {
+            type: 'info',
+            content:
+              'Sur Linux/macOS, `ping` envoie des paquets en continu (Ctrl+C pour arrêter). Utilisez `-c 4` pour limiter à 4 paquets. Sur Windows, `ping` s\'arrête automatiquement après 4 paquets.',
+            contentByEnv: {
+              windows: 'Sur Windows, `ping` envoie 4 paquets par défaut et s\'arrête automatiquement. Sur Linux/macOS, ajoutez `-c 4` pour le même comportement.',
+            },
+          },
+          {
+            type: 'code',
+            content: '# Limiter le nombre de paquets\n$ ping -c 4 google.com\n\n# Tester une adresse IP directement\n$ ping 8.8.8.8\n\n# Ping rapide (intervalle 0.2s)\n$ ping -i 0.2 google.com',
+            label: 'Options utiles (Linux/macOS)',
+            labelByEnv: {
+              windows: 'Options utiles (Windows)',
+            },
+            contentByEnv: {
+              windows: '# Limiter le nombre de paquets\nPS> ping -n 4 google.com\n\n# Tester une adresse IP directement\nPS> ping 8.8.8.8\n\n# Ping en continu (comme Unix)\nPS> ping -t google.com',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Si `ping` échoue, testez `ping 8.8.8.8` (DNS Google). Si ça marche mais que `ping google.com` échoue, c\'est un problème DNS, pas réseau.',
+          },
+        ],
+        exercise: {
+          instruction: 'Testez la connectivité vers `google.com` avec la commande `ping google.com`.',
+          hint: 'Tapez: ping google.com',
+          validate: (cmd) => /^ping\s+.+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Excellent ! Vous savez maintenant tester la connectivité réseau.',
+        },
+      },
+      {
+        id: 'curl',
+        title: 'curl — Requêtes HTTP',
+        description: 'Effectuez des requêtes HTTP/HTTPS directement depuis le terminal',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`curl` (Client URL) permet d\'envoyer des requêtes HTTP depuis le terminal. C\'est un outil indispensable pour tester des APIs, télécharger des fichiers et déboguer des endpoints web.',
+          },
+          {
+            type: 'code',
+            content: '# Requête GET simple\n$ curl https://api.github.com\n\n# Afficher les headers HTTP\n$ curl -I https://example.com\n\n# Envoyer du JSON (POST)\n$ curl -X POST https://api.example.com/data \\\n  -H "Content-Type: application/json" \\\n  -d \'{"key": "value"}\'',
+            label: 'Usages courants (Linux/macOS)',
+            labelByEnv: {
+              windows: 'Usages courants (Windows)',
+            },
+            contentByEnv: {
+              windows: '# curl est disponible nativement sur Windows 10+\nPS> curl https://api.github.com\n\n# Afficher les headers HTTP\nPS> curl -I https://example.com\n\n# Alternative PowerShell native\nPS> Invoke-WebRequest -Uri https://api.github.com',
+            },
+          },
+          {
+            type: 'info',
+            content:
+              '`curl` est disponible nativement sur Linux, macOS et Windows 10+. Sur Windows, `curl` est un alias de `Invoke-WebRequest` en PowerShell — utilisez `curl.exe` pour forcer le vrai curl.',
+            contentByEnv: {
+              windows: 'En PowerShell, `curl` est un alias de `Invoke-WebRequest`. Pour utiliser le vrai curl, tapez `curl.exe`. Les deux fonctionnent pour des requêtes simples.',
+            },
+          },
+          {
+            type: 'code',
+            content: '# Sauvegarder la réponse dans un fichier\n$ curl -o fichier.json https://api.example.com\n\n# Suivre les redirections\n$ curl -L https://example.com\n\n# Authentification\n$ curl -u user:password https://api.example.com',
+            label: 'Options avancées',
+          },
+          {
+            type: 'tip',
+            content: 'Ajoutez `-s` (silent) pour supprimer la barre de progression, et `| jq .` pour formater le JSON : `curl -s https://api.github.com | jq .`',
+          },
+        ],
+        exercise: {
+          instruction: 'Effectuez une requête GET vers l\'API GitHub avec `curl https://api.github.com`.',
+          instructionByEnv: {
+            windows: 'Effectuez une requête GET vers l\'API GitHub avec `curl https://api.github.com` ou `Invoke-WebRequest -Uri https://api.github.com`.',
+          },
+          hint: 'Tapez: curl https://api.github.com',
+          hintByEnv: {
+            windows: 'Tapez: curl https://api.github.com (ou Invoke-WebRequest -Uri https://api.github.com)',
+          },
+          validate: (cmd, env) => {
+            const c = cmd.trim().toLowerCase();
+            if (env === 'windows') {
+              return /^curl(\.exe)?\s+https?:\/\/.+/.test(c) || /^invoke-webrequest\s+-uri\s+https?:\/\/.+/.test(c);
+            }
+            return /^curl\s+.+/.test(c);
+          },
+          successMessage: 'Parfait ! Vous savez maintenant interroger des APIs depuis le terminal.',
+        },
+      },
+      {
+        id: 'wget',
+        title: 'wget — Télécharger des fichiers',
+        description: 'Téléchargez des fichiers depuis le web en ligne de commande',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`wget` (Web Get) est un utilitaire de téléchargement non-interactif. Contrairement à `curl`, il est optimisé pour télécharger des fichiers et peut reprendre les téléchargements interrompus.',
+          },
+          {
+            type: 'code',
+            content: '# Télécharger un fichier\n$ wget https://example.com/fichier.zip\n\n# Nommer le fichier à la sortie\n$ wget -O mon-fichier.zip https://example.com/fichier.zip\n\n# Reprendre un téléchargement interrompu\n$ wget -c https://example.com/gros-fichier.iso',
+            label: 'Usages courants (Linux/macOS)',
+            labelByEnv: {
+              windows: 'Usages courants (Windows)',
+            },
+            contentByEnv: {
+              windows: '# wget via winget (si installé)\nPS> wget https://example.com/fichier.zip\n\n# Alternative native PowerShell\nPS> Invoke-WebRequest -Uri https://example.com/fichier.zip -OutFile fichier.zip\n\n# Alias court\nPS> iwr https://example.com/fichier.zip -OutFile fichier.zip',
+            },
+          },
+          {
+            type: 'info',
+            content:
+              '`wget` est préinstallé sur la plupart des distributions Linux et disponible via Homebrew sur macOS. Sur Windows, il faut l\'installer ou utiliser `Invoke-WebRequest` de PowerShell.',
+            contentByEnv: {
+              windows: 'Sur Windows, l\'équivalent natif de `wget` est `Invoke-WebRequest` (alias `iwr`). La syntaxe est différente mais le résultat est identique : télécharger un fichier depuis une URL.',
+            },
+          },
+          {
+            type: 'code',
+            content: '# Télécharger en arrière-plan\n$ wget -b https://example.com/gros-fichier.iso\n\n# Télécharger plusieurs fichiers d\'une liste\n$ wget -i liste-urls.txt\n\n# Limiter la vitesse (utile pour ne pas saturer la connexion)\n$ wget --limit-rate=1m https://example.com/fichier.iso',
+            label: 'Options avancées (Linux/macOS)',
+          },
+          {
+            type: 'tip',
+            content: 'Pour télécharger un site entier en local (mirror) : `wget --mirror --convert-links https://example.com`. Utile pour archiver ou consulter hors-ligne.',
+          },
+        ],
+        exercise: {
+          instruction: 'Téléchargez un fichier avec `wget https://example.com/fichier.zip`.',
+          instructionByEnv: {
+            windows: 'Téléchargez un fichier avec `Invoke-WebRequest -Uri https://example.com/fichier.zip -OutFile fichier.zip` ou `wget https://example.com/fichier.zip`.',
+          },
+          hint: 'Tapez: wget https://example.com/fichier.zip',
+          hintByEnv: {
+            windows: 'Tapez: Invoke-WebRequest -Uri https://example.com/fichier.zip -OutFile fichier.zip',
+          },
+          validate: (cmd, env) => {
+            const c = cmd.trim().toLowerCase();
+            if (env === 'windows') {
+              return /^wget\s+https?:\/\/.+/.test(c) ||
+                /^invoke-webrequest\s+(-uri\s+)?https?:\/\/.+/.test(c) ||
+                /^iwr\s+https?:\/\/.+/.test(c);
+            }
+            return /^wget\s+https?:\/\/.+/.test(c);
+          },
+          successMessage: 'Bien joué ! Vous savez maintenant télécharger des fichiers depuis le terminal.',
+        },
+      },
+      {
+        id: 'dns',
+        title: 'DNS — Résoudre les noms de domaine',
+        description: 'Comprenez le DNS et diagnostiquez les problèmes de résolution de noms',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Le DNS (Domain Name System) traduit les noms de domaine (`google.com`) en adresses IP (`142.250.74.46`). Quand une page web ne charge pas, le problème vient souvent du DNS.',
+          },
+          {
+            type: 'code',
+            content: '# Résolution simple\n$ nslookup google.com\nServer:  8.8.8.8\nAddress: 8.8.8.8#53\n\nNon-authoritative answer:\nName: google.com\nAddress: 142.250.74.46\n\n# Interroger un serveur DNS spécifique\n$ nslookup google.com 1.1.1.1',
+            label: 'nslookup (disponible partout)',
+          },
+          {
+            type: 'code',
+            content: '# dig — plus verbeux, idéal pour le diagnostic\n$ dig google.com\n\n; <<>> DiG 9.18.1 <<>> google.com\n;; ANSWER SECTION:\ngoogle.com. 299 IN A 142.250.74.46\n\n;; Query time: 12 msec\n;; SERVER: 8.8.8.8#53\n\n# Réponse courte\n$ dig +short google.com\n142.250.74.46',
+            label: 'dig (Linux/macOS)',
+            labelByEnv: {
+              windows: 'Alternatives Windows',
+            },
+            contentByEnv: {
+              windows: '# nslookup fonctionne sur tous les OS\nPS> nslookup google.com\n\n# Résolution via PowerShell\nPS> Resolve-DnsName google.com\n\nName                           Type TTL  Section IPAddress\n----                           ---- ---  ------- ---------\ngoogle.com                     A    299  Answer  142.250.74.46',
+            },
+          },
+          {
+            type: 'info',
+            content:
+              '`nslookup` est disponible sur Linux, macOS et Windows. `dig` est disponible sur Linux et macOS (et via Chocolatey sur Windows). Pour Windows, `Resolve-DnsName` est l\'alternative PowerShell native.',
+            contentByEnv: {
+              windows: '`nslookup` est disponible nativement sur Windows. `Resolve-DnsName` est l\'outil PowerShell natif plus moderne. `dig` n\'est pas inclus par défaut mais peut être installé via Chocolatey.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Les serveurs DNS publics les plus rapides : `8.8.8.8` (Google), `1.1.1.1` (Cloudflare), `9.9.9.9` (Quad9 — axé privacy). Utilisez `dig @1.1.1.1 google.com` pour tester un DNS spécifique.',
+          },
+        ],
+        exercise: {
+          instruction: 'Résolvez le nom de domaine `google.com` avec `nslookup google.com`.',
+          instructionByEnv: {
+            windows: 'Résolvez le nom de domaine `google.com` avec `nslookup google.com` ou `Resolve-DnsName google.com`.',
+          },
+          hint: 'Tapez: nslookup google.com',
+          hintByEnv: {
+            windows: 'Tapez: nslookup google.com (ou Resolve-DnsName google.com)',
+          },
+          validate: (cmd, env) => {
+            const c = cmd.trim().toLowerCase();
+            if (env === 'windows') {
+              return /^nslookup\s+.+/.test(c) || /^resolve-dnsname\s+.+/.test(c) || /^dig\s+.+/.test(c);
+            }
+            return /^nslookup\s+.+/.test(c) || /^dig\s+.+/.test(c);
+          },
+          successMessage: 'Parfait ! Vous savez maintenant interroger le DNS depuis le terminal.',
+        },
+      },
+      {
+        id: 'ssh',
+        title: 'SSH — Connexion distante sécurisée',
+        description: 'Connectez-vous à des serveurs distants et gérez vos clés SSH',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'SSH (Secure Shell) est le protocole standard pour se connecter à des serveurs distants de manière chiffrée. C\'est une compétence fondamentale pour tout développeur qui déploie des applications.',
+          },
+          {
+            type: 'code',
+            content: '# Connexion de base\n$ ssh user@serveur.example.com\n\n# Connexion sur un port non-standard\n$ ssh -p 2222 user@serveur.example.com\n\n# Connexion avec une clé spécifique\n$ ssh -i ~/.ssh/ma-cle user@serveur.example.com',
+            label: 'Connexion SSH (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Générer une paire de clés ED25519 (recommandé)\n$ ssh-keygen -t ed25519 -C "mon@email.com"\n\nGenerating public/private ed25519 key pair.\nEnter file (.ssh/id_ed25519): [Entrée]\nEnter passphrase: [optionnel]\n\nYour public key has been saved in ~/.ssh/id_ed25519.pub\n\n# Copier la clé publique sur un serveur\n$ ssh-copy-id user@serveur.example.com',
+            label: 'Générer des clés SSH',
+          },
+          {
+            type: 'info',
+            content:
+              'SSH utilise une paire de clés : une **clé privée** (à ne jamais partager) et une **clé publique** (à déposer sur les serveurs). L\'authentification se fait sans mot de passe — bien plus sécurisé.',
+            contentByEnv: {
+              windows: 'OpenSSH est intégré à Windows 10+ (version 1803). Les commandes `ssh`, `ssh-keygen`, `ssh-copy-id` fonctionnent dans PowerShell et CMD. Les clés sont stockées dans `%USERPROFILE%\\.ssh\\`.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Préférez `ed25519` à `rsa` pour les nouvelles clés : plus court, plus rapide, plus sécurisé. Ajoutez toujours une passphrase à votre clé privée — c\'est votre dernière ligne de défense si la clé est volée.',
+          },
+        ],
+        exercise: {
+          instruction: 'Générez une paire de clés SSH ED25519 avec `ssh-keygen -t ed25519`.',
+          hint: 'Tapez: ssh-keygen -t ed25519',
+          validate: (cmd) => {
+            const c = cmd.trim().toLowerCase();
+            return /^ssh-keygen\s+.*-t\s+ed25519/.test(c) || /^ssh-keygen\s+-t\s+ed25519/.test(c);
+          },
+          successMessage: 'Bravo ! Vous venez de générer votre première paire de clés SSH.',
+        },
+      },
+      {
+        id: 'scp',
+        title: 'scp — Copier des fichiers via SSH',
+        description: 'Transférez des fichiers entre machines de manière sécurisée',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`scp` (Secure Copy Protocol) copie des fichiers entre machines en utilisant le protocole SSH. C\'est la méthode la plus simple pour transférer des fichiers vers un serveur distant sans interface graphique.',
+          },
+          {
+            type: 'code',
+            content: '# Copier un fichier local vers un serveur\n$ scp fichier.txt user@serveur:/home/user/\n\n# Copier depuis un serveur vers local\n$ scp user@serveur:/home/user/fichier.txt ./\n\n# Copier un répertoire entier (-r)\n$ scp -r mon-projet/ user@serveur:/var/www/',
+            label: 'Syntaxe scp (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Copier sur un port non-standard\n$ scp -P 2222 fichier.txt user@serveur:/home/user/\n\n# Copier avec compression (-C)\n$ scp -C gros-fichier.tar user@serveur:/backup/\n\n# Afficher la progression (-v verbose)\n$ scp -v fichier.txt user@serveur:/home/user/',
+            label: 'Options utiles',
+          },
+          {
+            type: 'info',
+            content:
+              'Note : `-p` en minuscule pour `ssh` (port), `-P` en majuscule pour `scp` (port). Cette asymétrie est historique.',
+            contentByEnv: {
+              windows: 'Sur Windows 10+, `scp` est disponible nativement. Pour des transferts récurrents ou complexes, `rsync` (via WSL ou Git Bash) offre plus d\'options : reprise sur interruption, synchronisation différentielle.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Pour des transferts récurrents ou de gros volumes, préférez `rsync` : `rsync -avz mon-projet/ user@serveur:/var/www/`. Il transfère uniquement les fichiers modifiés et supporte la reprise.',
+          },
+        ],
+        exercise: {
+          instruction: 'Copiez un fichier vers un serveur distant avec `scp fichier.txt user@serveur.example.com:/home/user/`.',
+          hint: 'Tapez: scp fichier.txt user@serveur.example.com:/home/user/',
+          validate: (cmd) => /^scp\s+.+\s+.+@.+:.+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Excellent ! Vous savez maintenant transférer des fichiers de manière sécurisée.',
+        },
+      },
+    ],
+  },
 ];
 
 export function getModuleById(id: string): Module | undefined {

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -1906,20 +1906,21 @@ export function processCommand(state: TerminalState, input: string, env: Termina
     case 'curl': {
       const url = args.find((a) => !a.startsWith('-')) ?? '';
       if (!url) return { lines: [{ text: 'Usage: curl [options] <url>', type: 'error' }], newState };
+      const urlHost = url.replace(/^https?:\/\//, '').split('/')[0] ?? 'server';
       if (args[0] === '-I' || args[0] === '--head') {
         return {
           lines: [
             { text: 'HTTP/2 200', type: 'success' },
             { text: 'content-type: application/json; charset=utf-8', type: 'output' },
-            { text: 'server: github.com', type: 'output' },
-            { text: 'x-ratelimit-limit: 60', type: 'output' },
+            { text: `server: ${urlHost}`, type: 'output' },
+            { text: 'x-content-type-options: nosniff', type: 'output' },
           ],
           newState,
         };
       }
       return {
         lines: [
-          { text: '{"current_user_url":"https://api.github.com/user","rate_limit_url":"https://api.github.com/rate_limit"}', type: 'output' },
+          { text: `{"url":"${url}","status":"ok"}`, type: 'output' },
         ],
         newState,
       };
@@ -1928,13 +1929,37 @@ export function processCommand(state: TerminalState, input: string, env: Termina
     case 'wget': {
       const url = args.find((a) => !a.startsWith('-')) ?? '';
       if (!url) return { lines: [{ text: 'Usage: wget <url>', type: 'error' }], newState };
-      const filename = url.split('/').pop() ?? 'index.html';
+      const filename = url.split('/').pop() || 'index.html';
       return {
         lines: [
           { text: `Connecting to ${url.split('/')[2] ?? 'host'}... connected.`, type: 'output' },
           { text: 'HTTP request sent, awaiting response... 200 OK', type: 'success' },
           { text: `Saving to: '${filename}'`, type: 'output' },
           { text: `'${filename}' saved [1024]`, type: 'success' },
+        ],
+        newState,
+      };
+    }
+
+    case 'invoke-webrequest':
+    case 'iwr': {
+      const url = args.find((a) => !a.startsWith('-')) ?? '';
+      if (!url) return { lines: [{ text: 'Usage: Invoke-WebRequest -Uri <url>', type: 'error' }], newState };
+      const outFile = (() => { const i = args.indexOf('-OutFile'); return i >= 0 ? args[i + 1] : null; })();
+      if (outFile) {
+        return {
+          lines: [
+            { text: `Downloading ${url}...`, type: 'output' },
+            { text: `Content saved to '${outFile}'`, type: 'success' },
+          ],
+          newState,
+        };
+      }
+      return {
+        lines: [
+          { text: 'StatusCode        : 200', type: 'output' },
+          { text: 'StatusDescription : OK', type: 'output' },
+          { text: `Content           : {"url":"${url}","status":"ok"}`, type: 'output' },
         ],
         newState,
       };
@@ -1989,7 +2014,7 @@ export function processCommand(state: TerminalState, input: string, env: Termina
       return {
         lines: [
           { text: `ssh: connexion simulée vers ${target}`, type: 'info' },
-          { text: '(Dans un vrai terminal, vous sériez connecté à l\'hôte distant)', type: 'info' },
+          { text: '(Dans un vrai terminal, vous seriez connecté à l\'hôte distant)', type: 'info' },
         ],
         newState,
       };
@@ -2004,7 +2029,7 @@ export function processCommand(state: TerminalState, input: string, env: Termina
           { text: `Enter file in which to save the key (/home/user/.ssh/id_${keyType}): (simulé)`, type: 'output' },
           { text: `Your identification has been saved in /home/user/.ssh/id_${keyType}`, type: 'success' },
           { text: `Your public key has been saved in /home/user/.ssh/id_${keyType}.pub`, type: 'success' },
-          { text: '+--[ED25519 256]--+', type: 'output' },
+          { text: `+--[${keyType.toUpperCase()}]--+`, type: 'output' },
           { text: '|     .o+.        |', type: 'output' },
           { text: '+----[SHA256]-----+', type: 'output' },
         ],

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -1885,6 +1885,144 @@ export function processCommand(state: TerminalState, input: string, env: Termina
       return { lines: [{ text: 'winget — Usage: winget install|list', type: 'output' }], newState };
     }
 
+    // ── Réseau & SSH (Module 8) ───────────────────────────────────────────────
+
+    case 'ping': {
+      const host = args.find((a) => !a.startsWith('-') && isNaN(Number(a))) ?? '';
+      if (!host) return { lines: [{ text: 'Usage: ping <hostname>', type: 'error' }], newState };
+      return {
+        lines: [
+          { text: `PING ${host}: 56 data bytes`, type: 'output' },
+          { text: `64 bytes from ${host}: icmp_seq=0 ttl=54 time=12.3 ms`, type: 'output' },
+          { text: `64 bytes from ${host}: icmp_seq=1 ttl=54 time=11.8 ms`, type: 'output' },
+          { text: `64 bytes from ${host}: icmp_seq=2 ttl=54 time=12.1 ms`, type: 'output' },
+          { text: `--- ${host} ping statistics ---`, type: 'output' },
+          { text: '3 packets transmitted, 3 received, 0% packet loss', type: 'success' },
+        ],
+        newState,
+      };
+    }
+
+    case 'curl': {
+      const url = args.find((a) => !a.startsWith('-')) ?? '';
+      if (!url) return { lines: [{ text: 'Usage: curl [options] <url>', type: 'error' }], newState };
+      if (args[0] === '-I' || args[0] === '--head') {
+        return {
+          lines: [
+            { text: 'HTTP/2 200', type: 'success' },
+            { text: 'content-type: application/json; charset=utf-8', type: 'output' },
+            { text: 'server: github.com', type: 'output' },
+            { text: 'x-ratelimit-limit: 60', type: 'output' },
+          ],
+          newState,
+        };
+      }
+      return {
+        lines: [
+          { text: '{"current_user_url":"https://api.github.com/user","rate_limit_url":"https://api.github.com/rate_limit"}', type: 'output' },
+        ],
+        newState,
+      };
+    }
+
+    case 'wget': {
+      const url = args.find((a) => !a.startsWith('-')) ?? '';
+      if (!url) return { lines: [{ text: 'Usage: wget <url>', type: 'error' }], newState };
+      const filename = url.split('/').pop() ?? 'index.html';
+      return {
+        lines: [
+          { text: `Connecting to ${url.split('/')[2] ?? 'host'}... connected.`, type: 'output' },
+          { text: 'HTTP request sent, awaiting response... 200 OK', type: 'success' },
+          { text: `Saving to: '${filename}'`, type: 'output' },
+          { text: `'${filename}' saved [1024]`, type: 'success' },
+        ],
+        newState,
+      };
+    }
+
+    case 'nslookup': {
+      const host = args[0] ?? '';
+      if (!host) return { lines: [{ text: 'Usage: nslookup <hostname>', type: 'error' }], newState };
+      return {
+        lines: [
+          { text: 'Server:  8.8.8.8', type: 'output' },
+          { text: 'Address: 8.8.8.8#53', type: 'output' },
+          { text: 'Non-authoritative answer:', type: 'output' },
+          { text: `Name: ${host}`, type: 'output' },
+          { text: 'Address: 142.250.74.46', type: 'output' },
+        ],
+        newState,
+      };
+    }
+
+    case 'dig': {
+      const host = args.find((a) => !a.startsWith('+') && !a.startsWith('@')) ?? '';
+      if (!host) return { lines: [{ text: 'Usage: dig <hostname>', type: 'error' }], newState };
+      return {
+        lines: [
+          { text: `; <<>> DiG 9.18.1 <<>> ${host}`, type: 'output' },
+          { text: ';; ANSWER SECTION:', type: 'output' },
+          { text: `${host}. 299 IN A 142.250.74.46`, type: 'output' },
+          { text: ';; Query time: 12 msec', type: 'output' },
+          { text: ';; SERVER: 8.8.8.8#53', type: 'output' },
+        ],
+        newState,
+      };
+    }
+
+    case 'resolve-dnsname': {
+      const host = args.find((a) => !a.startsWith('-')) ?? '';
+      if (!host) return { lines: [{ text: 'Usage: Resolve-DnsName <hostname>', type: 'error' }], newState };
+      return {
+        lines: [
+          { text: 'Name                           Type TTL  Section IPAddress', type: 'output' },
+          { text: '----                           ---- ---  ------- ---------', type: 'output' },
+          { text: `${host.padEnd(31)}A    299  Answer  142.250.74.46`, type: 'output' },
+        ],
+        newState,
+      };
+    }
+
+    case 'ssh': {
+      const target = args.find((a) => !a.startsWith('-')) ?? '';
+      if (!target) return { lines: [{ text: 'Usage: ssh user@hostname', type: 'error' }], newState };
+      return {
+        lines: [
+          { text: `ssh: connexion simulée vers ${target}`, type: 'info' },
+          { text: '(Dans un vrai terminal, vous sériez connecté à l\'hôte distant)', type: 'info' },
+        ],
+        newState,
+      };
+    }
+
+    case 'ssh-keygen': {
+      const tIdx = args.indexOf('-t');
+      const keyType = tIdx >= 0 ? (args[tIdx + 1] ?? 'rsa') : 'rsa';
+      return {
+        lines: [
+          { text: `Generating public/private ${keyType} key pair.`, type: 'output' },
+          { text: `Enter file in which to save the key (/home/user/.ssh/id_${keyType}): (simulé)`, type: 'output' },
+          { text: `Your identification has been saved in /home/user/.ssh/id_${keyType}`, type: 'success' },
+          { text: `Your public key has been saved in /home/user/.ssh/id_${keyType}.pub`, type: 'success' },
+          { text: '+--[ED25519 256]--+', type: 'output' },
+          { text: '|     .o+.        |', type: 'output' },
+          { text: '+----[SHA256]-----+', type: 'output' },
+        ],
+        newState,
+      };
+    }
+
+    case 'scp': {
+      if (args.length < 2) return { lines: [{ text: 'Usage: scp <source> user@host:<dest>', type: 'error' }], newState };
+      const src = args.find((a) => !a.startsWith('-') && !a.includes('@')) ?? args[0];
+      return {
+        lines: [
+          { text: `${src}      100%  1024   512.0KB/s   00:00`, type: 'success' },
+        ],
+        newState,
+      };
+    }
+
     default:
       return {
         lines: [{ text: `${cmd}: commande introuvable. Tapez 'help' pour la liste des commandes.`, type: 'error' }],

--- a/src/test/curriculumTypes.test.ts
+++ b/src/test/curriculumTypes.test.ts
@@ -96,9 +96,9 @@ describe('curriculum types', () => {
       }
     });
 
-    it('total lessons should be 32', () => {
+    it('total lessons should be 38', () => {
       const total = curriculum.reduce((acc, mod) => acc + mod.lessons.length, 0);
-      expect(total).toBe(32);
+      expect(total).toBe(38);
     });
 
     it('module ids are unique (no duplicate modules)', () => {

--- a/src/test/landing.test.tsx
+++ b/src/test/landing.test.tsx
@@ -100,11 +100,11 @@ describe('Landing — trust badges', () => {
 // ── Module grid ───────────────────────────────────────────────────────────────
 
 describe('Landing — module grid', () => {
-  it('renders all 7 module cards with unique labels', () => {
+  it('renders all 8 module cards with unique labels', () => {
     renderLanding();
     // Each card has an aria-label "Accéder au module X"
     const moduleCards = screen.getAllByRole('button', { name: /accéder au module/i });
-    expect(moduleCards).toHaveLength(7);
+    expect(moduleCards).toHaveLength(8);
     const labels = moduleCards.map((card) => card.getAttribute('aria-label'));
     expect(new Set(labels).size).toBe(labels.length);
   });

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -893,3 +893,223 @@ describe('tee — split output to file', () => {
     expect(result.lines.length).toBeGreaterThan(0);
   });
 });
+
+// ─── Module 8 — Réseau & SSH ──────────────────────────────────────────────────
+
+describe('ping', () => {
+  it('returns ping statistics for a hostname', () => {
+    const result = processCommand(makeState(), 'ping google.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('google.com');
+    expect(text).toContain('packet loss');
+  });
+
+  it('last line has success type', () => {
+    const result = processCommand(makeState(), 'ping google.com', 'linux');
+    expect(result.lines[result.lines.length - 1].type).toBe('success');
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'ping 8.8.8.8', 'windows');
+    expect(result.lines.length).toBeGreaterThan(0);
+    expect(result.lines[result.lines.length - 1].type).toBe('success');
+  });
+
+  it('returns error when no host provided', () => {
+    const result = processCommand(makeState(), 'ping', 'linux');
+    expect(result.lines[0].type).toBe('error');
+    expect(result.lines[0].text).toContain('Usage');
+  });
+
+  it('ignores flags and uses hostname', () => {
+    const result = processCommand(makeState(), 'ping -c 4 google.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('google.com');
+  });
+});
+
+describe('curl', () => {
+  it('returns JSON output for a GET request', () => {
+    const result = processCommand(makeState(), 'curl https://api.github.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('api.github.com');
+  });
+
+  it('returns HTTP headers with -I flag', () => {
+    const result = processCommand(makeState(), 'curl -I https://example.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('HTTP/2 200');
+    expect(text).toContain('content-type');
+  });
+
+  it('returns error when no URL provided', () => {
+    const result = processCommand(makeState(), 'curl', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on macos env', () => {
+    const result = processCommand(makeState(), 'curl https://api.github.com', 'macos');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'curl https://api.github.com', 'windows');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe('wget', () => {
+  it('simulates file download with success', () => {
+    const result = processCommand(makeState(), 'wget https://example.com/fichier.zip', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('fichier.zip');
+    expect(text).toContain('saved');
+  });
+
+  it('last download line has success type', () => {
+    const result = processCommand(makeState(), 'wget https://example.com/file.tar.gz', 'linux');
+    expect(result.lines[result.lines.length - 1].type).toBe('success');
+  });
+
+  it('returns error when no URL provided', () => {
+    const result = processCommand(makeState(), 'wget', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on macos env', () => {
+    const result = processCommand(makeState(), 'wget https://example.com/file.zip', 'macos');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'wget https://example.com/file.zip', 'windows');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe('nslookup', () => {
+  it('resolves a hostname and returns IP', () => {
+    const result = processCommand(makeState(), 'nslookup google.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('google.com');
+    expect(text).toContain('142.250.74.46');
+  });
+
+  it('shows DNS server used', () => {
+    const result = processCommand(makeState(), 'nslookup google.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('8.8.8.8');
+  });
+
+  it('returns error when no host provided', () => {
+    const result = processCommand(makeState(), 'nslookup', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'nslookup google.com', 'windows');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe('dig', () => {
+  it('returns DNS answer section', () => {
+    const result = processCommand(makeState(), 'dig google.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('ANSWER SECTION');
+    expect(text).toContain('google.com');
+  });
+
+  it('returns error when no host provided', () => {
+    const result = processCommand(makeState(), 'dig', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on macos env', () => {
+    const result = processCommand(makeState(), 'dig example.com', 'macos');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('example.com');
+  });
+});
+
+describe('resolve-dnsname', () => {
+  it('returns tabular DNS result on windows', () => {
+    const result = processCommand(makeState(), 'Resolve-DnsName google.com', 'windows');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('google.com');
+    expect(text).toContain('IPAddress');
+  });
+
+  it('returns error when no host provided', () => {
+    const result = processCommand(makeState(), 'Resolve-DnsName', 'windows');
+    expect(result.lines[0].type).toBe('error');
+  });
+});
+
+describe('ssh', () => {
+  it('simulates connection to a remote host', () => {
+    const result = processCommand(makeState(), 'ssh user@serveur.example.com', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('user@serveur.example.com');
+  });
+
+  it('returns error when no target provided', () => {
+    const result = processCommand(makeState(), 'ssh', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'ssh user@host.com', 'windows');
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ssh-keygen', () => {
+  it('generates ed25519 key pair', () => {
+    const result = processCommand(makeState(), 'ssh-keygen -t ed25519', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('ed25519');
+    expect(text).toContain('.pub');
+  });
+
+  it('reports both private and public key paths', () => {
+    const result = processCommand(makeState(), 'ssh-keygen -t ed25519', 'linux');
+    const successes = result.lines.filter((l) => l.type === 'success');
+    expect(successes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('uses rsa as default key type when -t is omitted', () => {
+    const result = processCommand(makeState(), 'ssh-keygen', 'linux');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('rsa');
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'ssh-keygen -t ed25519', 'windows');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('ed25519');
+  });
+});
+
+describe('scp', () => {
+  it('simulates file transfer success', () => {
+    const result = processCommand(makeState(), 'scp fichier.txt user@serveur.example.com:/home/user/', 'linux');
+    expect(result.lines[0].type).toBe('success');
+    expect(result.lines[0].text).toContain('100%');
+  });
+
+  it('returns error when fewer than 2 args', () => {
+    const result = processCommand(makeState(), 'scp fichier.txt', 'linux');
+    expect(result.lines[0].type).toBe('error');
+  });
+
+  it('works on macos env', () => {
+    const result = processCommand(makeState(), 'scp file.txt user@host:/tmp/', 'macos');
+    expect(result.lines[0].type).toBe('success');
+  });
+
+  it('works on windows env', () => {
+    const result = processCommand(makeState(), 'scp file.txt user@host:/tmp/', 'windows');
+    expect(result.lines[0].type).toBe('success');
+  });
+});

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -932,7 +932,7 @@ describe('curl', () => {
   it('returns JSON output for a GET request', () => {
     const result = processCommand(makeState(), 'curl https://api.github.com', 'linux');
     const text = result.lines.map((l) => l.text).join('\n');
-    expect(text).toContain('api.github.com');
+    expect(text).toContain('status');
   });
 
   it('returns HTTP headers with -I flag', () => {
@@ -984,6 +984,32 @@ describe('wget', () => {
   it('works on windows env', () => {
     const result = processCommand(makeState(), 'wget https://example.com/file.zip', 'windows');
     expect(result.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe('invoke-webrequest / iwr', () => {
+  it('returns StatusCode 200 for a basic request', () => {
+    const result = processCommand(makeState(), 'Invoke-WebRequest -Uri https://example.com', 'windows');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('200');
+  });
+
+  it('saves to file when -OutFile is specified', () => {
+    const result = processCommand(makeState(), 'Invoke-WebRequest -Uri https://example.com/file.zip -OutFile file.zip', 'windows');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('file.zip');
+    expect(result.lines[result.lines.length - 1].type).toBe('success');
+  });
+
+  it('iwr alias works identically', () => {
+    const result = processCommand(makeState(), 'iwr https://example.com', 'windows');
+    const text = result.lines.map((l) => l.text).join('\n');
+    expect(text).toContain('200');
+  });
+
+  it('returns error when no URL provided', () => {
+    const result = processCommand(makeState(), 'Invoke-WebRequest', 'windows');
+    expect(result.lines[0].type).toBe('error');
   });
 });
 

--- a/src/test/unlocking.test.ts
+++ b/src/test/unlocking.test.ts
@@ -87,6 +87,7 @@ describe('unlocking logic', () => {
         'processus',
         'redirection',
         'variables',
+        'reseau',
       ]);
       const next = getNextRecommendedModule(allModuleIds);
       expect(next).toBeNull();


### PR DESCRIPTION
## Summary

- Add **Module 8 — Réseau & SSH** to the Terminal Learning curriculum (6 lessons)
- Simulated commands in `terminalEngine.ts` for all 8 new commands
- 35 unit tests across 3 environments (linux/macos/windows)

## Lessons

| # | Leçon | Commandes | Env |
|---|-------|-----------|-----|
| 1 | ping | `ping -c N host` | linux/macos/windows |
| 2 | curl | `curl URL`, `curl -I URL`, `Invoke-WebRequest` | all |
| 3 | wget | `wget URL`, `iwr` | all |
| 4 | DNS | `nslookup`, `dig`, `Resolve-DnsName` | all |
| 5 | SSH | `ssh user@host`, `ssh-keygen -t ed25519` | all |
| 6 | scp | `scp src user@host:/dest` | all |

## Fixes included

- `ping -c 4 google.com` hostname detection bug (numeric arg `4` was incorrectly captured as host)
- Test assertions updated: 32→38 lessons, 7→8 modules, `reseau` added to completion set

## Test plan

- [x] 384/384 tests pass (35 new tests for Module 8)
- [x] `curriculum-validator` agent: no CRITICAL issues
- [x] All 6 lessons have `instructionByEnv`/`contentByEnv` for cross-platform coverage
- [x] `level: 3` (within 1-5 constraint)

Closes THI-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajoute un nouveau module Réseau & SSH au programme d’apprentissage du terminal avec des commandes réseau simulées et des tests correspondants.

Nouvelles fonctionnalités :
- Introduction du module Réseau & SSH avec six leçons couvrant ping, les outils HTTP, DNS, SSH et la copie de fichiers sécurisée.
- Simulation de nouvelles commandes liées au réseau (`ping`, `curl`, `wget`, `nslookup`, `dig`, `Resolve-DnsName`, `ssh`, `ssh-keygen`, `scp`) dans le moteur de terminal sur tous les environnements.

Corrections de bugs :
- Correction de l’analyse des noms d’hôte pour `ping` afin que les options numériques de comptage comme `-c 4` ne soient pas prises pour l’hôte.
- Mise à jour des attentes sur le nombre de modules et de leçons ainsi que de la logique de déverrouillage pour tenir compte du nouveau module et garantir que `reseau` soit traité comme terminé lorsque c’est approprié.

Tests :
- Ajout de tests unitaires complets pour toutes les nouvelles commandes réseau sur les environnements Linux, macOS et Windows.
- Ajustement des tests du programme et de la page d’accueil pour vérifier le nouveau nombre total de leçons et de modules, ainsi que la présence du module Réseau & SSH dans la grille.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Réseau & SSH module to the terminal learning curriculum with simulated network commands and corresponding tests.

New Features:
- Introduce the Réseau & SSH module with six lessons covering ping, HTTP tools, DNS, SSH, and secure file copy.
- Simulate new network-related commands (ping, curl, wget, nslookup, dig, Resolve-DnsName, ssh, ssh-keygen, scp) in the terminal engine across environments.

Bug Fixes:
- Fix ping hostname parsing so numeric count flags like -c 4 are not mistaken for the host.
- Update module and lesson count expectations and unlocking logic to reflect the new module and ensure reseau is treated as completed when appropriate.

Tests:
- Add comprehensive unit tests for all new network commands across Linux, macOS, and Windows environments.
- Adjust curriculum and landing page tests to assert the new total lesson and module counts and the presence of the Réseau & SSH module in the grid.

</details>