### PR TITLE
feat(curriculum): Modules 9+10 — Git Fondamentaux & GitHub Collaboration (THI-28)

### DIFF
--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -1,13 +1,13 @@
 import { useNavigate } from 'react-router';
 import {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge,
+  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
   CheckCircle2, ChevronRight, Terminal, Award, BookOpen, Zap, Lock,
 } from 'lucide-react';
 import { curriculum } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
 
 const iconMap: Record<string, React.ComponentType<{ className?: string; size?: number }>> = {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge,
+  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
 };
 
 const MODULE_GRADIENTS: Record<string, string> = {
@@ -17,6 +17,10 @@ const MODULE_GRADIENTS: Record<string, string> = {
   permissions: 'from-amber-500/20 to-amber-500/5',
   processus: 'from-red-500/20 to-red-500/5',
   redirection: 'from-cyan-500/20 to-cyan-500/5',
+  variables: 'from-yellow-500/20 to-yellow-500/5',
+  reseau: 'from-cyan-400/20 to-cyan-400/5',
+  git: 'from-orange-500/20 to-orange-500/5',
+  'github-collaboration': 'from-violet-500/20 to-violet-500/5',
 };
 
 const MODULE_BORDER: Record<string, string> = {
@@ -26,6 +30,10 @@ const MODULE_BORDER: Record<string, string> = {
   permissions: 'border-amber-500/30 hover:border-amber-500/60',
   processus: 'border-red-500/30 hover:border-red-500/60',
   redirection: 'border-cyan-500/30 hover:border-cyan-500/60',
+  variables: 'border-yellow-500/30 hover:border-yellow-500/60',
+  reseau: 'border-cyan-400/30 hover:border-cyan-400/60',
+  git: 'border-orange-500/30 hover:border-orange-500/60',
+  'github-collaboration': 'border-violet-500/30 hover:border-violet-500/60',
 };
 
 export function Dashboard() {

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -4,7 +4,7 @@ import { motion } from 'motion/react';
 import {
   Terminal, ChevronRight, Github, BookOpen, Zap, Shield, Heart,
   CheckCircle2, Clock, Star, Coffee, ShieldCheck, Lock, Infinity,
-  Compass, FolderOpen, FileText, Cpu, GitMerge,
+  Compass, FolderOpen, FileText, Cpu, GitMerge, GitBranch, GitFork, Globe,
   Monitor, LogIn,
 } from 'lucide-react';
 
@@ -112,6 +112,9 @@ const MODULE_ICONS: Record<string, React.ComponentType<{ size?: number; classNam
   Shield,
   Cpu,
   GitMerge,
+  GitBranch,
+  GitFork,
+  Globe,
 };
 
 const LEVEL_BADGE: Record<number, { label: string; text: string; border: string; bg: string }> = {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { NavLink, useNavigate } from 'react-router';
 import {
   Terminal, LayoutDashboard, BookOpen, Compass, FolderOpen,
-  FileText, Shield, Cpu, GitMerge, ChevronDown, ChevronRight,
-  CheckCircle2, Circle, X, Menu, Home, Lock,
+  FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
+  ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock,
 } from 'lucide-react';
 import { UserMenu } from './auth/UserMenu';
 import { curriculum } from '../data/curriculum';
@@ -11,7 +11,7 @@ import { useProgress } from '../context/ProgressContext';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 
 const iconMap: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge,
+  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
 };
 
 interface SidebarProps {

--- a/src/app/data/curriculum.ts
+++ b/src/app/data/curriculum.ts
@@ -1879,7 +1879,7 @@ export const curriculum: Module[] = [
     color: '#06b6d4',
     level: 3,
     prerequisites: ['variables'],
-    unlocks: [],
+    unlocks: ['github-collaboration'],
     lessons: [
       {
         id: 'ping',
@@ -2190,6 +2190,563 @@ export const curriculum: Module[] = [
           hint: 'Tapez: scp fichier.txt user@serveur.example.com:/home/user/',
           validate: (cmd) => /^scp\s+.+\s+.+@.+:.+/.test(cmd.trim().toLowerCase()),
           successMessage: 'Excellent ! Vous savez maintenant transférer des fichiers de manière sécurisée.',
+        },
+      },
+    ],
+  },
+
+  // ── Module 9 — Git Fondamentaux ─────────────────────────────────────────────
+  {
+    id: 'git',
+    title: 'Git Fondamentaux',
+    description: 'Maîtrisez le contrôle de version avec Git — l\'outil indispensable de tout développeur professionnel',
+    iconName: 'GitBranch',
+    color: '#f97316',
+    level: 4,
+    prerequisites: ['variables'],
+    unlocks: ['github-collaboration'],
+    lessons: [
+      {
+        id: 'git-init',
+        title: 'git init — Initialiser un dépôt',
+        description: 'Créez votre premier dépôt Git et comprenez la structure interne',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Git est un système de contrôle de version distribué. Chaque développeur possède une copie complète de l\'historique du projet. C\'est l\'outil #1 dans tous les environnements professionnels — maîtriser Git est non-négociable.',
+          },
+          {
+            type: 'code',
+            content: '# Créer un nouveau dépôt dans le répertoire courant\n$ git init\nInitialized empty Git repository in /home/user/mon-projet/.git/\n\n# Créer un dépôt avec un nom de répertoire\n$ git init mon-projet\nInitialized empty Git repository in /home/user/mon-projet/.git/',
+            label: 'git init (Linux/macOS)',
+          },
+          {
+            type: 'code',
+            content: '# PowerShell — même commande, multiplateforme\nPS> git init\nInitialized empty Git repository in C:\\Users\\user\\mon-projet\\.git\\\n\nPS> git init mon-projet',
+            label: 'git init (Windows PowerShell)',
+          },
+          {
+            type: 'info',
+            content:
+              'Le dossier `.git/` contient tout l\'historique du projet : commits, branches, configuration. **Ne jamais supprimer ce dossier** — c\'est la mémoire complète du dépôt.',
+            contentByEnv: {
+              windows: 'Sur Windows, `.git/` est un dossier caché. Dans l\'Explorateur, activez "Éléments masqués" pour le voir. En PowerShell : `ls -Force` ou `Get-ChildItem -Force`.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Convention pro : toujours initialiser un dépôt git dès le début d\'un projet, même seul. L\'historique est inestimable pour comprendre pourquoi une décision a été prise — même des mois plus tard.',
+          },
+        ],
+        exercise: {
+          instruction: 'Initialisez un nouveau dépôt Git avec `git init`.',
+          hint: 'Tapez: git init',
+          validate: (cmd) => /^git\s+init(\s+.*)?$/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Parfait ! Votre premier dépôt Git est initialisé. Le dossier .git/ a été créé.',
+        },
+      },
+      {
+        id: 'git-config',
+        title: 'git config — Configurer votre identité',
+        description: 'Configurez votre nom et email avant votre premier commit',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Avant de commencer à committer, Git a besoin de savoir qui vous êtes. Cette identité est attachée à chaque commit — elle est visible dans l\'historique et sur GitHub.',
+          },
+          {
+            type: 'code',
+            content: '# Configuration globale (pour tous vos projets)\n$ git config --global user.name "Votre Nom"\n$ git config --global user.email "vous@example.com"\n\n# Vérifier la configuration\n$ git config --list\nuser.name=Votre Nom\nuser.email=vous@example.com\ncore.editor=nano\ninit.defaultBranch=main',
+            label: 'Configuration git (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Définir l\'éditeur par défaut\n$ git config --global core.editor "code --wait"   # VS Code\n$ git config --global core.editor "nano"          # Nano\n$ git config --global core.editor "vim"           # Vim\n\n# Définir la branche par défaut\n$ git config --global init.defaultBranch main',
+            label: 'Configuration avancée',
+          },
+          {
+            type: 'info',
+            content:
+              '`--global` configure Git pour tous vos projets (fichier `~/.gitconfig`). Sans ce flag, la configuration ne s\'applique qu\'au dépôt courant (fichier `.git/config`). Utilisez `--local` pour surcharger par projet.',
+            contentByEnv: {
+              windows: 'Sur Windows, le fichier de configuration global est dans `C:\\Users\\VotreNom\\.gitconfig`. Vous pouvez aussi utiliser `git config --list --show-origin` pour voir d\'où vient chaque paramètre.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'En entreprise, vous utiliserez souvent une configuration globale pour votre compte personnel et une configuration locale par projet (email pro vs perso). `git config --list --show-origin` vous montre exactement quelle config est active.',
+          },
+        ],
+        exercise: {
+          instruction: 'Vérifiez votre configuration Git avec `git config --list`.',
+          hint: 'Tapez: git config --list',
+          validate: (cmd) => /^git\s+config\s+(--list|--global\s+user\.)/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Votre configuration Git est visible. Nom et email sont les deux réglages essentiels avant le premier commit.',
+        },
+      },
+      {
+        id: 'git-add-commit',
+        title: 'git add & commit — Enregistrer vos modifications',
+        description: 'Comprenez la zone de staging et créez vos premiers commits',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Git utilise un système en trois zones : le **répertoire de travail** (vos fichiers), la **zone de staging** (les modifications prêtes à être commitées) et le **dépôt** (l\'historique permanent). Cette architecture donne un contrôle précis sur ce qu\'on enregistre.',
+          },
+          {
+            type: 'code',
+            content: '# Voir l\'état actuel\n$ git status\nOn branch main\nUntracked files:\n  (use "git add <file>" to include)\n\tfichier.txt\n\n# Ajouter un fichier spécifique\n$ git add fichier.txt\n\n# Ajouter tous les fichiers du répertoire courant\n$ git add .\n\n# Ajouter interactivement (sélection fine)\n$ git add -p',
+            label: 'Staging (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Créer un commit avec message en ligne\n$ git commit -m "feat: ajouter la page d\'accueil"\n[main a3f8c12] feat: ajouter la page d\'accueil\n 1 file changed, 25 insertions(+)\n\n# Commit avec titre + description\n$ git commit -m "feat: authentification utilisateur" -m "Ajoute login/logout avec JWT et refresh token automatique"',
+            label: 'Créer un commit',
+          },
+          {
+            type: 'info',
+            content:
+              'Convention de message de commit (Conventional Commits) : `type(scope): description`. Types courants : `feat` (nouvelle feature), `fix` (bug), `refactor`, `test`, `docs`, `chore`. Cette convention est standard en entreprise — lisez les commits de projets open source pour vous en imprégner.',
+          },
+          {
+            type: 'warning',
+            content: '`git add .` ajoute TOUT — y compris les fichiers `.env`, les clés API, les mots de passe. Configurez toujours un `.gitignore` AVANT de faire `git add .` pour ne pas exposer de secrets.',
+          },
+          {
+            type: 'tip',
+            content: '`git add -p` ("patch mode") permet de sélectionner des hunks individuels à l\'intérieur d\'un même fichier. Indispensable pour faire des commits propres et atomiques — chaque commit = un sujet précis.',
+          },
+        ],
+        exercise: {
+          instruction: 'Ajoutez tous les fichiers du répertoire courant à la zone de staging avec `git add .`.',
+          hint: 'Tapez: git add .',
+          validate: (cmd) => /^git\s+add\s+(\.|--all|-A|-p)/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Fichiers stagés ! Maintenant vous pouvez les committer avec git commit -m "message".',
+        },
+      },
+      {
+        id: 'git-status-log',
+        title: 'git status & log — Surveiller votre dépôt',
+        description: 'Inspectez l\'état courant et consultez l\'historique des commits',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`git status` et `git log` sont vos yeux dans Git. Status vous dit où vous en êtes maintenant ; log vous raconte l\'histoire du projet. Vous les utiliserez des dizaines de fois par jour en entreprise.',
+          },
+          {
+            type: 'code',
+            content: '# État du répertoire de travail\n$ git status\nOn branch main\nChanges to be committed:\n  (use "git restore --staged" to unstage)\n\tnew file:   index.html\n\nChanges not staged for commit:\n  modified:   style.css\n\nUntracked files:\n  script.js',
+            label: 'git status',
+          },
+          {
+            type: 'code',
+            content: '# Historique complet\n$ git log\ncommit a3f8c12 (HEAD -> main)\nAuthor: Vous <vous@example.com>\nDate:   Mon Apr 11 2026\n\n    feat: ajouter la page d\'accueil\n\n# Format court (très utilisé en pratique)\n$ git log --oneline\na3f8c12 feat: ajouter la page d\'accueil\nb2e9d01 chore: initialisation du projet\n\n# Avec le graphe de branches\n$ git log --oneline --graph --all',
+            label: 'git log',
+          },
+          {
+            type: 'code',
+            content: '# Voir un commit spécifique en détail\n$ git show a3f8c12\n\n# Voir les commits d\'un auteur\n$ git log --author="Votre Nom"\n\n# Chercher dans les messages de commit\n$ git log --grep="feat"\n\n# Voir les fichiers modifiés par commit\n$ git log --stat',
+            label: 'git log avancé',
+          },
+          {
+            type: 'tip',
+            content: '`git log --oneline --graph --all --decorate` est la commande de référence pour visualiser l\'état complet d\'un dépôt avec toutes ses branches. Créez un alias : `git config --global alias.lg "log --oneline --graph --all --decorate"`',
+          },
+        ],
+        exercise: {
+          instruction: 'Affichez le statut de votre dépôt avec `git status`.',
+          hint: 'Tapez: git status',
+          validate: (cmd) => /^git\s+status/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Vous savez lire l\'état de votre dépôt. git status sera votre commande la plus utilisée au quotidien.',
+        },
+      },
+      {
+        id: 'git-diff-gitignore',
+        title: 'git diff & .gitignore — Comparer et filtrer',
+        description: 'Visualisez les différences et excluez les fichiers non pertinents',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`git diff` montre exactement ce qui a changé dans vos fichiers. `.gitignore` dit à Git quels fichiers ignorer — variables d\'environnement, dépendances, fichiers de build. Ces deux outils sont essentiels pour des commits propres.',
+          },
+          {
+            type: 'code',
+            content: '# Voir les modifications non-stagées\n$ git diff\ndiff --git a/style.css b/style.css\n--- a/style.css\n+++ b/style.css\n@@ -1,3 +1,4 @@\n body {\n+  font-family: sans-serif;\n   margin: 0;\n }\n\n# Voir les modifications stagées (avant commit)\n$ git diff --staged\n\n# Comparer deux branches\n$ git diff main feature/login',
+            label: 'git diff',
+          },
+          {
+            type: 'code',
+            content: '# Exemple de .gitignore pour un projet Node.js\nnode_modules/\ndist/\nbuild/\n\n# Fichiers sensibles — JAMAIS committer\n.env\n.env.local\n.env.*.local\n*.key\n*.pem\n\n# OS & IDE\n.DS_Store\nThumbs.db\n.vscode/settings.json\n.idea/\n\n# Logs\n*.log\nnpm-debug.log*',
+            label: '.gitignore — fichier de référence',
+          },
+          {
+            type: 'code',
+            content: '# Vérifier si un fichier est ignoré\n$ git check-ignore -v .env\n.gitignore:4:.env\t.env\n\n# Forcer l\'ajout d\'un fichier ignoré (rarement conseillé)\n$ git add --force fichier.log\n\n# Utiliser github.com/github/gitignore pour des templates\n# Ex. gitignore pour Node, Python, Rust, etc.',
+            label: 'Vérification et debug',
+          },
+          {
+            type: 'warning',
+            content: 'Un `.gitignore` ajouté après que des fichiers ont déjà été commités ne les supprime PAS de l\'historique. Pour supprimer des secrets déjà commités, utilisez `git filter-repo` ou contactez GitHub Support — et considérez les secrets compromis.',
+          },
+          {
+            type: 'tip',
+            content: 'Créez toujours votre `.gitignore` AVANT le premier `git add`. GitHub propose des templates ready-to-use pour chaque langage sur `github.com/github/gitignore`.',
+          },
+        ],
+        exercise: {
+          instruction: 'Visualisez les différences actuelles dans votre dépôt avec `git diff`.',
+          hint: 'Tapez: git diff',
+          validate: (cmd) => /^git\s+diff(\s+.*)?$/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Vous savez lire un diff Git. Les lignes en vert (+) sont les ajouts, en rouge (-) les suppressions.',
+        },
+      },
+      {
+        id: 'git-branch',
+        title: 'git branch — Travailler avec les branches',
+        description: 'Créez, listez et gérez les branches pour isoler vos développements',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Les branches sont l\'une des forces majeures de Git. Elles permettent de travailler sur une feature ou un bug fix en isolation totale, sans perturber la branche principale. En entreprise, vous ne travaillez pratiquement jamais directement sur `main`.',
+          },
+          {
+            type: 'code',
+            content: '# Lister les branches locales (* = branche active)\n$ git branch\n* main\n  feature/login\n  fix/typo-header\n\n# Créer une nouvelle branche\n$ git branch feature/panier\n\n# Créer et basculer immédiatement (méthode classique)\n$ git checkout -b feature/panier\n\n# Méthode moderne (Git 2.23+)\n$ git switch -c feature/panier\nSwitched to a new branch \'feature/panier\'',
+            label: 'Créer et lister des branches (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Renommer une branche\n$ git branch -m ancien-nom nouveau-nom\n\n# Supprimer une branche mergée\n$ git branch -d feature/login\n\n# Supprimer une branche non-mergée (force)\n$ git branch -D feature/experimental\n\n# Lister toutes les branches (locales + distantes)\n$ git branch -a\n* main\n  feature/login\n  remotes/origin/main\n  remotes/origin/develop',
+            label: 'Gérer les branches',
+          },
+          {
+            type: 'info',
+            content:
+              'Convention de nommage en entreprise : `feature/THI-28-git-modules` (prefixe + ID issue + description), `fix/login-redirect`, `hotfix/cve-2026`, `release/v2.0.0`. Chaque équipe a ses conventions — vérifiez le CONTRIBUTING.md du projet.',
+            contentByEnv: {
+              windows: 'Toutes les commandes git branch fonctionnent identiquement sur Windows, macOS et Linux. Git est conçu pour être cross-platform depuis le départ.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'La règle d\'or : **une branche = un sujet**. Ne mélangez pas une feature et un bugfix sur la même branche. Les Pull Requests seront plus faciles à relire et à revenir en arrière si nécessaire.',
+          },
+        ],
+        exercise: {
+          instruction: 'Créez une nouvelle branche `feature/ma-feature` et basculez dessus avec `git checkout -b feature/ma-feature`.',
+          hint: 'Tapez: git checkout -b feature/ma-feature',
+          validate: (cmd) => {
+            const c = cmd.trim().toLowerCase();
+            return /^git\s+checkout\s+-b\s+\S+/.test(c) || /^git\s+switch\s+-c\s+\S+/.test(c);
+          },
+          successMessage: 'Branche créée et activée ! Vous développez maintenant en isolation totale de main.',
+        },
+      },
+      {
+        id: 'git-merge',
+        title: 'git merge — Fusionner des branches',
+        description: 'Intégrez le travail d\'une branche dans une autre et gérez les conflits',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Une fois votre feature terminée, vous devez l\'intégrer dans la branche principale. `git merge` fusionne l\'historique de deux branches. C\'est la dernière étape du workflow feature branch — avant la Pull Request sur GitHub.',
+          },
+          {
+            type: 'code',
+            content: '# Retourner sur la branche cible\n$ git checkout main\n\n# Fusionner la branche feature\n$ git merge feature/panier\nUpdating a3f8c12..b7e2d45\nFast-forward\n panier.html | 42 ++++++++++++\n 1 file changed, 42 insertions(+)',
+            label: 'Merge fast-forward (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# En cas de conflit :\n$ git merge feature/login\nAuto-merging index.html\nCONFLICT (content): Merge conflict in index.html\nAutomatic merge failed; fix conflicts and then commit the result.\n\n# Ouvrez le fichier conflictueux :\n<<<<<<< HEAD\n<title>Mon App</title>\n=======\n<title>Login — Mon App</title>\n>>>>>>> feature/login\n\n# Après résolution manuelle :\n$ git add index.html\n$ git commit -m "merge: resolve conflict in index.html"',
+            label: 'Résoudre un conflit de merge',
+          },
+          {
+            type: 'info',
+            content:
+              'Deux stratégies de merge : **fast-forward** (si la branche cible n\'a pas avancé — historique linéaire) et **merge commit** (si les deux branches ont divergé — conserve la trace de la fusion). `git merge --no-ff` force un merge commit même si fast-forward est possible.',
+          },
+          {
+            type: 'tip',
+            content: 'En pratique en entreprise, le merge est souvent fait via une Pull Request sur GitHub — pas directement en ligne de commande. La PR permet la code review avant le merge. Comprendre `git merge` reste indispensable pour gérer les conflits.',
+          },
+        ],
+        exercise: {
+          instruction: 'Fusionnez la branche `feature/ma-feature` dans la branche courante avec `git merge feature/ma-feature`.',
+          hint: 'Tapez: git merge feature/ma-feature',
+          validate: (cmd) => /^git\s+merge\s+\S+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Fusion réussie ! Le travail de la branche est maintenant intégré. C\'est le coeur du workflow Git en entreprise.',
+        },
+      },
+    ],
+  },
+
+  // ── Module 10 — GitHub & Collaboration ──────────────────────────────────────
+  {
+    id: 'github-collaboration',
+    title: 'GitHub & Collaboration',
+    description: 'Synchronisez avec des dépôts distants, ouvrez des Pull Requests et collaborez comme en entreprise',
+    iconName: 'Github',
+    color: '#8b5cf6',
+    level: 4,
+    prerequisites: ['git', 'reseau'],
+    unlocks: [],
+    lessons: [
+      {
+        id: 'git-remote',
+        title: 'git remote — Connecter au dépôt distant',
+        description: 'Liez votre dépôt local à GitHub et gérez vos remotes',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Un "remote" est un lien entre votre dépôt local et un dépôt hébergé (GitHub, GitLab, Bitbucket…). C\'est le pont entre votre machine et le monde. En équipe, le remote `origin` est la référence partagée par tous.',
+          },
+          {
+            type: 'code',
+            content: '# Ajouter un remote (étape après git init)\n$ git remote add origin https://github.com/user/mon-projet.git\n\n# Lister les remotes configurés\n$ git remote -v\norigin\thttps://github.com/user/mon-projet.git (fetch)\norigin\thttps://github.com/user/mon-projet.git (push)\n\n# Supprimer un remote\n$ git remote remove origin\n\n# Renommer un remote\n$ git remote rename origin upstream',
+            label: 'Gérer les remotes (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# HTTPS vs SSH — deux méthodes d\'authentification\n\n# HTTPS (simple, authentification par token)\nhttps://github.com/user/repo.git\n\n# SSH (recommandé, clé cryptographique)\ngit@github.com:user/repo.git\n\n# Changer l\'URL d\'un remote existant\n$ git remote set-url origin git@github.com:user/repo.git',
+            label: 'HTTPS vs SSH',
+          },
+          {
+            type: 'info',
+            content:
+              'GitHub a supprimé l\'authentification par mot de passe en 2021. Pour HTTPS, vous avez besoin d\'un **Personal Access Token (PAT)** ou d\'utiliser GitHub CLI (`gh auth login`). Pour SSH, configurez vos clés SSH dans les paramètres GitHub → SSH and GPG keys.',
+            contentByEnv: {
+              windows: 'Sur Windows, **Git Credential Manager** (inclus avec Git for Windows) stocke automatiquement vos tokens HTTPS. Pour SSH, les clés générées avec `ssh-keygen` dans PowerShell ou Git Bash fonctionnent identiquement.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Convention : le remote principal s\'appelle toujours `origin`. Quand vous forkez un projet pour contribuer, le dépôt original s\'appelle `upstream` — vous pouvez synchroniser avec `git pull upstream main`.',
+          },
+        ],
+        exercise: {
+          instruction: 'Ajoutez un remote `origin` pointant vers `https://github.com/user/mon-projet.git` avec `git remote add origin https://github.com/user/mon-projet.git`.',
+          hint: 'Tapez: git remote add origin https://github.com/user/mon-projet.git',
+          validate: (cmd) => /^git\s+remote\s+add\s+\S+\s+https?:\/\/\S+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Remote ajouté ! Votre dépôt local est maintenant connecté à GitHub.',
+        },
+      },
+      {
+        id: 'git-push-pull',
+        title: 'git push & pull — Synchroniser avec GitHub',
+        description: 'Envoyez vos commits vers GitHub et récupérez les modifications de votre équipe',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`git push` envoie vos commits locaux vers le dépôt distant. `git pull` récupère les commits distants et les intègre à votre branche. Ces deux commandes sont le rythme quotidien du travail en équipe.',
+          },
+          {
+            type: 'code',
+            content: '# Premier push — définir la branche de tracking\n$ git push -u origin main\nEnumerating objects: 3, done.\nCounting objects: 100% (3/3), done.\nTo https://github.com/user/repo.git\n * [new branch]      main -> main\nBranch \'main\' set up to track \'origin/main\'.\n\n# Push suivants (tracking déjà configuré)\n$ git push\n\n# Push d\'une nouvelle branche feature\n$ git push -u origin feature/panier',
+            label: 'git push (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Récupérer ET intégrer les commits distants\n$ git pull\nremote: Enumerating objects: 5, done.\nUpdating a3f8c12..c9f1e34\nFast-forward\n README.md | 3 +++\n 1 file changed, 3 insertions(+)\n\n# Pull avec rebase (historique linéaire)\n$ git pull --rebase\n\n# Voir ce qui arrive avant d\'intégrer\n$ git fetch && git log HEAD..origin/main --oneline',
+            label: 'git pull',
+          },
+          {
+            type: 'info',
+            content:
+              'La différence entre `pull` et `fetch` : `fetch` télécharge les changements sans les intégrer (safe), `pull` = `fetch` + `merge` (intègre automatiquement). En équipe active, `fetch` d\'abord, puis analyser, puis `merge` ou `rebase`.',
+            contentByEnv: {
+              windows: 'Toutes ces commandes fonctionnent identiquement sur Windows. Si vous utilisez GitHub Desktop ou Fork (GUI), ces apps exécutent les mêmes commandes git en arrière-plan.',
+            },
+          },
+          {
+            type: 'warning',
+            content: '`git push --force` ou `git push -f` réécrit l\'historique distant. **Ne jamais faire sur une branche partagée** (`main`, `develop`) — vous écrasez le travail de vos collègues. Utilisez `--force-with-lease` si vous devez forcer sur votre propre branche feature.',
+          },
+          {
+            type: 'tip',
+            content: 'Workflow quotidien en équipe : 1) `git pull` au démarrage, 2) travailler sur votre branche, 3) `git push` en fin de journée ou après chaque feature terminée. Ne laissez jamais des commits locaux non-poussés plus d\'une journée.',
+          },
+        ],
+        exercise: {
+          instruction: 'Envoyez vos commits vers GitHub avec `git push -u origin main`.',
+          hint: 'Tapez: git push -u origin main',
+          validate: (cmd) => /^git\s+push(\s+-u\s+\S+\s+\S+|\s+\S+\s+\S+|\s*)$/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Push réussi ! Vos commits sont maintenant sur GitHub, visibles par toute votre équipe.',
+        },
+      },
+      {
+        id: 'git-fetch-clone',
+        title: 'git fetch & clone — Récupérer et cloner',
+        description: 'Clonez un dépôt existant et récupérez les mises à jour sans intégration automatique',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              '`git clone` est votre point d\'entrée sur un projet existant. `git fetch` est l\'outil de synchronisation safe — il télécharge sans toucher à votre travail. Ces deux commandes sont indispensables dès le premier jour dans une entreprise.',
+          },
+          {
+            type: 'code',
+            content: '# Cloner un dépôt public\n$ git clone https://github.com/org/projet.git\nCloning into \'projet\'...\nremote: Enumerating objects: 1247, done.\nReceiving objects: 100% (1247/1247), done.\n\n# Cloner dans un dossier spécifique\n$ git clone https://github.com/org/projet.git mon-dossier\n\n# Cloner une branche spécifique\n$ git clone -b develop https://github.com/org/projet.git\n\n# Cloner en SSH (recommandé)\n$ git clone git@github.com:org/projet.git',
+            label: 'git clone (Linux/macOS/Windows)',
+          },
+          {
+            type: 'code',
+            content: '# Fetch : télécharger sans intégrer\n$ git fetch origin\nFrom https://github.com/org/projet\n * branch            main       -> FETCH_HEAD\n\n# Voir ce qui a changé sur le remote\n$ git fetch && git log HEAD..origin/main --oneline\n\n# Voir toutes les branches distantes\n$ git fetch --all\n\n# Comparer local vs remote après fetch\n$ git diff main origin/main',
+            label: 'git fetch',
+          },
+          {
+            type: 'code',
+            content: '# Workflow de contribution typique en open source\n# 1. Forker sur GitHub (via l\'interface web)\n\n# 2. Cloner votre fork\n$ git clone git@github.com:VOTRE-USER/projet.git\n\n# 3. Ajouter l\'upstream (projet original)\n$ git remote add upstream git@github.com:org/projet.git\n\n# 4. Synchroniser régulièrement\n$ git fetch upstream\n$ git merge upstream/main',
+            label: 'Workflow fork & contribution',
+          },
+          {
+            type: 'tip',
+            content: '`git fetch` est la commande la plus "safe" pour la synchronisation — elle ne modifie jamais votre travail local. Utilisez-la pour voir les changements avant de les intégrer avec `merge` ou `rebase`.',
+          },
+        ],
+        exercise: {
+          instruction: 'Clonez un dépôt distant avec `git clone https://github.com/user/projet.git`.',
+          hint: 'Tapez: git clone https://github.com/user/projet.git',
+          validate: (cmd) => /^git\s+clone\s+\S+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Dépôt cloné ! Vous pouvez maintenant travailler sur un projet existant avec tout son historique.',
+        },
+      },
+      {
+        id: 'pull-requests',
+        title: 'Pull Requests — Code Review & Collaboration',
+        description: 'Maîtrisez le workflow Pull Request, pilier de la collaboration professionnelle',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'La Pull Request (PR) — ou Merge Request sur GitLab — est le mécanisme central de la collaboration en équipe. Elle permet de proposer des changements, de les faire relire avant le merge, et de documenter les décisions techniques.',
+          },
+          {
+            type: 'code',
+            content: '# Workflow complet pour ouvrir une PR\n\n# 1. Créer une branche feature\n$ git checkout -b feature/THI-28-git-modules\n\n# 2. Développer et committer\n$ git add .\n$ git commit -m "feat(curriculum): add git module"\n\n# 3. Pousser la branche\n$ git push -u origin feature/THI-28-git-modules\n\n# 4. Ouvrir la PR sur GitHub (interface web ou CLI)\n$ gh pr create --title "feat(curriculum): add git module" --body "..."',
+            label: 'Workflow PR complet',
+          },
+          {
+            type: 'code',
+            content: '# GitHub CLI (gh) — travailler avec les PRs depuis le terminal\n\n# Lister les PRs ouvertes\n$ gh pr list\n\n# Voir une PR spécifique\n$ gh pr view 42\n\n# Checkout d\'une PR pour review locale\n$ gh pr checkout 42\n\n# Approuver une PR\n$ gh pr review 42 --approve\n\n# Merger une PR\n$ gh pr merge 42 --squash',
+            label: 'GitHub CLI — PR management',
+          },
+          {
+            type: 'info',
+            content:
+              'Anatomie d\'une bonne PR : **titre clair** (même format que le commit message), **description** avec le contexte + screenshots si UI, **checklist** de ce qui a été fait et testé, **lien vers l\'issue** Linear/Jira. Une PR < 400 lignes de diff est plus facile à relire.',
+            contentByEnv: {
+              windows: 'GitHub CLI (`gh`) est disponible sur Windows via `winget install GitHub.cli` ou `scoop install gh`. Il s\'intègre avec Git Credential Manager pour l\'authentification.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'En code review : soyez constructif, non subjectif. "Cette fonction fait 200 lignes, pourrions-nous la découper ?" est mieux que "c\'est trop long". Approuvez ce qui est bon, suggérez ce qui peut s\'améliorer, bloquez ce qui est une erreur réelle.',
+          },
+        ],
+        exercise: {
+          instruction: 'Simulez le début d\'un workflow PR : créez une branche `feature/nouvelle-feature` avec `git checkout -b feature/nouvelle-feature`.',
+          hint: 'Tapez: git checkout -b feature/nouvelle-feature',
+          validate: (cmd) => {
+            const c = cmd.trim().toLowerCase();
+            return /^git\s+checkout\s+-b\s+feature\/\S+/.test(c) || /^git\s+switch\s+-c\s+feature\/\S+/.test(c);
+          },
+          successMessage: 'Branche feature créée ! Dans un vrai projet, vous développeriez ici puis ouvreriez une PR vers main.',
+        },
+      },
+      {
+        id: 'conflicts',
+        title: 'Conflits de merge — Les résoudre comme un pro',
+        description: 'Comprenez pourquoi les conflits apparaissent et apprenez à les résoudre avec méthode',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Les conflits de merge sont inévitables en équipe. Ils surviennent quand deux développeurs modifient la même ligne dans la même période. Ce n\'est pas un bug Git — c\'est Git qui refuse de deviner lequel des deux changements est correct.',
+          },
+          {
+            type: 'code',
+            content: '# Scénario typique de conflit\n$ git merge feature/login\nAuto-merging index.html\nCONFLICT (content): Merge conflict in index.html\nAutomatic merge failed; fix conflicts and then commit the result.\n\n# Voir quels fichiers sont en conflit\n$ git status\nboth modified:   index.html\n\n# Contenu d\'un fichier en conflit\n<<<<<<< HEAD (votre version)\n<title>Mon App v2</title>\n=======\n<title>Login — Mon App</title>\n>>>>>>> feature/login (version entrante)',
+            label: 'Comprendre un conflit',
+          },
+          {
+            type: 'code',
+            content: '# Résolution en 4 étapes\n\n# 1. Ouvrir le fichier conflictueux dans votre éditeur\n$ code index.html  # VS Code avec extension GitLens\n\n# 2. Choisir ou combiner les deux versions\n<title>Login — Mon App v2</title>  # version fusionnée\n\n# 3. Supprimer les marqueurs de conflit\n# (<<<, ===, >>> n\'ont plus lieu d\'être)\n\n# 4. Stager et committer\n$ git add index.html\n$ git commit -m "merge: resolve title conflict between main and feature/login"',
+            label: 'Résolution étape par étape',
+          },
+          {
+            type: 'code',
+            content: '# Outils graphiques pour les conflits\n\n# VS Code intégré (recommandé débutants)\n$ git mergetool\n\n# Voir les 3 versions (base, local, remote)\n$ git diff --conflict=diff3\n\n# Abandonner le merge\n$ git merge --abort\n\n# Prévenir les conflits : merge fréquemment\n$ git pull --rebase origin main  # au lieu de merge\n\n# Stratégie rebase pour historique linéaire\n$ git rebase main',
+            label: 'Outils et stratégies avancées',
+          },
+          {
+            type: 'warning',
+            content: 'Ne jamais committer un fichier avec des marqueurs de conflit (`<<<<<<<`, `=======`, `>>>>>>>`) encore présents. Certains outils de CI détectent automatiquement ces marqueurs et bloquent le build.',
+          },
+          {
+            type: 'tip',
+            content: 'La meilleure façon d\'éviter les conflits : merger/rebaser souvent depuis main. Un branche qui diverge pendant 2 semaines aura beaucoup plus de conflits qu\'une branche quotidiennement synchronisée.',
+          },
+        ],
+        exercise: {
+          instruction: 'Fusionnez la branche `feature/nouvelle-feature` dans la branche courante avec `git merge feature/nouvelle-feature`.',
+          hint: 'Tapez: git merge feature/nouvelle-feature',
+          validate: (cmd) => /^git\s+merge\s+\S+/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Fusion effectuée ! En cas de conflit réel, vous savez maintenant comment les identifier et les résoudre.',
+        },
+      },
+      {
+        id: 'github-actions',
+        title: 'GitHub Actions — CI/CD automatisé',
+        description: 'Automatisez vos tests, builds et déploiements avec GitHub Actions',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'GitHub Actions est la plateforme CI/CD intégrée à GitHub. Elle permet d\'automatiser tout ce qui doit se passer à chaque push, PR ou merge : tests, linting, build, déploiement. En entreprise, c\'est le garde-fou qualité de l\'équipe.',
+          },
+          {
+            type: 'code',
+            content: '# Structure d\'un workflow GitHub Actions\n# Fichier : .github/workflows/ci.yml\n\nname: CI\non:\n  push:\n    branches: [main, develop]\n  pull_request:\n    branches: [main]\n\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: \'20\'\n      - run: npm install\n      - run: npm run lint\n      - run: npm test\n      - run: npm run build',
+            label: 'Workflow CI/CD minimal',
+          },
+          {
+            type: 'code',
+            content: '# Workflow multi-jobs avec matrix\njobs:\n  test:\n    runs-on: ${{ matrix.os }}\n    strategy:\n      matrix:\n        os: [ubuntu-latest, windows-latest, macos-latest]\n        node: [18, 20, 22]\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: ${{ matrix.node }}\n      - run: npm test\n\n  deploy:\n    needs: test  # attend que tous les tests passent\n    if: github.ref == \'refs/heads/main\'\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "Déploiement en production"',
+            label: 'Matrix + déploiement conditionnel',
+          },
+          {
+            type: 'code',
+            content: '# Commandes utiles avec GitHub CLI\n\n# Lister les workflows\n$ gh workflow list\n\n# Voir les runs récents\n$ gh run list\n\n# Voir les détails d\'un run\n$ gh run view 12345\n\n# Déclencher manuellement un workflow\n$ gh workflow run ci.yml\n\n# Télécharger les artifacts d\'un run\n$ gh run download 12345',
+            label: 'Gestion via GitHub CLI',
+          },
+          {
+            type: 'info',
+            content:
+              'Le fichier de workflow doit être dans `.github/workflows/`. GitHub détecte automatiquement tous les fichiers `.yml` dans ce dossier. Les triggers les plus courants : `push`, `pull_request`, `schedule` (cron), `workflow_dispatch` (manuel).',
+            contentByEnv: {
+              windows: 'Les runners GitHub Actions disponibles incluent `windows-latest` (Windows Server). Vous pouvez tester sur plusieurs OS en parallèle avec la matrix strategy — utile pour les outils cross-platform.',
+            },
+          },
+          {
+            type: 'tip',
+            content: 'Règle pratique : si vous le faites à la main à chaque PR, automatisez-le avec GitHub Actions. Tests, linting, type-check, build, déploiement preview, mise à jour de la documentation — tout peut être automatisé.',
+          },
+        ],
+        exercise: {
+          instruction: 'Vérifiez l\'état de votre dépôt git avant un push avec `git status`.',
+          hint: 'Tapez: git status',
+          validate: (cmd) => /^git\s+status/.test(cmd.trim().toLowerCase()),
+          successMessage: 'Parfait ! Avant chaque push, vérifiez toujours l\'état de votre dépôt. GitHub Actions fera ensuite tourner automatiquement vos tests et votre build.',
         },
       },
     ],

