### PR TITLE
fix(auth): instant sign-out + faster sync timeout

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -39,13 +39,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signOut = useCallback(async () => {
     if (!supabase) return;
-    // scope:'global' revokes the refresh token server-side, which is required with
-    // OAuth providers (GitHub, Google): scope:'local' only cleared localStorage but
-    // left the server-side session active, causing Supabase to immediately re-sign
-    // the user in via onAuthStateChange — making sign-out appear broken.
+    // Clear local session immediately — the UI reacts instantly.
+    // Then revoke the server-side refresh token in the background (fire-and-forget).
+    // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the
+    // server-side session active, causing Supabase to re-sign the user immediately
+    // via onAuthStateChange — making sign-out appear broken.
+    // We don't await the API call: the local session is already gone, and token
+    // revocation completing a few seconds later is an acceptable trade-off.
     // See: https://supabase.com/docs/reference/javascript/auth-signout
-    await supabase.auth.signOut({ scope: 'global' });
-    setSession(null); // immediate UI reset — don't wait for onAuthStateChange
+    setSession(null);
+    void supabase.auth.signOut({ scope: 'global' });
   }, []);
 
   return (

--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -81,13 +81,14 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
       if (event !== 'INITIAL_SESSION' && event !== 'SIGNED_IN') return;
 
       setSyncStatus('syncing');
-      // Abort if Supabase doesn't respond within 10 s — prevents indefinite yellow dot.
+      // Abort if Supabase doesn't respond within 5 s — prevents a long yellow dot.
+      // Free-tier cold starts are typically < 3 s; 5 s gives a safe margin.
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 10_000);
+      const timeout = setTimeout(() => controller.abort(), 5_000);
       try {
         const { data: remote, error } = await client
           .from('progress')
-          .select('*')
+          .select('lesson_id, completed')   // only the two columns we actually use
           .eq('user_id', session.user.id)
           .abortSignal(controller.signal);
         clearTimeout(timeout);

--- a/src/app/lib/progressSync.ts
+++ b/src/app/lib/progressSync.ts
@@ -2,13 +2,16 @@ import type { Database } from '../types/database';
 
 export type RemoteLesson = Database['public']['Tables']['progress']['Row'];
 
+/** Minimal shape used by merge/delta — only the two columns we actually fetch. */
+export type RemoteLessonPartial = Pick<RemoteLesson, 'lesson_id' | 'completed'>;
+
 /**
  * Merge local (localStorage) progress with remote (Supabase) records.
  * Rule: a completed lesson is never downgraded — once true, stays true.
  */
 export function mergeProgress(
   local: Record<string, boolean>,
-  remote: RemoteLesson[]
+  remote: RemoteLessonPartial[]
 ): Record<string, boolean> {
   const merged = { ...local };
   for (const row of remote) {
@@ -24,7 +27,7 @@ export function mergeProgress(
  */
 export function getDelta(
   local: Record<string, boolean>,
-  remote: RemoteLesson[]
+  remote: RemoteLessonPartial[]
 ): string[] {
   const remoteCompleted = new Set(
     remote.filter((r) => r.completed).map((r) => r.lesson_id)


### PR DESCRIPTION
## Problème

Deux régressions UX en production :
1. **Bouton déconnexion bloqué** — `await supabase.auth.signOut({ scope: 'global' })` attendait la réponse serveur avant de libérer le bouton et de naviguer. Sur réseau lent = plusieurs secondes de freeze.
2. **Dot jaune qui reste longtemps** — timeout de sync à 10 s, et requête `select('*')` inutilement large.

## Solution

### `AuthContext.tsx`
- `setSession(null)` en premier → session locale effacée immédiatement
- `void supabase.auth.signOut({ scope: 'global' })` → révocation serveur en background (fire-and-forget)
- Le bouton répond instantanément

### `ProgressContext.tsx`
- Timeout 10 s → **5 s** (cold start Supabase free tier < 3 s)
- `select('lesson_id, completed')` au lieu de `select('*')` — payload réduit

### `progressSync.ts`
- Nouveau type `RemoteLessonPartial` (Pick des 2 champs utilisés) pour matcher le select partiel

## Sécurité
**Trade-off connu** : si le browser est fermé dans les ~1 s après sign-out, la révocation serveur pourrait ne pas compléter → le refresh token resterait valide jusqu'à son TTL Supabase. Risque marginal pour une app éducative sans données financières ; RLS protège la DB même avec un token valide.

## Tests
- 394/394 ✅
- TypeScript strict ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)