### PR TITLE
chore(agents): Content Auditor agent — audit pédagogique A→Z (THI-45)

### DIFF
--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -18,10 +18,13 @@ Analyse en profondeur l'ensemble du curriculum et produis un rapport structuré 
 
 ## Vérifications à effectuer
 
-### 1. Couverture environnement
+### 1. Couverture des environnements
 Pour chaque leçon, vérifier la présence de `instructionByEnv`, `hintByEnv` et `contentByEnv` couvrant `linux`, `macos`, `windows`.
 - CRITICAL si un env manque sans raison légitime
-- WARNING si une leçon est volontairement mono-OS (ex: commandes Windows-only comme `taskkill`, `Get-Help`)
+- WARNING si une leçon est volontairement mono-OS. Heuristique : classer en WARNING (pas CRITICAL) si la commande appartient à l'une des listes suivantes :
+  - Windows-only : `taskkill`, `Get-Help`, `Get-Command`, `Get-Member`, `Get-ChildItem`, `Invoke-WebRequest`, `iwr`, `Resolve-DnsName`, `wevtutil`, `Get-EventLog`
+  - Linux/macOS-only : `man`, `whatis`, `apropos`, `brew`, `apt`, `dpkg`
+  - Ou si la leçon contient explicitement un seul env dans son champ `id` ou `title` (ex: "PowerShell", "Windows")
 
 ### 2. Cohérence curriculum ↔ terminalEngine
 Pour chaque commande référencée dans une leçon (champ `command` des exercices), vérifier qu'un `case 'command':` existe dans `terminalEngine.ts`.
@@ -46,9 +49,12 @@ Pour chaque exercice, la fonction `validate()` doit être non-triviale :
 - Validate toujours `true` — CRITICAL
 - Validate vide ou absente — CRITICAL
 
