### PR TITLE
docs: sync counters post THI-39

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
-- Phase 5 🔄 Curriculum expansion — 8 modules, 38 leçons, 388 tests unitaires + 176 E2E Playwright (en cours)
+- Phase 5 🔄 Curriculum expansion — 8 modules, 39 leçons, 530 tests unitaires + 176 E2E Playwright (en cours)
 
 ## Tech debt
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full security policy and vulnerability reporting: [SECURITY.md](SECURITY.md)
 | **Phase 2** | ✅ Done | Vercel Analytics + Sentry error monitoring |
 | **Phase 3** | ✅ Done | Supabase Auth + user progress sync |
 | **Phase 4** | ✅ Done | Curriculum v2 + multi-environment selection + terminal profiles |
-| **Phase 5** | 🔄 In progress | Curriculum expansion: 7 modules, 32 lessons, 242 unit tests + 176 E2E |
+| **Phase 5** | 🔄 In progress | Curriculum expansion: 8 modules, 39 lessons, 530 unit tests + 176 E2E |
 | **Phase 6** | 🔮 Planned | Terminal multi-session (tabs) + changelog |
 | **Phase 7** | 🔮 Planned | Member space — profiles, stats, roles (student/teacher), badges |
 | **Phase 8** | 🔮 Planned | Ticket system — bug reports, suggestions, in-app feedback |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 11 avril 2026
-> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 8 modules ✅, 38 leçons, 388 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
+> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 8 modules ✅, 39 leçons, 530 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
 
 ---
 
@@ -216,7 +216,7 @@ CREATE TABLE quiz_results (
 
 ---
 
-### 🔮 Phase 5c — Commande `help` native + Leçon 0 transversale (THI-39)
+### ✅ Phase 5c — Commande `help` native + Leçon 0 transversale (THI-39)
 
 Première manifestation de la philosophie **"apprendre à apprendre"** dans le terminal simulé.
 


### PR DESCRIPTION
## Summary
- README, CLAUDE.md, docs/plan.md synced to post-merge state
- 39 lessons (was 38), 530 unit tests (was 388)
- Phase 5c THI-39 marked ✅ Done in plan.md

## No code changes — docs only