### PR TITLE
security(deps): bump Vite 6.4.2 — fix CVEs GHSA-4w7w + GHSA-p9ff [THI-55]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "pngjs": "^7.0.0",
         "tailwindcss": "4.1.12",
         "typescript": "^6.0.2",
-        "vite": "^6.4.1",
+        "vite": "^6.4.2",
         "vitest": "^4.1.2"
       },
       "peerDependencies": {
@@ -12173,9 +12173,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "pngjs": "^7.0.0",
     "tailwindcss": "4.1.12",
     "typescript": "^6.0.2",
-    "vite": "^6.4.1",
+    "vite": "^6.4.2",
     "vitest": "^4.1.2"
   },
   "peerDependencies": {
@@ -123,11 +123,6 @@
     },
     "react-dom": {
       "optional": true
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "6.3.5"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Bumps Vite from `6.3.5` (pinned via pnpm.overrides) to `6.4.2`
- Removes the `pnpm.overrides` section that prevented the CVE fix
- Fixes two dev-server vulnerabilities identified in security audit THI-53:
  - **GHSA-4w7w-66w2-5vf9** — path traversal
  - **GHSA-p9ff-h696-f583** — arbitrary file read

> Note: these CVEs only affect the local dev server, not production builds. Still worth patching to protect developer environments.

## Changes

- `package.json`: removed `pnpm.overrides`, updated `devDependencies.vite` to `^6.4.2`
- `package-lock.json`: updated lockfile to Vite 6.4.2

## Test plan

- [ ] CI passes (build + type-check + lint + tests)
- [ ] `npm run build` produces valid bundle
- [ ] `npm run dev` works locally

Closes THI-55

🤖 Generated with [Claude Code](https://claude.com/claude-code)