-### 7. Liens externes (best-effort)
-Si des URLs apparaissent dans `contentByEnv` ou `hintByEnv`, tenter une requête WebFetch.
-- WARNING si une URL retourne une erreur HTTP ou est inaccessible
+### 7. Liens externes (best-effort, limité)
+Si des URLs apparaissent dans `contentByEnv` ou `hintByEnv`, tenter une requête WebFetch sur les **10 premières URLs distinctes** uniquement.
+- Ignorer les URLs déjà vérifiées dans la même session (déduplication)
+- Timeout implicite WebFetch : si pas de réponse, classer WARNING et continuer (ne pas bloquer l'audit)
+- WARNING si une URL retourne une erreur HTTP (4xx/5xx) ou est inaccessible
+- Ne pas agréger les échecs réseau transitoires comme des WARNING : signaler uniquement les erreurs répétables
 
 ### 8. ExerciseTypes (Phase 5b — futur)
 Si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement :

--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -1,0 +1,83 @@
+---
+name: content-auditor
+description: Full pedagogical content audit — checks env coverage, curriculum↔terminalEngine consistency, test coverage, external link validity, prerequisite chain logic, and validate() function quality. Run on demand or before major releases. Returns a structured report.
+tools: Read, Grep, Glob, WebFetch
+model: haiku
+---
+
+Tu es un auditeur de contenu pédagogique pour Terminal Learning.
+
+Analyse en profondeur l'ensemble du curriculum et produis un rapport structuré A→Z.
+
+## Fichiers à analyser
+
+- `src/app/data/curriculum.ts` — modules et leçons
+- `src/app/data/terminalEngine.ts` — commandes simulées
+- `src/app/data/commandCatalogue.ts` — catalogue de référence
+- `src/test/terminalEngine.test.ts` — tests unitaires
+
+## Vérifications à effectuer
+
+### 1. Couverture environnement
+Pour chaque leçon, vérifier la présence de `instructionByEnv`, `hintByEnv` et `contentByEnv` couvrant `linux`, `macos`, `windows`.
+- CRITICAL si un env manque sans raison légitime
+- WARNING si une leçon est volontairement mono-OS (ex: commandes Windows-only comme `taskkill`, `Get-Help`)
+
+### 2. Cohérence curriculum ↔ terminalEngine
+Pour chaque commande référencée dans une leçon (champ `command` des exercices), vérifier qu'un `case 'command':` existe dans `terminalEngine.ts`.
+- CRITICAL si une commande enseignée n'est pas simulée dans le moteur
+
+### 3. Couverture tests
+Pour chaque `case` dans le switch de `terminalEngine.ts`, vérifier qu'au moins 1 test `describe`/`it` existe dans `terminalEngine.test.ts`.
+- WARNING si une commande du moteur n'a aucun test
+
+### 4. Cohérence curriculum ↔ commandCatalogue
+Pour chaque module présent dans les deux fichiers, vérifier que `level` et `prerequisites` sont identiques.
+- WARNING si incohérence détectée
+
+### 5. Chaîne pédagogique
+- Les prérequis forment-ils un graphe acyclique ? (pas de dépendance circulaire)
+- La progression de niveaux est-elle logique ? (prérequis = niveau N → module = niveau N+1 au max)
+- WARNING si anomalie détectée
+
+### 6. Qualité des fonctions validate()
+Pour chaque exercice, la fonction `validate()` doit être non-triviale :
+- Regex trop permissive : `/.*cmd.*/` — WARNING
+- Validate toujours `true` — CRITICAL
+- Validate vide ou absente — CRITICAL
+
+### 7. Liens externes (best-effort)
+Si des URLs apparaissent dans `contentByEnv` ou `hintByEnv`, tenter une requête WebFetch.
+- WARNING si une URL retourne une erreur HTTP ou est inaccessible
+
+### 8. ExerciseTypes (Phase 5b — futur)
+Si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement :
+`fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`.
+Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.
+
+## Format de rapport obligatoire
+
+```
+CONTENT AUDIT REPORT — Terminal Learning
+==========================================
+Date     : YYYY-MM-DD
+Modules  : N  |  Leçons : N  |  Tests : N
+
+CRITICAL (bloquants — corriger avant merge) :
+  [C1] module/leçon — description précise du problème
+
+WARNINGS (à corriger dans le prochain sprint) :
+  [W1] module/leçon — description précise
+
+INFO :
+  [I1] statistiques générales (couverture env, ratio tests/commandes, etc.)
+  [I2] observations pédagogiques (liens morts, progressions inhabituelles)
+
+VERDICT: ✅ Propre | ⚠️ N warnings, 0 critiques | ❌ N critiques à corriger
+```
+
+Retourne UNIQUEMENT ce rapport + une recommandation d'action (1-2 phrases).
+
+## Note V2 (future)
+Quand le panel admin Supabase sera en place (Phase 9), ce rapport sera écrit dans la table
+`audit_reports` via une Edge Function. Pour l'instant, retourner uniquement le texte.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **`linear-sync`** — vérifie PRs GitHub vs statuts Linear, détecte incohérences
 - **`curriculum-validator`** — valide structure de `curriculum.ts` avant toute modification
 - **`test-runner`** — lance vitest, retourne uniquement failures + commandes sans test
-- **`content-auditor`** — audit pédagogique A→Z : env coverage, cohérence curriculum↔moteur↔tests, liens externes, chaîne prérequis, qualité validate(). Lancer avant chaque release majeure ou à la demande.
+- **`content-auditor`** — audit pédagogique A→Z : env coverage, cohérence curriculum↔moteur↔tests, liens externes, chaîne de prérequis, qualité validate(). Lancer avant chaque release majeure ou à la demande.
 
 ### Début de chaque session
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
-- Phase 5 🔄 Curriculum expansion — 7 modules, 32 leçons, 242 tests unitaires + 176 E2E Playwright (en cours)
+- Phase 5 🔄 Curriculum expansion — 8 modules, 38 leçons, 388 tests unitaires + 176 E2E Playwright (en cours)
 
 ## Tech debt
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
@@ -56,6 +56,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **`linear-sync`** — vérifie PRs GitHub vs statuts Linear, détecte incohérences
 - **`curriculum-validator`** — valide structure de `curriculum.ts` avant toute modification
 - **`test-runner`** — lance vitest, retourne uniquement failures + commandes sans test
+- **`content-auditor`** — audit pédagogique A→Z : env coverage, cohérence curriculum↔moteur↔tests, liens externes, chaîne prérequis, qualité validate(). Lancer avant chaque release majeure ou à la demande.
 
 ### Début de chaque session
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 10 avril 2026
-> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 7 modules ✅, 32 leçons, 242 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
+> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 8 modules ✅, 38 leçons, 388 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
 
 ---
 
@@ -9,12 +9,13 @@
 
 | Issue Linear | Phase | Contenu |
 |-------------|-------|---------|
-| THI-27 | 5 | Module 8 — Réseau & SSH (`ping`, `curl`, `wget`, `ssh`, `scp`, DNS) |
+| THI-27 | 5 | Module 8 — Réseau & SSH (`ping`, `curl`, `wget`, `ssh`, `scp`, DNS) ✅ Done |
 | THI-28 | 5 | Modules 9+10 — Git Fondamentaux + GitHub & Collaboration *(combinés)* |
 | THI-29 | 5 | Module 11 — L'IA comme outil dev |
 | THI-35 | docs | Architecture stratégique — Terminal Sentinel, RBAC, Admin Panel, PWA ✅ Done |
 | THI-36 | 5.5 | Terminal Sentinel — outil d'audit de sécurité automatisé |
 | THI-37 | 7 | RBAC complet — student / teacher / institution / admin |
+| THI-45 | agents | Content Auditor V1 — audit pédagogique A→Z (`.claude/agents/content-auditor.md`) |
 
 ---
 
@@ -125,8 +126,12 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 - Fallback `<PageLoader>` accessible dans `App.tsx`
 - Objectif : réduire le bundle initial de ~30-40%, améliorer LCP/TTI landing
 
-#### 🔜 Modules planifiés (THI-27 à THI-29)
-- **Module 8 — Réseau & SSH** (THI-27) : `ping`, `curl`, `wget`, `ssh`, `scp`, DNS
+#### ✅ Module 8 — Réseau & SSH (THI-27 — mergé 10 avril 2026)
+- `ping`, `curl`, `wget`, `nslookup`, `dig`, `Resolve-DnsName`, `ssh`, `ssh-keygen`, `scp` + PowerShell `iwr`
+- 6 leçons × 3 environnements, 39 tests unitaires
+- Invoke-WebRequest/iwr simulé (Windows), curl generic (urlHost dynamique), ssh-keygen banner dynamique
+
+#### 🔜 Modules planifiés
 - **Module 9 + 10 — Git Fondamentaux + GitHub & Collaboration** (THI-28) : `init`, `add`, `commit`, branches, remotes, PRs, Issues, GitHub Actions
 - **Module 11 — L'IA comme outil dev** (THI-29) : Claude Code CLI, prompts contextuels, limites et risques
 
@@ -287,6 +292,39 @@ output:
 #### Tests requis
 - Tests unitaires : fonctions de parsing et scoring des rapports
 - Dry-run CI : le workflow GitHub Actions est valide syntaxiquement
+
+---
+
+### 🔄 Phase 5 Agents — Agents Claude Code (THI-45)
+
+> Infrastructure d'agents pédagogiques pour la maintenance qualité du projet.
+
+#### Agents opérationnels (`.claude/agents/`)
+
+| Agent | Modèle | Déclencheur | Rôle |
+|-------|--------|-------------|------|
+| `linear-sync` | haiku | Début de session | Vérifie cohérence PRs GitHub ↔ statuts Linear |
+| `curriculum-validator` | haiku | Avant toute modif `curriculum.ts` | Valide structure, env coverage, IDs uniques |
+| `test-runner` | haiku | Après modif `curriculum.ts` ou `terminalEngine.ts` | Lance vitest, retourne failures uniquement |
+| `content-auditor` | haiku | Avant release majeure / à la demande | Audit pédagogique A→Z (voir ci-dessous) |
+
+#### Content Auditor V1 — analyse statique
+
+Vérifications effectuées :
+1. **Couverture env** : `instructionByEnv`, `hintByEnv`, `contentByEnv` pour linux/macos/windows
+2. **Cohérence curriculum ↔ terminalEngine** : chaque commande enseignée est simulée
+3. **Couverture tests** : chaque `case` du moteur a ≥ 1 test
+4. **Cohérence curriculum ↔ commandCatalogue** : niveaux + prérequis identiques
+5. **Chaîne pédagogique** : graphe acyclique, progression de niveaux logique
+6. **Qualité validate()** : pas de regex trop permissive, pas de validate toujours `true`
+7. **Liens externes** : URLs dans les leçons retournent HTTP 200
+
+#### Content Auditor V2 — intégration CMS Admin (Phase 9)
+
+- Rapport écrit dans table Supabase `audit_reports`
+- Dashboard admin : historique + tendances + alertes
+- Cron CI GitHub Actions hebdomadaire
+- Email alertes si CRITICAL détecté
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/content-auditor.md`: new Claude Code sub-agent for full pedagogical content audit
- Updates `CLAUDE.md`: new agent listed + Phase 5 stats corrected (8 modules / 38 lessons / 388 tests)
- Updates `docs/plan.md`: THI-27 marked Done, new "Phase 5 Agents" section with V1/V2 architecture

## Content Auditor — what it checks

| Check | Severity |
|-------|----------|
| Env coverage (`instructionByEnv`, `hintByEnv`, `contentByEnv` for linux/macos/windows) | CRITICAL / WARNING |
| Curriculum ↔ terminalEngine consistency (every taught command is simulated) | CRITICAL |
| Test coverage (every engine `case` has ≥ 1 test) | WARNING |
| Curriculum ↔ commandCatalogue alignment (levels + prerequisites) | WARNING |
| Prerequisite chain (acyclic graph, logical level progression) | WARNING |
| `validate()` quality (no always-true, no over-permissive regex) | CRITICAL / WARNING |
| External links (HTTP 200) | WARNING |

## Phased roadmap

- **V1 (this PR)**: static analysis, text report returned to session
- **V2 (Phase 9)**: Supabase `audit_reports` table + admin dashboard + weekly CI cron

## Test plan

- [ ] Invoke `content-auditor` agent in a new session — verify report format and accuracy
- [ ] Check that all 8 modules are covered in the audit output
- [ ] Confirm CI passes (no source code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Introduction d’un nouvel agent Claude Code de contrôle de contenu et mise à jour de la documentation de planification du projet pour refléter l’achèvement du Module 8 et la nouvelle infrastructure qualité basée sur des agents.

Nouvelles fonctionnalités :
- Ajout d’une définition d’agent Claude Code « content-auditor » pour des audits pédagogiques complets des contenus, couvrant le curriculum, le moteur, les tests et les liens externes.

Améliorations :
- Documentation de l’architecture des agents de la Phase 5, incluant la feuille de route V1/V2 de l’agent « content-auditor » et les rôles des agents existants.

Documentation :
- Mise à jour du plan et de la documentation CLAUDE pour refléter 8 modules, les nombres étendus de leçons/tests, l’achèvement de THI-27 et le suivi de THI-45 Content Auditor V1.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new Claude Code content-auditor agent and update project planning docs to reflect completed Module 8 and the new agent-based quality infrastructure.

New Features:
- Add a content-auditor Claude Code agent definition for full pedagogical content audits across curriculum, engine, tests, and external links.

Enhancements:
- Document the Phase 5 agent architecture, including the content-auditor V1/V2 roadmap and roles of existing agents.

Documentation:
- Update plan and CLAUDE documentation to reflect 8 modules, expanded lessons/tests counts, completion of THI-27, and tracking of THI-45 Content Auditor V1.

</details>