### PR TITLE
chore(domain): migrate all URLs to terminallearning.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Contexte projet
 App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratuit.
-- **Live** : https://terminal-learning.vercel.app
+- **Live** : https://terminallearning.dev
 - **Repo** : https://github.com/thierryvm/TerminalLearning
 - **Vercel** : https://vercel.com/thierry-vanmeeterens-projects/terminal-learning
 - **Ko-fi** : https://ko-fi.com/thierryvm (dons suspendus dans l'UI — en attente de l'accord de la mutuelle Solidaris (RIZIV/INAMI))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Learn the terminal by doing — not just reading.**
 
-[![Live Demo](https://img.shields.io/badge/Live%20Demo-Vercel-black?style=flat-square&logo=vercel)](https://terminal-learning.vercel.app)
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-Vercel-black?style=flat-square&logo=vercel)](https://terminallearning.dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-emerald?style=flat-square)](LICENSE)
 [![Built with Vite](https://img.shields.io/badge/Built%20with-Vite%206-646cff?style=flat-square&logo=vite)](https://vitejs.dev)
 [![React](https://img.shields.io/badge/React-18-61dafb?style=flat-square&logo=react)](https://react.dev)
@@ -22,7 +22,7 @@ The terminal is powerful — but also frustrating to learn. Commands look differ
 
 No account required. No setup. Just open it and start learning.
 
-🌐 **[Try it live →](https://terminal-learning.vercel.app)**
+🌐 **[Try it live →](https://terminallearning.dev)**
 
 ---
 
@@ -190,6 +190,6 @@ MIT License — see [LICENSE](LICENSE) for details.
 
 <p align="center">
   Made with ♥ in Belgium &nbsp;·&nbsp;
-  <a href="https://terminal-learning.vercel.app">Live Demo</a> &nbsp;·&nbsp;
+  <a href="https://terminallearning.dev">Live Demo</a> &nbsp;·&nbsp;
   <a href="https://github.com/thierryvm/TerminalLearning/issues">Report a Bug</a>
 </p>

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -51,7 +51,7 @@ Page `/privacy` créée. Vercel Analytics sans cookies → pas de bannière cook
 
 ### ✅ Phase 0 — Déploiement (TERMINÉ)
 - [x] Build validé, vercel.json, .gitignore
-- [x] Déployé sur Vercel — https://terminal-learning.vercel.app
+- [x] Déployé sur Vercel — https://terminallearning.dev
 - [x] Headers sécurisés (CSP, X-Frame-Options, etc.)
 
 ### ✅ Phase 1 — Landing + Routing + CI (TERMINÉ)
@@ -288,7 +288,7 @@ output:
 #### Composant B — Script Playwright local
 ```bash
 # scripts/security-audit.cjs — avant chaque release majeure
-node scripts/security-audit.cjs [--url https://terminal-learning.vercel.app]
+node scripts/security-audit.cjs [--url https://terminallearning.dev]
 checks:
   - Messages d'erreur auth génériques (pas de leak "user not found" vs "wrong password")
   - Rate limiting actif sur /auth et /api endpoints

--- a/docs/troubleshooting/auth-issues.md
+++ b/docs/troubleshooting/auth-issues.md
@@ -20,7 +20,7 @@
 ## Callback OAuth échoue (/auth/callback)
 
 - Vérifier que l'URL de redirection est dans la liste Supabase Auth → URL Configuration
-- URLs autorisées : `https://terminal-learning.vercel.app/auth/callback` + `http://localhost:5173/auth/callback`
+- URLs autorisées : `https://terminallearning.dev/auth/callback` + `http://localhost:5173/auth/callback`
 - En cas de nouvelle URL Vercel (preview deployments) : ajouter le domaine Vercel preview
 
 ## Reset de mot de passe ne fonctionne pas

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -28,7 +28,7 @@ test.describe('SEO — primary meta tags', () => {
 
   test('canonical URL is set', async ({ page }) => {
     const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
-    expect(canonical).toContain('terminal-learning.vercel.app');
+    expect(canonical).toContain('terminallearning.dev');
   });
 
   test('robots meta allows indexing', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -37,10 +37,8 @@
     <meta name="twitter:image" content="https://terminal-learning.vercel.app/og-image.png" />
     <meta name="twitter:creator" content="@thierryvm" />
 
-    <!-- Google Fonts — preconnect reduces DNS + TLS handshake from critical path -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600;700&display=swap" />
+    <!-- Fonts self-hosted via fontsource — eliminates render-blocking Google CDN round-trip -->
+    <!-- Inter (variable) + JetBrains Mono loaded in src/main.tsx -->
 
     <!-- Favicon & PWA -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="keywords" content="terminal, bash, linux, apprendre, débutant, commandes, shell, open source, gratuit" />
     <meta name="author" content="Thierry Vanmeeteren" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://terminal-learning.vercel.app/" />
+    <link rel="canonical" href="https://terminallearning.dev/" />
 
     <!-- GEO -->
     <meta name="geo.region" content="BE" />
@@ -19,10 +19,10 @@
 
     <!-- Open Graph (Facebook, LinkedIn, Discord, WhatsApp) -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://terminal-learning.vercel.app/" />
+    <meta property="og:url" content="https://terminallearning.dev/" />
     <meta property="og:title" content="Terminal Learning — Apprends le terminal pas à pas" />
     <meta property="og:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 8 modules progressifs (Linux, macOS, Windows), émulateur réel. Pour débutants, 100% open source." />
-    <meta property="og:image" content="https://terminal-learning.vercel.app/og-image.png" />
+    <meta property="og:image" content="https://terminallearning.dev/og-image.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -34,7 +34,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terminal Learning — Apprends le terminal pas à pas" />
     <meta name="twitter:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 8 modules (Linux, macOS, Windows), émulateur réel, 100% open source." />
-    <meta name="twitter:image" content="https://terminal-learning.vercel.app/og-image.png" />
+    <meta name="twitter:image" content="https://terminallearning.dev/og-image.png" />
     <meta name="twitter:creator" content="@thierryvm" />
 
     <!-- Fonts self-hosted via fontsource — eliminates render-blocking Google CDN round-trip -->
@@ -58,8 +58,8 @@
       "@graph": [
         {
           "@type": "WebSite",
-          "@id": "https://terminal-learning.vercel.app/#website",
-          "url": "https://terminal-learning.vercel.app/",
+          "@id": "https://terminallearning.dev/#website",
+          "url": "https://terminallearning.dev/",
           "name": "Terminal Learning",
           "description": "Application interactive gratuite pour apprendre les commandes du terminal Linux/Unix.",
           "inLanguage": "fr",
@@ -71,9 +71,9 @@
         },
         {
           "@type": "SoftwareApplication",
-          "@id": "https://terminal-learning.vercel.app/#app",
+          "@id": "https://terminallearning.dev/#app",
           "name": "Terminal Learning",
-          "url": "https://terminal-learning.vercel.app/",
+          "url": "https://terminallearning.dev/",
           "description": "Apprends les commandes du terminal dans ton navigateur. 8 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Gratuit, open source, sans installation.",
           "applicationCategory": "EducationalApplication",
           "applicationSubCategory": "Terminal / Shell Learning",
@@ -103,10 +103,10 @@
         },
         {
           "@type": "Course",
-          "@id": "https://terminal-learning.vercel.app/#course",
+          "@id": "https://terminallearning.dev/#course",
           "name": "Apprendre le terminal — de zéro à autonome (Linux, macOS, Windows)",
           "description": "Formation interactive et gratuite aux commandes du terminal. 8 modules progressifs couvrant Linux, macOS et Windows : navigation, fichiers, permissions, processus, redirection, variables, réseau et SSH.",
-          "url": "https://terminal-learning.vercel.app/app",
+          "url": "https://terminallearning.dev/app",
           "inLanguage": "fr",
           "isAccessibleForFree": true,
           "educationalLevel": "Beginner",
@@ -128,7 +128,7 @@
           "provider": {
             "@type": "Organization",
             "name": "Terminal Learning",
-            "url": "https://terminal-learning.vercel.app/"
+            "url": "https://terminallearning.dev/"
           },
           "offers": {
             "@type": "Offer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@mui/icons-material": "7.3.5",
         "@mui/material": "7.3.5",
         "@popperjs/core": "2.11.8",
@@ -1476,6 +1478,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/inter": "5.2.8",
+    "@fontsource/jetbrains-mono": "5.2.8",
     "@mui/icons-material": "7.3.5",
     "@mui/material": "7.3.5",
     "@popperjs/core": "2.11.8",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@mui/icons-material": "7.3.5",
     "@mui/material": "7.3.5",
     "@popperjs/core": "2.11.8",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@
 
 Terminal Learning is a beginner-friendly educational web app built with React and TypeScript. Users type real commands in a simulated terminal emulator and receive immediate feedback. Progress is saved locally (localStorage) and optionally synced to the cloud via a free account (Supabase). The app is 100% free, open source, and requires no installation.
 
-- **Live app**: https://terminal-learning.vercel.app
+- **Live app**: https://terminallearning.dev
 - **Source code**: https://github.com/thierryvm/TerminalLearning
 - **Author**: Thierry Vanmeeteren (Belgium)
 - **Language**: French (UI and lessons) — commands are universal Linux/macOS/Windows
@@ -15,65 +15,65 @@ Terminal Learning is a beginner-friendly educational web app built with React an
 
 ### Module 1 — Navigation
 `pwd`, `ls`, `ls -la`, `cd` — moving through the file system
-- https://terminal-learning.vercel.app/app/learn/navigation/pwd
-- https://terminal-learning.vercel.app/app/learn/navigation/ls
-- https://terminal-learning.vercel.app/app/learn/navigation/ls-la
-- https://terminal-learning.vercel.app/app/learn/navigation/cd
+- https://terminallearning.dev/app/learn/navigation/pwd
+- https://terminallearning.dev/app/learn/navigation/ls
+- https://terminallearning.dev/app/learn/navigation/ls-la
+- https://terminallearning.dev/app/learn/navigation/cd
 
 ### Module 2 — Fichiers & Dossiers
 `mkdir`, `touch`, `cp`, `mv`, `rm` — creating, copying, moving, deleting
-- https://terminal-learning.vercel.app/app/learn/fichiers/mkdir
-- https://terminal-learning.vercel.app/app/learn/fichiers/touch
-- https://terminal-learning.vercel.app/app/learn/fichiers/cp
-- https://terminal-learning.vercel.app/app/learn/fichiers/mv
-- https://terminal-learning.vercel.app/app/learn/fichiers/rm
+- https://terminallearning.dev/app/learn/fichiers/mkdir
+- https://terminallearning.dev/app/learn/fichiers/touch
+- https://terminallearning.dev/app/learn/fichiers/cp
+- https://terminallearning.dev/app/learn/fichiers/mv
+- https://terminallearning.dev/app/learn/fichiers/rm
 
 ### Module 3 — Lecture de fichiers
 `cat`, `head`, `tail`, `grep`, `wc` — viewing and searching file content
-- https://terminal-learning.vercel.app/app/learn/lecture/cat
-- https://terminal-learning.vercel.app/app/learn/lecture/head-tail
-- https://terminal-learning.vercel.app/app/learn/lecture/grep
-- https://terminal-learning.vercel.app/app/learn/lecture/wc
+- https://terminallearning.dev/app/learn/lecture/cat
+- https://terminallearning.dev/app/learn/lecture/head-tail
+- https://terminallearning.dev/app/learn/lecture/grep
+- https://terminallearning.dev/app/learn/lecture/wc
 
 ### Module 4 — Permissions
 Unix permission model, `chmod`, `chown`, `sudo`, security best practices
-- https://terminal-learning.vercel.app/app/learn/permissions/comprendre-permissions
-- https://terminal-learning.vercel.app/app/learn/permissions/chmod
-- https://terminal-learning.vercel.app/app/learn/permissions/chown
-- https://terminal-learning.vercel.app/app/learn/permissions/sudo
-- https://terminal-learning.vercel.app/app/learn/permissions/security-permissions
+- https://terminallearning.dev/app/learn/permissions/comprendre-permissions
+- https://terminallearning.dev/app/learn/permissions/chmod
+- https://terminallearning.dev/app/learn/permissions/chown
+- https://terminallearning.dev/app/learn/permissions/sudo
+- https://terminallearning.dev/app/learn/permissions/security-permissions
 
 ### Module 5 — Processus
 `ps`, `kill`, `top`, background jobs (`bg`, `fg`, `&`, `jobs`) — managing running processes
-- https://terminal-learning.vercel.app/app/learn/processus/ps
-- https://terminal-learning.vercel.app/app/learn/processus/kill
-- https://terminal-learning.vercel.app/app/learn/processus/top
-- https://terminal-learning.vercel.app/app/learn/processus/background
+- https://terminallearning.dev/app/learn/processus/ps
+- https://terminallearning.dev/app/learn/processus/kill
+- https://terminallearning.dev/app/learn/processus/top
+- https://terminallearning.dev/app/learn/processus/background
 
 ### Module 6 — Redirection & Pipes
 `>`, `>>`, `|`, `2>`, `tee` — chaining and redirecting command output
-- https://terminal-learning.vercel.app/app/learn/redirection/redirection-sortie
-- https://terminal-learning.vercel.app/app/learn/redirection/pipes
-- https://terminal-learning.vercel.app/app/learn/redirection/stderr
-- https://terminal-learning.vercel.app/app/learn/redirection/tee
+- https://terminallearning.dev/app/learn/redirection/redirection-sortie
+- https://terminallearning.dev/app/learn/redirection/pipes
+- https://terminallearning.dev/app/learn/redirection/stderr
+- https://terminallearning.dev/app/learn/redirection/tee
 
 ### Module 7 — Variables & Scripts
 Environment variables, `$PATH`, `.env`, shell config, bash scripts, `cron`
-- https://terminal-learning.vercel.app/app/learn/variables/env-vars
-- https://terminal-learning.vercel.app/app/learn/variables/path-variable
-- https://terminal-learning.vercel.app/app/learn/variables/shell-config
-- https://terminal-learning.vercel.app/app/learn/variables/dotenv
-- https://terminal-learning.vercel.app/app/learn/variables/scripts
-- https://terminal-learning.vercel.app/app/learn/variables/cron
+- https://terminallearning.dev/app/learn/variables/env-vars
+- https://terminallearning.dev/app/learn/variables/path-variable
+- https://terminallearning.dev/app/learn/variables/shell-config
+- https://terminallearning.dev/app/learn/variables/dotenv
+- https://terminallearning.dev/app/learn/variables/scripts
+- https://terminallearning.dev/app/learn/variables/cron
 
 ### Module 8 — Réseau & SSH
 `ping`, `curl`, `wget`, DNS (`nslookup`, `dig`), `ssh`, `ssh-keygen`, `scp`
-- https://terminal-learning.vercel.app/app/learn/reseau/ping
-- https://terminal-learning.vercel.app/app/learn/reseau/curl
-- https://terminal-learning.vercel.app/app/learn/reseau/wget
-- https://terminal-learning.vercel.app/app/learn/reseau/dns
-- https://terminal-learning.vercel.app/app/learn/reseau/ssh
-- https://terminal-learning.vercel.app/app/learn/reseau/scp
+- https://terminallearning.dev/app/learn/reseau/ping
+- https://terminallearning.dev/app/learn/reseau/curl
+- https://terminallearning.dev/app/learn/reseau/wget
+- https://terminallearning.dev/app/learn/reseau/dns
+- https://terminallearning.dev/app/learn/reseau/ssh
+- https://terminallearning.dev/app/learn/reseau/scp
 
 ## Multi-environment support
 
@@ -96,6 +96,6 @@ Beginners who want to learn the terminal for the first time: developers switchin
 ## Optional
 
 - [Full README](https://github.com/thierryvm/TerminalLearning/blob/main/README.md): complete project documentation, setup instructions, contributing guide
-- [Command reference](https://terminal-learning.vercel.app/app/reference): all commands covered, with syntax and examples per environment
-- [Privacy policy](https://terminal-learning.vercel.app/privacy): GDPR-compliant data usage details
+- [Command reference](https://terminallearning.dev/app/reference): all commands covered, with syntax and examples per environment
+- [Privacy policy](https://terminallearning.dev/privacy): GDPR-compliant data usage details
 - [GitHub source](https://github.com/thierryvm/TerminalLearning): full source code, issues, pull requests

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -29,7 +29,7 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-Sitemap: https://terminal-learning.vercel.app/sitemap.xml
+Sitemap: https://terminallearning.dev/sitemap.xml
 
 # LLM context file
-# https://terminal-learning.vercel.app/llms.txt
+# https://terminallearning.dev/llms.txt

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const today = new Date().toISOString().slice(0, 10);
-const BASE = 'https://terminal-learning.vercel.app';
+const BASE = 'https://terminallearning.dev';
 
 /**
  * URL config — single source of truth for sitemap entries.

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -1638,7 +1638,7 @@ export function processCommand(state: TerminalState, input: string, env: Termina
           { text: '║  Licence   : MIT                                 ║', type: 'info' },
           { text: '║  Auteur    : Thierry Vanmeeteren                 ║', type: 'info' },
           { text: '║  GitHub    : github.com/thierryvm/TerminalLearning ║', type: 'info' },
-          { text: '║  Live      : terminal-learning.vercel.app        ║', type: 'info' },
+          { text: '║  Live      : terminallearning.dev        ║', type: 'info' },
           { text: '║                                                  ║', type: 'info' },
           { text: '║  Stack     : React 18 · Vite 6 · Tailwind 4     ║', type: 'info' },
           { text: '╚══════════════════════════════════════════════════╝', type: 'info' },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import App from './app/App.tsx';
+import '@fontsource-variable/inter';
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
+import '@fontsource/jetbrains-mono/600.css';
+import '@fontsource/jetbrains-mono/400-italic.css';
 import './styles/index.css';
 import { initSentry } from './lib/sentry.ts';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
 import { createRoot } from 'react-dom/client';
 import App from './app/App.tsx';
-import '@fontsource-variable/inter';
-import '@fontsource/jetbrains-mono/400.css';
-import '@fontsource/jetbrains-mono/500.css';
-import '@fontsource/jetbrains-mono/600.css';
-import '@fontsource/jetbrains-mono/400-italic.css';
 import './styles/index.css';
 import { initSentry } from './lib/sentry.ts';
 

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,1 +1,6 @@
-/* Fonts are loaded via <link> in index.html to avoid render-blocking @import */
+/* Self-hosted fonts via fontsource — no external CDN dependency */
+@import '@fontsource-variable/inter';
+@import '@fontsource/jetbrains-mono/400.css';
+@import '@fontsource/jetbrains-mono/500.css';
+@import '@fontsource/jetbrains-mono/600.css';
+@import '@fontsource/jetbrains-mono/400-italic.css';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -79,6 +79,8 @@
 }
 
 @theme inline {
+  --font-sans: 'Inter Variable', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
**Linear:** [THI-51](https://linear.app/thierryvm/issue/THI-51)

## Summary

- Replaces all occurrences of `terminal-learning.vercel.app` with `terminallearning.dev`
- Files updated: `index.html`, `sitemap.xml`, `robots.txt`, `llms.txt`, `README.md`, `CLAUDE.md`, `docs/`, `e2e/seo.spec.ts`, `terminalEngine.ts`, `generate-sitemap.mjs`

## Supabase Auth ✅

- Site URL mis à jour : `https://terminallearning.dev`
- Redirect URLs : localhost + vercel.app (sessions existantes) + terminallearning.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)