### PR TITLE
security(tunnel): per-IP rate limiting on Sentry tunnel [THI-57]

### DIFF
--- a/api/sentry-tunnel.ts
+++ b/api/sentry-tunnel.ts
@@ -2,9 +2,11 @@
  * Sentry tunnel — proxies Sentry envelopes through our own domain so that
  * ad-blockers targeting *.ingest.sentry.io do not suppress error reports.
  *
- * Security: validates that every envelope targets only our specific Sentry
- * project before forwarding, preventing this endpoint from being used as an
- * open proxy to arbitrary Sentry projects.
+ * Security:
+ * - Validates that every envelope targets only our specific Sentry project,
+ *   preventing this endpoint from being used as an open proxy.
+ * - Per-IP rate limiting (sliding window) to prevent Sentry quota exhaustion
+ *   or billing spikes from abusive clients.
  *
  * Vercel Edge Runtime — no Node.js APIs, uses standard Web platform APIs only.
  */
@@ -17,11 +19,64 @@ const ALLOWED_PROJECT_ID = '4511149719552080';
 /** 1 MB — well above any real Sentry envelope; guards against DoS via large payloads. */
 const MAX_BODY_BYTES = 1 * 1024 * 1024;
 
+// ─── Rate limiting (sliding window, per IP) ───────────────────────────────────
+// Module-level state persists within a single Edge isolate instance.
+// Not globally shared across all edge nodes, but provides meaningful protection
+// against single-IP burst abuse on the same warm instance.
+const RATE_LIMIT_MAX = 50; // requests
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+
+interface RateEntry {
+  timestamps: number[];
+}
+const rateLimitMap = new Map<string, RateEntry>();
+
+function isRateLimited(ip: string, now: number): boolean {
+  const entry = rateLimitMap.get(ip) ?? { timestamps: [] };
+  // Evict timestamps outside the sliding window
+  entry.timestamps = entry.timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  if (entry.timestamps.length >= RATE_LIMIT_MAX) {
+    rateLimitMap.set(ip, entry);
+    return true;
+  }
+  entry.timestamps.push(now);
+  rateLimitMap.set(ip, entry);
+  return false;
+}
+
+// Prevent unbounded Map growth: evict all stale entries every 5 minutes.
+// Edge isolates are short-lived, so this is a safety net rather than a
+// long-running maintenance task.
+let lastCleanup = Date.now();
+function maybeCleanup(now: number): void {
+  if (now - lastCleanup < 5 * 60_000) return;
+  lastCleanup = now;
+  for (const [ip, entry] of rateLimitMap) {
+    if (entry.timestamps.every((t) => now - t >= RATE_LIMIT_WINDOW_MS)) {
+      rateLimitMap.delete(ip);
+    }
+  }
+}
+
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', {
       status: 405,
       headers: { Allow: 'POST' },
+    });
+  }
+
+  // Rate limiting — sliding window per IP
+  const now = Date.now();
+  maybeCleanup(now);
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    req.headers.get('cf-connecting-ip') ??
+    'unknown';
+  if (isRateLimited(ip, now)) {
+    return new Response('Too Many Requests', {
+      status: 429,
+      headers: { 'Retry-After': '60' },
     });
   }
 


### PR DESCRIPTION
## Summary

Adds a sliding-window per-IP rate limiter to `/api/sentry-tunnel` (OWASP API4 — Unrestricted Resource Consumption).

**Before**: any IP could spam the endpoint indefinitely, exhausting the Sentry free-tier quota.  
**After**: max 50 requests/min per IP — excess requests get `429 Too Many Requests` with `Retry-After: 60`.

## Implementation details

- **Algorithm**: sliding window (evicts timestamps older than 60s on each request)
- **Storage**: module-level `Map` — persists within an Edge isolate instance, not globally shared across edge nodes
- **Cleanup**: stale entries evicted every 5 minutes to prevent unbounded memory growth
- **IP extraction**: `x-forwarded-for` (Vercel) → `cf-connecting-ip` (Cloudflare) → `'unknown'` fallback
- **No external dependencies** — fully compatible with Vercel Edge Runtime

> The per-isolate (non-global) nature is a known trade-off on Edge Runtime. Global rate limiting would require Vercel KV or Upstash Redis. For a Sentry tunnel carrying ~1 req/error, 50 req/min per IP per isolate is more than sufficient to block abuse while never impacting legitimate users.

## Changes

`api/sentry-tunnel.ts` only.

## Test plan

- [ ] CI passes (type-check + build)
- [ ] Preview: Sentry still receives error reports (rate limit not triggered on normal use)
- [ ] `curl -X POST /api/sentry-tunnel` 51 times → 429 on 51st call

Closes THI-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)