### PR TITLE
fix(sentry): filter Supabase navigator lock noise

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -19,6 +19,18 @@ export function initSentry() {
       const evalErr = 'Eval' + 'Error';
       if (event.exception?.values?.some((e) => e.type === evalErr)) return null;
 
+      // Drop Supabase navigator lock errors — internal tab coordination, not app bugs
+      // Happens when multiple tabs refresh the auth token simultaneously
+      const lockPrefix = 'lock:sb-';
+      if (
+        event.exception?.values?.some(
+          (e) =>
+            e.value?.includes(lockPrefix) ||
+            (e.type === 'AbortError' && e.value?.includes('steal'))
+        )
+      )
+        return null;
+
       // Strip any potential PII from request URLs
       if (event.request?.url) {
         try {


### PR DESCRIPTION
## Summary

- Adds `beforeSend` filter for Supabase Web Locks API errors (`lock:sb-*` and `AbortError: steal`)
- These are internal tab coordination events from `@supabase/auth-js`, not app bugs
- 0 users were impacted — confirmed via Sentry
- Resolves SENTRY-CLARET-CUSHION-2 and SENTRY-CLARET-CUSHION-3 (both marked resolved in Sentry)

## Why not a real bug?

Supabase Auth uses the [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) to prevent race conditions when multiple tabs refresh the auth token simultaneously. When one tab "steals" the lock, the other throws an unhandled rejection — this is expected behavior from the Supabase SDK internals.

## Test plan

- [ ] CI green
- [ ] Vercel preview loads normally
- [ ] Sentry feed stays clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)