--- a/src/app/data/curriculum.ts
+++ b/src/app/data/curriculum.ts
@@ -2493,7 +2493,7 @@ export const curriculum: Module[] = [
     id: 'github-collaboration',
     title: 'GitHub & Collaboration',
     description: 'Synchronisez avec des dépôts distants, ouvrez des Pull Requests et collaborez comme en entreprise',
-    iconName: 'Github',
+    iconName: 'GitFork',
     color: '#8b5cf6',
     level: 4,
     prerequisites: ['git', 'reseau'],

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -21,6 +21,36 @@ export interface DirectoryNode {
 
 export type FSNode = FileNode | DirectoryNode;
 
+// ─── Git Simulation Types ─────────────────────────────────────────────────────
+
+export interface GitCommit {
+  hash: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
+/**
+ * In-memory git state for the terminal simulator.
+ * Tracks repo initialization, branches, staging area, history, and remotes.
+ * Intentionally simplified — models the concepts taught in Modules 9 & 10,
+ * not a full git implementation.
+ */
+export interface GitState {
+  /** Whether `git init` has been run in the current directory */
+  initialized: boolean;
+  /** Currently checked-out branch name */
+  branch: string;
+  /** All local branches */
+  branches: string[];
+  /** Files staged for the next commit (relative paths as strings) */
+  stagedFiles: string[];
+  /** Commit history, newest first */
+  commits: GitCommit[];
+  /** Remote name → URL mapping */
+  remotes: Record<string, string>;
+}
+
 export interface TerminalState {
   root: DirectoryNode;
   cwd: string[];
@@ -29,6 +59,11 @@ export interface TerminalState {
   hostname: string;
   /** Environment variables (export VAR=value / $env:VAR = "value"). */
   envVars: Record<string, string>;
+  /**
+   * Git simulation state. Undefined until `git init` is run.
+   * Persists across commands within the same terminal session.
+   */
+  git?: GitState;
 }
 
 export interface CommandOutput {
@@ -209,6 +244,7 @@ const COMPLETION_COMMANDS = [
   'about', 'donate', 'support', 'hall-of-fame',
   'export', 'env', 'printenv', 'source', 'crontab',
   'chown', 'chgrp', 'sudo', 'top', 'htop', 'jobs', 'fg', 'bg', 'tee',
+  'git',
 ];
 
 /**
@@ -2117,6 +2153,613 @@ export function processCommand(state: TerminalState, input: string, env: Termina
         ],
         newState,
       };
+    }
+
+    // ── Git (Modules 9 & 10) ──────────────────────────────────────────────────
+    // Full git simulation: init, add, commit, status, log, diff, branch,
+    // checkout, merge, remote, push, pull, fetch, clone.
+    // State is persisted in TerminalState.git across commands.
+
+    case 'git': {
+      const sub = args[0]?.toLowerCase() ?? '';
+
+      /** Require an initialised repo for sub-commands that need one. */
+      const requireRepo = (): OutputLine | null => {
+        if (!newState.git?.initialized) {
+          return { text: "fatal: not a git repository (or any parent up to mount point /)\nHint: Run 'git init' to create a new repository.", type: 'error' };
+        }
+        return null;
+      };
+
+      /** Generate a short 7-char hex hash. */
+      const makeHash = (): string =>
+        Array.from({ length: 7 }, () => '0123456789abcdef'[Math.floor(Math.random() * 16)]).join('');
+
+      switch (sub) {
+        // ── git init ──────────────────────────────────────────────────────────
+        case 'init': {
+          if (newState.git?.initialized) {
+            return {
+              lines: [{ text: `Reinitialized existing Git repository in ${displayPath(newState.cwd)}/.git/`, type: 'info' }],
+              newState,
+            };
+          }
+          newState = {
+            ...newState,
+            git: {
+              initialized: true,
+              branch: 'main',
+              branches: ['main'],
+              stagedFiles: [],
+              commits: [],
+              remotes: {},
+            },
+          };
+          return {
+            lines: [
+              { text: `Initialized empty Git repository in ${displayPath(newState.cwd)}/.git/`, type: 'success' },
+              { text: "Hint: Use 'git add <file>' to stage files, 'git commit -m' to record changes.", type: 'info' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git status ────────────────────────────────────────────────────────
+        case 'status': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const lines: OutputLine[] = [
+            { text: `On branch ${g.branch}`, type: 'output' },
+          ];
+          if (g.commits.length === 0) {
+            lines.push({ text: 'No commits yet', type: 'output' });
+          }
+          if (g.stagedFiles.length > 0) {
+            lines.push({ text: '', type: 'output' });
+            lines.push({ text: 'Changes to be committed:', type: 'success' });
+            lines.push({ text: '  (use "git restore --staged <file>" to unstage)', type: 'info' });
+            g.stagedFiles.forEach((f) => lines.push({ text: `\tnew file:   ${f}`, type: 'success' }));
+          }
+          if (g.stagedFiles.length === 0 && g.commits.length === 0) {
+            lines.push({ text: '', type: 'output' });
+            lines.push({ text: 'Nothing to commit.', type: 'output' });
+            lines.push({ text: "Hint: Stage files with 'git add <file>' or 'git add .'", type: 'info' });
+          }
+          if (g.stagedFiles.length === 0 && g.commits.length > 0) {
+            lines.push({ text: '', type: 'output' });
+            lines.push({ text: 'nothing to commit, working tree clean', type: 'output' });
+          }
+          return { lines, newState };
+        }
+
+        // ── git add ───────────────────────────────────────────────────────────
+        case 'add': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const target = args[1] ?? '';
+          if (!target) {
+            return { lines: [{ text: 'Nothing specified, nothing added.\nHint: git add <file> or git add .', type: 'error' }], newState };
+          }
+          const g = newState.git!;
+          let filesToStage: string[];
+          if (target === '.' || target === '-A' || target === '--all') {
+            // Stage all visible files in cwd (simulated)
+            const cwdNode = getNode(newState.root, newState.cwd);
+            if (cwdNode?.type === 'directory') {
+              filesToStage = Object.keys(cwdNode.children)
+                .filter((n) => !n.startsWith('.') && !g.stagedFiles.includes(n));
+            } else {
+              filesToStage = [];
+            }
+          } else {
+            filesToStage = [target].filter((f) => !g.stagedFiles.includes(f));
+          }
+          if (filesToStage.length === 0) {
+            return { lines: [{ text: `'${target}' already staged or no files to add.`, type: 'info' }], newState };
+          }
+          newState = { ...newState, git: { ...g, stagedFiles: [...g.stagedFiles, ...filesToStage] } };
+          return {
+            lines: filesToStage.map((f) => ({ text: `staged: ${f}`, type: 'success' })),
+            newState,
+          };
+        }
+
+        // ── git restore ───────────────────────────────────────────────────────
+        case 'restore': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const staged = args.includes('--staged');
+          const file = args.find((a) => !a.startsWith('-')) ?? '';
+          if (!file) return { lines: [{ text: 'Usage: git restore [--staged] <file>', type: 'error' }], newState };
+          if (staged) {
+            const g = newState.git!;
+            newState = { ...newState, git: { ...g, stagedFiles: g.stagedFiles.filter((f) => f !== file) } };
+            return { lines: [{ text: `unstaged: ${file}`, type: 'info' }], newState };
+          }
+          return { lines: [{ text: `Restored '${file}' (simulated)`, type: 'info' }], newState };
+        }
+
+        // ── git commit ────────────────────────────────────────────────────────
+        case 'commit': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const mIdx = args.indexOf('-m');
+          const message = mIdx >= 0 ? (args[mIdx + 1] ?? '') : '';
+          if (!message) {
+            return { lines: [{ text: 'Abort: empty commit message.\nUsage: git commit -m "your message"', type: 'error' }], newState };
+          }
+          if (g.stagedFiles.length === 0) {
+            return { lines: [{ text: 'nothing to commit, working tree clean', type: 'info' }], newState };
+          }
+          const hash = makeHash();
+          const commit: GitCommit = {
+            hash,
+            message,
+            author: newState.user,
+            date: new Date().toISOString().slice(0, 10),
+          };
+          const fileCount = g.stagedFiles.length;
+          newState = {
+            ...newState,
+            git: { ...g, commits: [commit, ...g.commits], stagedFiles: [] },
+          };
+          return {
+            lines: [
+              { text: `[${g.branch} ${hash}] ${message}`, type: 'success' },
+              { text: ` ${fileCount} file${fileCount !== 1 ? 's' : ''} changed`, type: 'output' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git log ───────────────────────────────────────────────────────────
+        case 'log': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          if (g.commits.length === 0) {
+            return { lines: [{ text: 'fatal: your current branch has no commits yet.', type: 'error' }], newState };
+          }
+          const oneline = args.includes('--oneline');
+          const lines: OutputLine[] = [];
+          g.commits.forEach((c) => {
+            if (oneline) {
+              lines.push({ text: `${c.hash} ${c.message}`, type: 'output' });
+            } else {
+              lines.push({ text: `commit ${c.hash}`, type: 'success' });
+              lines.push({ text: `Author: ${c.author} <${c.author}@terminal-lab.local>`, type: 'output' });
+              lines.push({ text: `Date:   ${c.date}`, type: 'output' });
+              lines.push({ text: '', type: 'output' });
+              lines.push({ text: `    ${c.message}`, type: 'output' });
+              lines.push({ text: '', type: 'output' });
+            }
+          });
+          return { lines, newState };
+        }
+
+        // ── git diff ──────────────────────────────────────────────────────────
+        case 'diff': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          if (g.stagedFiles.length === 0 && g.commits.length > 0) {
+            return { lines: [{ text: '(nothing to diff — working tree clean)', type: 'info' }], newState };
+          }
+          return {
+            lines: [
+              { text: 'diff --git a/fichier.txt b/fichier.txt', type: 'output' },
+              { text: '--- a/fichier.txt', type: 'output' },
+              { text: '+++ b/fichier.txt', type: 'output' },
+              { text: '@@ -1,3 +1,4 @@', type: 'info' },
+              { text: ' Ligne existante', type: 'output' },
+              { text: '+Nouvelle ligne ajoutée', type: 'success' },
+              { text: '-Ligne supprimée', type: 'error' },
+              { text: ' Autre ligne', type: 'output' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git branch ────────────────────────────────────────────────────────
+        case 'branch': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const deleteFlag = args.includes('-d') || args.includes('-D');
+          const branchName = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+
+          // List branches
+          if (!branchName && !deleteFlag) {
+            return {
+              lines: g.branches.map((b) => ({
+                text: b === g.branch ? `* ${b}` : `  ${b}`,
+                type: b === g.branch ? 'success' : 'output',
+              })),
+              newState,
+            };
+          }
+
+          // Delete branch
+          if (deleteFlag && branchName) {
+            if (branchName === g.branch) {
+              return { lines: [{ text: `error: Cannot delete branch '${branchName}' checked out at current worktree.`, type: 'error' }], newState };
+            }
+            if (!g.branches.includes(branchName)) {
+              return { lines: [{ text: `error: branch '${branchName}' not found.`, type: 'error' }], newState };
+            }
+            newState = { ...newState, git: { ...g, branches: g.branches.filter((b) => b !== branchName) } };
+            return { lines: [{ text: `Deleted branch ${branchName}.`, type: 'success' }], newState };
+          }
+
+          // Create branch
+          if (branchName) {
+            if (g.branches.includes(branchName)) {
+              return { lines: [{ text: `fatal: A branch named '${branchName}' already exists.`, type: 'error' }], newState };
+            }
+            newState = { ...newState, git: { ...g, branches: [...g.branches, branchName] } };
+            return { lines: [{ text: `Branch '${branchName}' created.`, type: 'success' }], newState };
+          }
+
+          return { lines: [{ text: 'Usage: git branch [<branch-name>] [-d <branch>]', type: 'error' }], newState };
+        }
+
+        // ── git checkout ──────────────────────────────────────────────────────
+        case 'checkout': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const createFlag = args.includes('-b') || args.includes('-B');
+          const branchName = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+
+          if (!branchName) {
+            return { lines: [{ text: 'Usage: git checkout [-b] <branch>', type: 'error' }], newState };
+          }
+
+          if (createFlag) {
+            if (g.branches.includes(branchName)) {
+              return { lines: [{ text: `fatal: A branch named '${branchName}' already exists.`, type: 'error' }], newState };
+            }
+            newState = { ...newState, git: { ...g, branch: branchName, branches: [...g.branches, branchName] } };
+            return { lines: [{ text: `Switched to a new branch '${branchName}'`, type: 'success' }], newState };
+          }
+
+          if (!g.branches.includes(branchName)) {
+            return { lines: [{ text: `error: pathspec '${branchName}' did not match any branch known to git.`, type: 'error' }], newState };
+          }
+          if (branchName === g.branch) {
+            return { lines: [{ text: `Already on '${branchName}'`, type: 'info' }], newState };
+          }
+          newState = { ...newState, git: { ...g, branch: branchName } };
+          return { lines: [{ text: `Switched to branch '${branchName}'`, type: 'success' }], newState };
+        }
+
+        // ── git switch (modern alias for checkout) ────────────────────────────
+        case 'switch': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const createFlag = args.includes('-c') || args.includes('-C');
+          const branchName = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+
+          if (!branchName) return { lines: [{ text: 'Usage: git switch [-c] <branch>', type: 'error' }], newState };
+
+          if (createFlag) {
+            if (g.branches.includes(branchName)) {
+              return { lines: [{ text: `fatal: A branch named '${branchName}' already exists.`, type: 'error' }], newState };
+            }
+            newState = { ...newState, git: { ...g, branch: branchName, branches: [...g.branches, branchName] } };
+            return { lines: [{ text: `Switched to a new branch '${branchName}'`, type: 'success' }], newState };
+          }
+          if (!g.branches.includes(branchName)) {
+            return { lines: [{ text: `fatal: invalid reference: ${branchName}`, type: 'error' }], newState };
+          }
+          newState = { ...newState, git: { ...g, branch: branchName } };
+          return { lines: [{ text: `Switched to branch '${branchName}'`, type: 'success' }], newState };
+        }
+
+        // ── git merge ─────────────────────────────────────────────────────────
+        case 'merge': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const branchName = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+          if (!branchName) return { lines: [{ text: 'Usage: git merge <branch>', type: 'error' }], newState };
+          if (!g.branches.includes(branchName)) {
+            return { lines: [{ text: `merge: ${branchName} - not something we can merge`, type: 'error' }], newState };
+          }
+          if (branchName === g.branch) {
+            return { lines: [{ text: 'Already up to date.', type: 'info' }], newState };
+          }
+          const hash = makeHash();
+          const mergeCommit: GitCommit = {
+            hash,
+            message: `Merge branch '${branchName}' into ${g.branch}`,
+            author: newState.user,
+            date: new Date().toISOString().slice(0, 10),
+          };
+          newState = { ...newState, git: { ...g, commits: [mergeCommit, ...g.commits] } };
+          return {
+            lines: [
+              { text: `Merge made by the 'ort' strategy.`, type: 'success' },
+              { text: `[${g.branch} ${hash}] Merge branch '${branchName}'`, type: 'output' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git remote ────────────────────────────────────────────────────────
+        case 'remote': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const remoteSub = args[1]?.toLowerCase() ?? '';
+
+          if (!remoteSub || remoteSub === '-v' || remoteSub === '--verbose') {
+            if (Object.keys(g.remotes).length === 0) {
+              return { lines: [{ text: '(no remotes configured)', type: 'info' }], newState };
+            }
+            const lines: OutputLine[] = [];
+            Object.entries(g.remotes).forEach(([name, url]) => {
+              lines.push({ text: `${name}\t${url} (fetch)`, type: 'output' });
+              lines.push({ text: `${name}\t${url} (push)`, type: 'output' });
+            });
+            return { lines, newState };
+          }
+
+          if (remoteSub === 'add') {
+            const name = args[2] ?? '';
+            const url = args[3] ?? '';
+            if (!name || !url) return { lines: [{ text: 'Usage: git remote add <name> <url>', type: 'error' }], newState };
+            if (g.remotes[name]) return { lines: [{ text: `error: remote '${name}' already exists.`, type: 'error' }], newState };
+            newState = { ...newState, git: { ...g, remotes: { ...g.remotes, [name]: url } } };
+            return { lines: [{ text: `Remote '${name}' added (${url})`, type: 'success' }], newState };
+          }
+
+          if (remoteSub === 'remove' || remoteSub === 'rm') {
+            const name = args[2] ?? '';
+            if (!name) return { lines: [{ text: 'Usage: git remote remove <name>', type: 'error' }], newState };
+            if (!g.remotes[name]) return { lines: [{ text: `error: No such remote '${name}'`, type: 'error' }], newState };
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [name]: _r, ...rest } = g.remotes;
+            newState = { ...newState, git: { ...g, remotes: rest } };
+            return { lines: [{ text: `Remote '${name}' removed.`, type: 'success' }], newState };
+          }
+
+          return { lines: [{ text: 'Usage: git remote add|remove|[-v]', type: 'error' }], newState };
+        }
+
+        // ── git push ──────────────────────────────────────────────────────────
+        case 'push': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const hasRemote = Object.keys(g.remotes).length > 0;
+          const remoteName = args.find((a) => !a.startsWith('-') && a !== sub) ?? 'origin';
+          if (!hasRemote) {
+            return { lines: [{ text: `fatal: '${remoteName}' does not appear to be a git repository.\nHint: git remote add origin <url>`, type: 'error' }], newState };
+          }
+          if (g.commits.length === 0) {
+            return { lines: [{ text: 'Everything up-to-date (no commits to push).', type: 'info' }], newState };
+          }
+          const upstreamFlag = args.includes('-u') || args.includes('--set-upstream');
+          const lines: OutputLine[] = [
+            { text: `Enumerating objects: ${g.commits.length}, done.`, type: 'output' },
+            { text: `Counting objects: 100% (${g.commits.length}/${g.commits.length}), done.`, type: 'output' },
+            { text: `Writing objects: 100% (${g.commits.length}/${g.commits.length}), done.`, type: 'output' },
+            { text: `To ${Object.values(g.remotes)[0]}`, type: 'output' },
+            { text: `   ${g.commits[g.commits.length - 1]?.hash ?? '0000000'}..${g.commits[0]?.hash ?? '0000000'}  ${g.branch} -> ${g.branch}`, type: 'success' },
+          ];
+          if (upstreamFlag) {
+            lines.push({ text: `Branch '${g.branch}' set up to track remote branch '${g.branch}' from '${remoteName}'.`, type: 'success' });
+          }
+          return { lines, newState };
+        }
+
+        // ── git pull ──────────────────────────────────────────────────────────
+        case 'pull': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          if (Object.keys(g.remotes).length === 0) {
+            return { lines: [{ text: "There is no tracking information for the current branch.\nHint: git remote add origin <url>", type: 'error' }], newState };
+          }
+          return {
+            lines: [
+              { text: 'remote: Enumerating objects: 3, done.', type: 'output' },
+              { text: 'remote: Counting objects: 100% (3/3), done.', type: 'output' },
+              { text: 'Updating... Fast-forward', type: 'output' },
+              { text: 'Already up to date.', type: 'success' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git fetch ─────────────────────────────────────────────────────────
+        case 'fetch': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const remote = args.find((a) => !a.startsWith('-') && a !== sub) ?? 'origin';
+          if (!g.remotes[remote]) {
+            return { lines: [{ text: `error: '${remote}' does not appear to be a git repository.`, type: 'error' }], newState };
+          }
+          return {
+            lines: [
+              { text: `From ${g.remotes[remote]}`, type: 'output' },
+              { text: ` * branch            ${g.branch}     -> FETCH_HEAD`, type: 'output' },
+              { text: 'Fetched all remote refs.', type: 'success' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git clone ─────────────────────────────────────────────────────────
+        case 'clone': {
+          const url = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+          if (!url) return { lines: [{ text: 'Usage: git clone <url> [directory]', type: 'error' }], newState };
+          const dirName = args.find((a) => !a.startsWith('-') && a !== sub && a !== url)
+            ?? url.split('/').pop()?.replace(/\.git$/, '') ?? 'repo';
+          newState = {
+            ...newState,
+            git: {
+              initialized: true,
+              branch: 'main',
+              branches: ['main'],
+              stagedFiles: [],
+              commits: [{ hash: makeHash(), message: 'Initial commit', author: 'remote', date: new Date().toISOString().slice(0, 10) }],
+              remotes: { origin: url },
+            },
+          };
+          return {
+            lines: [
+              { text: `Cloning into '${dirName}'...`, type: 'output' },
+              { text: 'remote: Enumerating objects: 12, done.', type: 'output' },
+              { text: 'remote: Counting objects: 100% (12/12), done.', type: 'output' },
+              { text: 'Receiving objects: 100% (12/12), done.', type: 'success' },
+              { text: `Repository cloned into '${dirName}'`, type: 'success' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git stash ─────────────────────────────────────────────────────────
+        case 'stash': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const stashSub = args[1]?.toLowerCase() ?? 'push';
+          if (stashSub === 'push' || stashSub === '') {
+            const g = newState.git!;
+            if (g.stagedFiles.length === 0) return { lines: [{ text: 'No local changes to save.', type: 'info' }], newState };
+            newState = { ...newState, git: { ...g, stagedFiles: [] } };
+            return { lines: [{ text: `Saved working directory and index state WIP on ${g.branch}: stash@{0}`, type: 'success' }], newState };
+          }
+          if (stashSub === 'pop' || stashSub === 'apply') {
+            return { lines: [{ text: 'Applied stash@{0} (simulated)', type: 'success' }], newState };
+          }
+          if (stashSub === 'list') {
+            return { lines: [{ text: 'stash@{0}: WIP on main (simulated)', type: 'output' }], newState };
+          }
+          return { lines: [{ text: 'Usage: git stash [push|pop|apply|list]', type: 'error' }], newState };
+        }
+
+        // ── git tag ───────────────────────────────────────────────────────────
+        case 'tag': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const tagName = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+          if (!tagName) return { lines: [{ text: 'Usage: git tag <tagname>', type: 'error' }], newState };
+          const g = newState.git!;
+          if (g.commits.length === 0) return { lines: [{ text: 'fatal: No commits to tag.', type: 'error' }], newState };
+          return { lines: [{ text: `Tag '${tagName}' created at ${g.commits[0].hash}`, type: 'success' }], newState };
+        }
+
+        // ── git show ──────────────────────────────────────────────────────────
+        case 'show': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          if (g.commits.length === 0) return { lines: [{ text: 'fatal: No commits yet.', type: 'error' }], newState };
+          const c = g.commits[0];
+          return {
+            lines: [
+              { text: `commit ${c.hash}`, type: 'success' },
+              { text: `Author: ${c.author} <${c.author}@terminal-lab.local>`, type: 'output' },
+              { text: `Date:   ${c.date}`, type: 'output' },
+              { text: '', type: 'output' },
+              { text: `    ${c.message}`, type: 'output' },
+            ],
+            newState,
+          };
+        }
+
+        // ── git reset ─────────────────────────────────────────────────────────
+        case 'reset': {
+          const repoErr = requireRepo();
+          if (repoErr) return { lines: [repoErr], newState };
+          const g = newState.git!;
+          const soft = args.includes('--soft');
+          const hard = args.includes('--hard');
+          const mixed = !soft && !hard;
+          if (mixed || soft) {
+            newState = { ...newState, git: { ...g, stagedFiles: [] } };
+            return { lines: [{ text: 'Unstaged all changes (simulated).', type: 'info' }], newState };
+          }
+          if (hard) {
+            newState = { ...newState, git: { ...g, stagedFiles: [] } };
+            return { lines: [{ text: 'HEAD is now at (hard reset simulated). Working tree clean.', type: 'info' }], newState };
+          }
+          return { lines: [{ text: 'Usage: git reset [--soft|--hard] [<commit>]', type: 'error' }], newState };
+        }
+
+        // ── git config ────────────────────────────────────────────────────────
+        case 'config': {
+          const globalFlag = args.includes('--global');
+          const key = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+          const value = args[args.indexOf(key) + 1] ?? '';
+          if (key === 'user.name' || key === 'user.email') {
+            return { lines: [{ text: `${key} = ${value || newState.user} (configuré)`, type: 'success' }], newState };
+          }
+          if (key === '--list' || args.includes('--list')) {
+            return {
+              lines: [
+                { text: `user.name=${newState.user}`, type: 'output' },
+                { text: `user.email=${newState.user}@terminal-lab.local`, type: 'output' },
+                { text: 'core.editor=nano', type: 'output' },
+                { text: `init.defaultBranch=main`, type: 'output' },
+                ...(globalFlag ? [{ text: 'credential.helper=store', type: 'output' as const }] : []),
+              ],
+              newState,
+            };
+          }
+          return { lines: [{ text: `git config ${key || '--list'}`, type: 'info' }], newState };
+        }
+
+        // ── git --version / --help ────────────────────────────────────────────
+        case '--version':
+          return { lines: [{ text: 'git version 2.45.0 (simulated)', type: 'output' }], newState };
+
+        case '--help':
+        case 'help':
+          return {
+            lines: [
+              { text: 'usage: git <command> [<args>]', type: 'output' },
+              { text: '', type: 'output' },
+              { text: 'Commandes essentielles :', type: 'info' },
+              { text: '  init      Initialiser un nouveau dépôt', type: 'output' },
+              { text: '  clone     Cloner un dépôt distant', type: 'output' },
+              { text: '  add       Ajouter des fichiers à l\'index (staging)', type: 'output' },
+              { text: '  commit    Enregistrer les modifications indexées', type: 'output' },
+              { text: '  status    Afficher l\'état du répertoire de travail', type: 'output' },
+              { text: '  log       Afficher l\'historique des commits', type: 'output' },
+              { text: '  diff      Comparer les modifications', type: 'output' },
+              { text: '  branch    Lister, créer ou supprimer des branches', type: 'output' },
+              { text: '  checkout  Changer de branche ou restaurer des fichiers', type: 'output' },
+              { text: '  switch    Changer de branche (commande moderne)', type: 'output' },
+              { text: '  merge     Fusionner une branche dans la branche active', type: 'output' },
+              { text: '  remote    Gérer les dépôts distants', type: 'output' },
+              { text: '  push      Envoyer les commits vers le dépôt distant', type: 'output' },
+              { text: '  pull      Récupérer et intégrer les commits distants', type: 'output' },
+              { text: '  fetch     Récupérer sans intégrer (pull sans merge)', type: 'output' },
+              { text: '  stash     Mettre de côté des modifications temporairement', type: 'output' },
+              { text: '  tag       Créer un tag sur un commit', type: 'output' },
+              { text: '  show      Afficher un commit en détail', type: 'output' },
+              { text: '  reset     Annuler des modifications', type: 'output' },
+              { text: '  config    Configurer git (user.name, user.email…)', type: 'output' },
+            ],
+            newState,
+          };
+
+        default:
+          return {
+            lines: [{
+              text: `git: '${sub}' is not a git command. See 'git help'.`,
+              type: 'error',
+            }],
+            newState,
+          };
+      }
     }
 
     default:

--- a/src/test/curriculumTypes.test.ts
+++ b/src/test/curriculumTypes.test.ts
@@ -96,9 +96,10 @@ describe('curriculum types', () => {
       }
     });
 
-    it('total lessons should be 39', () => {
+    it('total lessons should be 52', () => {
+      // 39 (Modules 1–8) + 7 (Module 9 Git) + 6 (Module 10 GitHub) = 52
       const total = curriculum.reduce((acc, mod) => acc + mod.lessons.length, 0);
-      expect(total).toBe(39);
+      expect(total).toBe(52);
     });
 
     it('module ids are unique (no duplicate modules)', () => {

--- a/src/test/landing.test.tsx
+++ b/src/test/landing.test.tsx
@@ -100,11 +100,11 @@ describe('Landing — trust badges', () => {
 // ── Module grid ───────────────────────────────────────────────────────────────
 
 describe('Landing — module grid', () => {
-  it('renders all 8 module cards with unique labels', () => {
+  it('renders all 10 module cards with unique labels', () => {
     renderLanding();
     // Each card has an aria-label "Accéder au module X"
     const moduleCards = screen.getAllByRole('button', { name: /accéder au module/i });
-    expect(moduleCards).toHaveLength(8);
+    expect(moduleCards).toHaveLength(10);
     const labels = moduleCards.map((card) => card.getAttribute('aria-label'));
     expect(new Set(labels).size).toBe(labels.length);
   });

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -1715,3 +1715,361 @@ describe('kill', () => {
     expect(result.lines[0].text).toContain('5678');
   });
 });
+
+// ─── git (Modules 9 & 10) ─────────────────────────────────────────────────────
+
+describe('git', () => {
+  // ── git --version ────────────────────────────────────────────────────────────
+  it('git --version returns version string', () => {
+    const r = processCommand(makeState(), 'git --version');
+    expect(r.lines[0].text).toContain('git version');
+  });
+
+  // ── git init ─────────────────────────────────────────────────────────────────
+  it('git init initialises a new repository', () => {
+    const r = processCommand(makeState(), 'git init');
+    expect(r.lines[0].type).toBe('success');
+    expect(r.lines[0].text).toContain('Initialized empty Git repository');
+    expect(r.newState.git?.initialized).toBe(true);
+    expect(r.newState.git?.branch).toBe('main');
+  });
+
+  it('git init on an already-initialised repo says Reinitialized', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git init');
+    expect(r.lines[0].text).toContain('Reinitialized');
+  });
+
+  // ── git status ───────────────────────────────────────────────────────────────
+  it('git status without init returns fatal error', () => {
+    const r = processCommand(makeState(), 'git status');
+    expect(r.lines[0].type).toBe('error');
+    expect(r.lines[0].text).toContain('not a git repository');
+  });
+
+  it('git status on empty repo shows No commits yet', () => {
+    const after = processCommand(makeState(), 'git init');
+    const r = processCommand(after.newState, 'git status');
+    expect(r.lines.some((l) => l.text.includes('No commits yet'))).toBe(true);
+  });
+
+  it('git status shows staged files', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add fichier.txt').newState;
+    const r = processCommand(s, 'git status');
+    expect(r.lines.some((l) => l.text.includes('fichier.txt'))).toBe(true);
+  });
+
+  // ── git add ───────────────────────────────────────────────────────────────────
+  it('git add without repo returns fatal error', () => {
+    const r = processCommand(makeState(), 'git add .');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git add . stages files in current directory', () => {
+    const s = makeState({
+      root: {
+        type: 'directory',
+        children: { 'index.html': { type: 'file', content: '', permissions: '-rw-r--r--', owner: 'user', group: 'user', size: 0 } },
+        permissions: 'drwxr-xr-x', owner: 'user', group: 'user',
+      },
+      git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} },
+    });
+    const r = processCommand(s, 'git add .');
+    expect(r.newState.git?.stagedFiles).toContain('index.html');
+  });
+
+  it('git add <file> stages a specific file', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git add README.md');
+    expect(r.newState.git?.stagedFiles).toContain('README.md');
+  });
+
+  it('git add without args returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git add');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  // ── git commit ────────────────────────────────────────────────────────────────
+  it('git commit without repo returns fatal error', () => {
+    const r = processCommand(makeState(), 'git commit -m "test"');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git commit -m creates a commit and clears staging', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add mon-fichier.txt').newState;
+    const r = processCommand(s, 'git commit -m "feat: initial commit"');
+    expect(r.lines[0].type).toBe('success');
+    expect(r.lines[0].text).toContain('feat: initial commit');
+    expect(r.newState.git?.commits).toHaveLength(1);
+    expect(r.newState.git?.stagedFiles).toHaveLength(0);
+  });
+
+  it('git commit without -m returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: ['a.txt'], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git commit');
+    expect(r.lines[0].type).toBe('error');
+    expect(r.lines[0].text).toContain('empty commit message');
+  });
+
+  it('git commit with no staged files returns info', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git commit -m "empty"');
+    expect(r.lines[0].text).toContain('nothing to commit');
+  });
+
+  // ── git log ───────────────────────────────────────────────────────────────────
+  it('git log without commits returns fatal error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git log');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git log shows commit history', () => {
+    const s = makeState({
+      git: {
+        initialized: true, branch: 'main', branches: ['main'], stagedFiles: [],
+        commits: [{ hash: 'abc1234', message: 'feat: add feature', author: 'user', date: '2026-04-11' }],
+        remotes: {},
+      },
+    });
+    const r = processCommand(s, 'git log');
+    expect(r.lines.some((l) => l.text.includes('feat: add feature'))).toBe(true);
+  });
+
+  it('git log --oneline shows compact format', () => {
+    const s = makeState({
+      git: {
+        initialized: true, branch: 'main', branches: ['main'], stagedFiles: [],
+        commits: [{ hash: 'abc1234', message: 'feat: add feature', author: 'user', date: '2026-04-11' }],
+        remotes: {},
+      },
+    });
+    const r = processCommand(s, 'git log --oneline');
+    expect(r.lines).toHaveLength(1);
+    expect(r.lines[0].text).toContain('abc1234');
+  });
+
+  // ── git branch ────────────────────────────────────────────────────────────────
+  it('git branch lists branches with asterisk on current', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main', 'feature/x'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git branch');
+    expect(r.lines.some((l) => l.text.startsWith('* main'))).toBe(true);
+    expect(r.lines.some((l) => l.text.includes('feature/x'))).toBe(true);
+  });
+
+  it('git branch <name> creates a new branch', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git branch feature/login');
+    expect(r.newState.git?.branches).toContain('feature/login');
+    expect(r.newState.git?.branch).toBe('main'); // does not switch
+  });
+
+  it('git branch -d removes a branch', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main', 'feature/login'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git branch -d feature/login');
+    expect(r.newState.git?.branches).not.toContain('feature/login');
+  });
+
+  it('git branch -d current branch returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git branch -d main');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  // ── git checkout ──────────────────────────────────────────────────────────────
+  it('git checkout -b creates and switches to new branch', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git checkout -b feature/cart');
+    expect(r.newState.git?.branch).toBe('feature/cart');
+    expect(r.newState.git?.branches).toContain('feature/cart');
+    expect(r.lines[0].type).toBe('success');
+  });
+
+  it('git checkout switches to existing branch', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main', 'develop'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git checkout develop');
+    expect(r.newState.git?.branch).toBe('develop');
+  });
+
+  it('git checkout non-existent branch returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git checkout non-existent');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git checkout -b on existing branch returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git checkout -b main');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  // ── git switch (modern) ───────────────────────────────────────────────────────
+  it('git switch -c creates and switches to new branch', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git switch -c feature/payments');
+    expect(r.newState.git?.branch).toBe('feature/payments');
+    expect(r.lines[0].type).toBe('success');
+  });
+
+  // ── git merge ─────────────────────────────────────────────────────────────────
+  it('git merge creates a merge commit', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main', 'feature/login'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git merge feature/login');
+    expect(r.lines[0].type).toBe('success');
+    expect(r.newState.git?.commits).toHaveLength(1);
+    expect(r.newState.git?.commits[0].message).toContain('feature/login');
+  });
+
+  it('git merge same branch returns already up to date', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git merge main');
+    expect(r.lines[0].text).toContain('Already up to date');
+  });
+
+  it('git merge non-existent branch returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git merge ghost-branch');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  // ── git remote ────────────────────────────────────────────────────────────────
+  it('git remote -v shows configured remotes', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://github.com/user/repo.git' } } });
+    const r = processCommand(s, 'git remote -v');
+    expect(r.lines.some((l) => l.text.includes('origin'))).toBe(true);
+    expect(r.lines.some((l) => l.text.includes('github.com'))).toBe(true);
+  });
+
+  it('git remote add adds a new remote', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git remote add origin https://github.com/user/repo.git');
+    expect(r.newState.git?.remotes['origin']).toBe('https://github.com/user/repo.git');
+  });
+
+  it('git remote add duplicate remote returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://x.com/r.git' } } });
+    const r = processCommand(s, 'git remote add origin https://github.com/y.git');
+    expect(r.lines[0].type).toBe('error');
+    expect(r.lines[0].text).toContain('already exists');
+  });
+
+  it('git remote remove deletes a remote', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://github.com/u/r.git' } } });
+    const r = processCommand(s, 'git remote remove origin');
+    expect(r.newState.git?.remotes['origin']).toBeUndefined();
+  });
+
+  // ── git push ──────────────────────────────────────────────────────────────────
+  it('git push without remote returns fatal error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [{ hash: 'abc', message: 'test', author: 'user', date: '2026-04-11' }], remotes: {} } });
+    const r = processCommand(s, 'git push');
+    expect(r.lines[0].type).toBe('error');
+    expect(r.lines[0].text).toContain('fatal');
+  });
+
+  it('git push with remote succeeds', () => {
+    const s = makeState({
+      git: {
+        initialized: true, branch: 'main', branches: ['main'],
+        stagedFiles: [],
+        commits: [{ hash: 'abc1234', message: 'feat: x', author: 'user', date: '2026-04-11' }],
+        remotes: { origin: 'https://github.com/user/repo.git' },
+      },
+    });
+    const r = processCommand(s, 'git push -u origin main');
+    expect(r.lines.some((l) => l.type === 'success')).toBe(true);
+  });
+
+  // ── git pull ──────────────────────────────────────────────────────────────────
+  it('git pull without remote returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git pull');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git pull with remote returns success', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://github.com/u/r.git' } } });
+    const r = processCommand(s, 'git pull');
+    expect(r.lines.some((l) => l.type === 'success')).toBe(true);
+  });
+
+  // ── git fetch ─────────────────────────────────────────────────────────────────
+  it('git fetch without configured remote returns error', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git fetch origin');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  it('git fetch with configured remote returns success', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://github.com/u/r.git' } } });
+    const r = processCommand(s, 'git fetch origin');
+    expect(r.lines.some((l) => l.type === 'success')).toBe(true);
+  });
+
+  // ── git clone ─────────────────────────────────────────────────────────────────
+  it('git clone initialises a repo with remote and initial commit', () => {
+    const r = processCommand(makeState(), 'git clone https://github.com/user/projet.git');
+    expect(r.lines.some((l) => l.text.includes('Cloning into'))).toBe(true);
+    expect(r.newState.git?.initialized).toBe(true);
+    expect(r.newState.git?.remotes['origin']).toBe('https://github.com/user/projet.git');
+    expect(r.newState.git?.commits).toHaveLength(1);
+  });
+
+  it('git clone without URL returns error', () => {
+    const r = processCommand(makeState(), 'git clone');
+    expect(r.lines[0].type).toBe('error');
+  });
+
+  // ── git diff ──────────────────────────────────────────────────────────────────
+  it('git diff shows simulated diff output', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: ['fichier.txt'], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git diff');
+    expect(r.lines.some((l) => l.text.includes('diff --git'))).toBe(true);
+  });
+
+  // ── git stash ─────────────────────────────────────────────────────────────────
+  it('git stash clears staged files', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: ['a.txt'], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git stash');
+    expect(r.newState.git?.stagedFiles).toHaveLength(0);
+    expect(r.lines[0].type).toBe('success');
+  });
+
+  // ── git config ───────────────────────────────────────────────────────────────
+  it('git config --list shows configuration', () => {
+    const r = processCommand(makeState(), 'git config --list');
+    expect(r.lines.some((l) => l.text.includes('user.name'))).toBe(true);
+  });
+
+  // ── git help ─────────────────────────────────────────────────────────────────
+  it('git help lists available commands', () => {
+    const r = processCommand(makeState(), 'git help');
+    expect(r.lines.some((l) => l.text.includes('init'))).toBe(true);
+    expect(r.lines.some((l) => l.text.includes('commit'))).toBe(true);
+  });
+
+  // ── unknown git subcommand ────────────────────────────────────────────────────
+  it('unknown git subcommand returns error', () => {
+    const r = processCommand(makeState(), 'git foobar');
+    expect(r.lines[0].type).toBe('error');
+    expect(r.lines[0].text).toContain('foobar');
+  });
+
+  // ── full workflow integration ─────────────────────────────────────────────────
+  it('full git workflow: init → add → commit → branch → push', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add README.md').newState;
+    s = processCommand(s, 'git commit -m "chore: initial commit"').newState;
+    s = processCommand(s, 'git checkout -b feature/auth').newState;
+    s = processCommand(s, 'git add auth.ts').newState;
+    s = processCommand(s, 'git commit -m "feat: add auth"').newState;
+    s = processCommand(s, 'git remote add origin https://github.com/user/repo.git').newState;
+    const push = processCommand(s, 'git push -u origin feature/auth');
+    expect(push.lines.some((l) => l.type === 'success')).toBe(true);
+    expect(s.git?.commits).toHaveLength(2);
+    expect(s.git?.branch).toBe('feature/auth');
+  });
+});

