### PR TITLE
fix(csp): add frame-src for vercel.live preview toolbar

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 11 avril 2026
-> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 8 modules ✅, 39 leçons, 530 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
+> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 10 modules ✅, 52 leçons, 579 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale)
 
 ---
 
@@ -10,7 +10,7 @@
 | Issue Linear | Phase | Contenu |
 |-------------|-------|---------|
 | THI-27 | 5 | Module 8 — Réseau & SSH (`ping`, `curl`, `wget`, `ssh`, `scp`, DNS) ✅ Done |
-| THI-28 | 5 | Modules 9+10 — Git Fondamentaux + GitHub & Collaboration *(combinés)* |
+| THI-28 | 5 | Modules 9+10 — Git Fondamentaux + GitHub & Collaboration *(combinés)* — 52 leçons, 579 tests (PR #72) ✅ Done |
 | THI-29 | 5 | Module 11 — L'IA comme outil dev |
 | THI-35 | docs | Architecture stratégique — Terminal Sentinel, RBAC, Admin Panel, PWA ✅ Done |
 | THI-36 | 5.5 | Terminal Sentinel — outil d'audit de sécurité automatisé |

--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live wss://ws-us3.pusher.com https://sockjs-mt1.pusher.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live wss://ws-us3.pusher.com https://sockjs-mt1.pusher.com; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary

- Adds `frame-src 'self' https://vercel.live` to the CSP in `vercel.json`
- Fixes console error on preview deployments: *"Framing vercel.live violates CSP default-src 'self'"*
- `frame-ancestors 'none'` unchanged — clickjacking protection unaffected in production
- Also updates `docs/plan.md`: THI-28 Done, 10 modules / 52 leçons / 579 tests

## Why

`frame-src` was missing from the CSP — `default-src 'self'` was used as fallback, blocking the Vercel Live widget iframe injected on preview URLs. Production is unaffected (no Vercel Live widget there).

## Security note

`frame-src` (what our page can embed) ≠ `frame-ancestors` (who can embed our page). Adding `vercel.live` to `frame-src` only allows our preview pages to load the Vercel toolbar iframe. It does not weaken clickjacking protection.

## Test plan

- [ ] Vercel preview: no more CSP `frame-src` console error
- [ ] Production (`terminallearning.dev`): security headers unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Met à jour la politique de sécurité de contenu (CSP) pour autoriser l’intégration en iframe de la barre d’aperçu en direct Vercel Live et actualise la documentation du plan de lancement afin de refléter la nouvelle progression du programme.

Corrections de bugs :
- Autoriser le chargement de l’iframe de la barre d’aperçu en direct Vercel Live en ajoutant une directive `frame-src` explicite pour `vercel.live` dans la CSP.

Documentation :
- Mettre à jour les métriques du plan de lancement et marquer THI-28 comme complété avec les nouveaux modules, leçons et nombres de tests.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update content security policy to allow Vercel Live preview toolbar iframing and refresh launch plan documentation to reflect new curriculum progress.

Bug Fixes:
- Allow Vercel Live preview toolbar iframe to load by adding an explicit frame-src directive for vercel.live in the CSP.

Documentation:
- Update launch plan metrics and mark THI-28 as completed with the new modules, lessons, and test counts.

</details>