### PR TITLE
security(csp): CORP header + restrict Supabase connect-src to exact FQDN [THI-54]

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,10 +19,11 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=()" },
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.supabase.co https://*.supabase.io https://vercel.live wss://ws-us3.pusher.com https://sockjs-mt1.pusher.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live wss://ws-us3.pusher.com https://sockjs-mt1.pusher.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary

Security audit findings (THI-53) — two vercel.json fixes:

- **H2**: Add `Cross-Origin-Resource-Policy: same-origin` — mitigates Spectre-class cross-origin read attacks
- **M5**: Replace `*.supabase.co` wildcard in `connect-src` with exact project FQDN `jdnukbpkjyyyjpuwgxhv.supabase.co` — prevents data exfiltration to attacker-controlled Supabase projects if the anon key ever leaks

## Changes

`vercel.json` only — 2 lines changed.

## Test plan

- [ ] CI passes (no code change, config only)
- [ ] Preview deployment: check response headers contain `Cross-Origin-Resource-Policy: same-origin`
- [ ] Verify app loads normally (Supabase auth + data still works with exact FQDN)

Closes THI-54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Met à jour la configuration Vercel pour ajouter un en-tête Cross-Origin-Resource-Policy défini sur `same-origin` et restreindre `connect-src` de Supabase au FQDN spécifique du projet.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Vercel configuration to add a Cross-Origin-Resource-Policy header set to same-origin and restrict Supabase connect-src to the specific project FQDN.

</details>