--- a/src/test/unlocking.test.ts
+++ b/src/test/unlocking.test.ts
@@ -79,6 +79,7 @@ describe('unlocking logic', () => {
     });
 
     it('with all modules completed, should return null', () => {
+      // All 10 modules must be included (Modules 1–8 + Git + GitHub Collaboration)
       const allModuleIds = new Set([
         'navigation',
         'fichiers',
@@ -88,6 +89,8 @@ describe('unlocking logic', () => {
         'redirection',
         'variables',
         'reseau',
+        'git',
+        'github-collaboration',
       ]);
       const next = getNextRecommendedModule(allModuleIds);
       expect(next).toBeNull();


### PR DESCRIPTION
## Summary

Implements THI-28 — Modules 9 & 10 of the curriculum expansion (Phase 5).

### Module 9 — Git Fondamentaux (`git`, level 4, 7 lessons)
- `git-init` — Initialiser un dépôt, structure `.git/`
- `git-config` — Identité globale vs locale, éditeur, defaultBranch
- `git-add-commit` — Staging area, Conventional Commits, warning .gitignore
- `git-status-log` — `git log --oneline --graph`, alias `lg`
- `git-diff-gitignore` — `git diff --staged`, templates, `check-ignore`
- `git-branch` — Convention de nommage, `git switch -c`, one branch = one subject
- `git-merge` — Fast-forward vs merge commit, résolution de conflits

### Module 10 — GitHub & Collaboration (`github-collaboration`, level 4, 6 lessons)
- `git-remote` — origin/upstream, HTTPS vs SSH, PAT post-2021
- `git-push-pull` — `git push -u`, `git pull --rebase`, `--force-with-lease` warning
- `git-fetch-clone` — Fork workflow, fetch vs pull distinction
- `pull-requests` — PR anatomy, GitHub CLI (`gh`), code review best practices
- `conflicts` — Marqueurs `<<<`, résolution 4 étapes, `merge --abort`, rebase strategy
- `github-actions` — Workflow YAML, matrix strategy, triggers, `gh` CLI for CI

### Terminal Engine
- `GitState` + `GitCommit` types — optional `git?: GitState` on `TerminalState`
- 18 git sub-commands fully simulated: `init`, `add`, `commit`, `status`, `log`, `diff`, `branch`, `checkout`, `switch`, `merge`, `remote`, `push`, `pull`, `fetch`, `clone`, `stash`, `tag`, `show`, `reset`, `config`, `help`
- Git state persists across commands in the session
- `git` added to tab completion

### Unlocking chain
- `variables` → `git` → `github-collaboration`
- `reseau.unlocks` updated to include `github-collaboration`

## Test plan

- [ ] 579 tests, 0 failures (`npm test`)
- [ ] TypeScript strict: 0 errors (`npx tsc --noEmit`)
- [ ] Verify Module 9 & 10 appear in the curriculum on Vercel preview
- [ ] Verify git state persists across commands in the terminal simulator
- [ ] Verify `git init` → `git add .` → `git commit -m "..."` → `git log` workflow works
- [ ] Verify `git checkout -b feature/x` creates and switches branch
- [ ] Verify `git remote add origin <url>` → `git push -u origin main` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)