### PR TITLE
feat(ui): UserMenu GitHub-style — avatar + sync dot + dropdown (THI-47)

### DIFF
--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { LogOut } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 
 interface UserMenuProps {
@@ -7,11 +8,11 @@ interface UserMenuProps {
   placement?: 'bottom' | 'top';
 }
 
-const SYNC_LABELS: Record<UserMenuProps['syncStatus'], { label: string; color: string }> = {
-  local:   { label: 'local',   color: 'text-[#8b949e]' },
-  syncing: { label: 'sync...', color: 'text-yellow-400' },
-  synced:  { label: 'synced',  color: 'text-emerald-400' },
-  error:   { label: 'erreur',  color: 'text-[#f85149]' },
+const SYNC_CONFIG: Record<UserMenuProps['syncStatus'], { label: string; dot: string }> = {
+  local:   { label: 'Local',    dot: 'bg-[#8b949e]' },
+  syncing: { label: 'Sync…',    dot: 'bg-yellow-400 animate-pulse' },
+  synced:  { label: 'Synced',   dot: 'bg-emerald-400' },
+  error:   { label: 'Erreur',   dot: 'bg-[#f85149]' },
 };
 
 export function UserMenu({ syncStatus, placement = 'bottom' }: UserMenuProps) {
@@ -19,6 +20,25 @@ export function UserMenu({ syncStatus, placement = 'bottom' }: UserMenuProps) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointer);
+    return () => document.removeEventListener('pointerdown', onPointer);
+  }, [open]);
 
   const handleSignOut = async () => {
     setOpen(false);
@@ -39,46 +59,85 @@ export function UserMenu({ syncStatus, placement = 'bottom' }: UserMenuProps) {
   const displayName =
     (user.user_metadata?.full_name as string | undefined) ??
     (user.user_metadata?.user_name as string | undefined) ??
-    user.email ??
+    user.email?.split('@')[0] ??
     'Utilisateur';
 
-  const sync = SYNC_LABELS[syncStatus];
+  const sync = SYNC_CONFIG[syncStatus];
+  const initials = displayName[0].toUpperCase();
 
   return (
-    <div className="relative">
+    <div ref={menuRef} className="relative">
+      {/* ── Trigger button — avatar only + sync dot ── */}
       <button
         onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#30363d] bg-[#161b22] hover:border-emerald-500/40 transition-colors"
+        aria-label={`Menu utilisateur — ${displayName}`}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="relative flex items-center justify-center rounded-full ring-2 ring-transparent hover:ring-emerald-500/50 focus-visible:ring-emerald-500 transition-all outline-none"
       >
         {avatarUrl ? (
-          <img src={avatarUrl} alt="" className="w-6 h-6 rounded-full" />
+          <img
+            src={avatarUrl}
+            alt={displayName}
+            className="w-8 h-8 rounded-full"
+          />
         ) : (
-          <span className="w-6 h-6 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 text-xs font-mono">
-            {displayName[0].toUpperCase()}
+          <span className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 text-sm font-mono select-none">
+            {initials}
           </span>
         )}
-        <span className="text-xs text-[#e6edf3] font-mono hidden sm:block max-w-[120px] truncate">
-          {displayName}
-        </span>
-        <span className={`text-xs font-mono ${sync.color}`}>{sync.label}</span>
+        {/* Sync status dot */}
+        <span
+          aria-hidden="true"
+          className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[#0d1117] ${sync.dot}`}
+        />
       </button>
 
+      {/* ── Dropdown ── */}
       {open && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className={`absolute right-0 z-20 w-48 bg-[#161b22] border border-[#30363d] rounded-lg shadow-xl overflow-hidden ${placement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
-            <div className="px-3 py-2 border-b border-[#30363d]">
-              <p className="text-xs text-[#8b949e] font-mono truncate">{user.email}</p>
+        <div
+          role="menu"
+          aria-label="Menu utilisateur"
+          className={`absolute right-0 z-50 w-64 bg-[#161b22] border border-[#30363d] rounded-xl shadow-2xl overflow-hidden ${
+            placement === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'
+          }`}
+        >
+          {/* Header */}
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-[#30363d]">
+            {avatarUrl ? (
+              <img src={avatarUrl} alt="" aria-hidden="true" className="w-10 h-10 rounded-full shrink-0" />
+            ) : (
+              <span className="w-10 h-10 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 text-base font-mono shrink-0 select-none">
+                {initials}
+              </span>
+            )}
+            <div className="min-w-0">
+              <p className="text-sm text-[#e6edf3] font-medium truncate">{displayName}</p>
+              <p className="text-xs text-[#8b949e] truncate">{user.email}</p>
+              <span className={`inline-flex items-center gap-1 mt-0.5 text-[10px] font-mono ${
+                syncStatus === 'synced' ? 'text-emerald-400' :
+                syncStatus === 'syncing' ? 'text-yellow-400' :
+                syncStatus === 'error' ? 'text-[#f85149]' : 'text-[#8b949e]'
+              }`}>
+                <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full ${sync.dot}`} />
+                {sync.label}
+              </span>
             </div>
+          </div>
+
+          {/* Actions */}
+          <div className="py-1">
             <button
+              role="menuitem"
               onClick={handleSignOut}
               disabled={signingOut}
-              className="w-full text-left px-3 py-2.5 text-sm text-[#f85149] hover:bg-[#0d1117] font-mono transition-colors disabled:opacity-50"
+              className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-[#f85149] hover:bg-[#f85149]/10 font-mono transition-colors disabled:opacity-50 outline-none focus-visible:bg-[#f85149]/10"
             >
+              <LogOut size={14} aria-hidden="true" />
               {signingOut ? 'Déconnexion…' : 'Déconnexion'}
             </button>
           </div>
-        </>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Remplace le bouton verbeux `[avatar][Thierry][sync...]` par un design GitHub-style épuré.

**Avant** : bouton rectangulaire avec avatar + nom tronqué + label sync
**Après** : avatar circulaire seul + petit dot coloré + dropdown riche au clic

## Design

**Bouton trigger**
- Avatar 32px circulaire (ou initiale si pas d'avatar OAuth)
- Dot de statut sync en position `-bottom-0.5 -right-0.5` :
  - 🟢 `bg-emerald-400` — synced
  - 🟡 `bg-yellow-400 animate-pulse` — syncing
  - 🔴 `bg-[#f85149]` — erreur
  - ⚫ `bg-[#8b949e]` — local

**Dropdown**
- Header : avatar 40px + nom + email + badge sync textuel
- Déconnexion avec icône `LogOut` (Lucide)

## Accessibilité

- `aria-label`, `aria-expanded`, `aria-haspopup="menu"` sur le bouton
- `role="menu"` / `role="menuitem"` sur le dropdown
- Fermeture : `Escape` (keydown) + clic extérieur (`pointerdown`)
- `focus-visible` ring sur tous les éléments interactifs
- Remplacement du hack `fixed inset-0` overlay par `pointerdown` natif

## Test plan

- [ ] Tester connexion GitHub OAuth — avatar réel visible
- [ ] Tester connexion email — initiale fallback visible
- [ ] Vérifier dot sync dans les 4 états (local → syncing → synced → error)
- [ ] Keyboard : Tab → Enter ouvre, Escape ferme, Tab navigue dans dropdown
- [ ] Mobile : placement `top` fonctionne en sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redésigner le menu de l’utilisateur authentifié en un déclencheur compact basé sur l’avatar, avec un menu déroulant plus riche et une meilleure accessibilité ainsi qu’une gestion améliorée des interactions.

Nouvelles fonctionnalités :
- Afficher un déclencheur uniquement sous forme d’avatar circulaire avec un point de statut de synchronisation, au lieu d’un bouton utilisateur riche en texte.
- Afficher un en-tête de menu déroulant plus riche avec l’avatar, le nom d’affichage, l’e-mail et un badge textuel indiquant l’état de synchronisation.
- Inclure une action de déconnexion dédiée avec une icône dans le menu déroulant de l’utilisateur.

Améliorations :
- Améliorer la configuration de l’état de synchronisation pour piloter à la fois le texte du libellé et le style visuel du point de statut dans le menu utilisateur.
- Affiner la gestion du nom d’affichage et la solution de repli utilisant les initiales lorsqu’aucun avatar n’est disponible.
- Ajouter la prise en charge de la touche Échap et la détection de clic à l’extérieur pour fermer le menu utilisateur, et appliquer les rôles ARIA ainsi que les styles de focus pour une meilleure accessibilité.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Redesign the authenticated user menu to a compact avatar-based trigger with a richer dropdown and improved accessibility and interaction handling.

New Features:
- Show a circular avatar-only trigger with a sync status dot instead of a text-heavy user button.
- Display a richer dropdown header with avatar, display name, email, and textual sync status badge.
- Include a dedicated logout action with an icon in the user menu dropdown.

Enhancements:
- Improve sync status configuration to drive both label text and visual dot styling for the user menu.
- Refine display name handling and initials fallback when no avatar is available.
- Add keyboard Escape handling and outside-click detection to close the user menu, and apply ARIA roles and focus styles for better accessibility.

</details>