### PR TITLE
refactor: cmdHead/cmdTail DRY + iconMap centralisé (THI-60, THI-66)

### DIFF
--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -1,14 +1,10 @@
 import { useNavigate } from 'react-router';
 import {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
   CheckCircle2, ChevronRight, Terminal, Award, BookOpen, Zap, Lock,
 } from 'lucide-react';
 import { curriculum } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
-
-const iconMap: Record<string, React.ComponentType<{ className?: string; size?: number }>> = {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
-};
+import { iconMap } from '../data/moduleIcons';
 
 const MODULE_GRADIENTS: Record<string, string> = {
   navigation: 'from-emerald-500/20 to-emerald-500/5',

--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import {
   ChevronLeft, ChevronRight, CheckCircle2, Terminal,

--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import {
   ChevronLeft, ChevronRight, CheckCircle2, Terminal,
@@ -11,6 +11,7 @@ import {
 import { useProgress } from '../context/ProgressContext';
 import { useAuth } from '../context/AuthContext';
 import { useEnvironment } from '../context/EnvironmentContext';
+import { useLessonSEO } from '../hooks/useLessonSEO';
 import { toUnixUsername } from '../../lib/username';
 import { TerminalState } from '../data/terminalEngine';
 import { TerminalEmulator } from './TerminalEmulator';
@@ -110,42 +111,7 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
   const { user } = useAuth();
   const { selectedEnv } = useEnvironment();
 
-  // ── Dynamic SEO per lesson ──────────────────────────────────────────────────
-  useEffect(() => {
-    const pageTitle = `${lesson.title} — ${mod.title} | Terminal Learning`;
-    const pageDesc = lesson.description
-      || `Apprends ${lesson.title} dans le module ${mod.title}. Exercice interactif avec émulateur terminal. Gratuit, open source.`;
-    const canonicalUrl = `https://terminallearning.dev/app/learn/${moduleId}/${lessonId}`;
-
-    document.title = pageTitle;
-
-    const setMeta = (sel: string, attr: string, val: string) => {
-      const el = document.querySelector(sel);
-      if (el) el.setAttribute(attr, val);
-    };
-
-    setMeta('meta[name="description"]', 'content', pageDesc);
-    setMeta('link[rel="canonical"]', 'href', canonicalUrl);
-    setMeta('meta[property="og:title"]', 'content', pageTitle);
-    setMeta('meta[property="og:description"]', 'content', pageDesc);
-    setMeta('meta[property="og:url"]', 'content', canonicalUrl);
-    setMeta('meta[name="twitter:title"]', 'content', pageTitle);
-    setMeta('meta[name="twitter:description"]', 'content', pageDesc);
-
-    return () => {
-      document.title = 'Terminal Learning — Apprends le terminal pas à pas';
-      setMeta('meta[name="description"]', 'content',
-        'Apprends les commandes du terminal gratuitement. 8 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source.');
-      setMeta('link[rel="canonical"]', 'href', 'https://terminallearning.dev/');
-      setMeta('meta[property="og:title"]', 'content', 'Terminal Learning — Apprends le terminal pas à pas');
-      setMeta('meta[property="og:description"]', 'content',
-        'Application interactive gratuite pour apprendre les commandes du terminal. 8 modules progressifs (Linux, macOS, Windows), émulateur réel. Pour débutants, 100% open source.');
-      setMeta('meta[property="og:url"]', 'content', 'https://terminallearning.dev/');
-      setMeta('meta[name="twitter:title"]', 'content', 'Terminal Learning — Apprends le terminal pas à pas');
-      setMeta('meta[name="twitter:description"]', 'content',
-        'Application interactive gratuite pour apprendre les commandes du terminal. 8 modules (Linux, macOS, Windows), émulateur réel, 100% open source.');
-    };
-  }, [mod, lesson, moduleId, lessonId]);
+  useLessonSEO(mod, lesson, moduleId, lessonId);
   const terminalUsername = toUnixUsername(user);
   // Derived from context on every render — no local state needed
   const exerciseCompleted = isLessonCompleted(moduleId, lessonId);

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,18 +1,14 @@
 import { useState } from 'react';
 import { NavLink, useNavigate } from 'react-router';
 import {
-  Terminal, LayoutDashboard, BookOpen, Compass, FolderOpen,
-  FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
+  Terminal, LayoutDashboard, BookOpen,
   ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock,
 } from 'lucide-react';
 import { UserMenu } from './auth/UserMenu';
 import { curriculum } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
-
-const iconMap: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
-  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
-};
+import { iconMap } from '../data/moduleIcons';
 
 interface SidebarProps {
   isOpen: boolean;

--- a/src/app/data/moduleIcons.ts
+++ b/src/app/data/moduleIcons.ts
@@ -1,5 +1,5 @@
-import { Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe } from 'lucide-react';
+import { type LucideIcon, Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe } from 'lucide-react';
 
-export const iconMap: Record<string, React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
+export const iconMap: Record<string, LucideIcon> = {
   Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
 };

--- a/src/app/data/moduleIcons.ts
+++ b/src/app/data/moduleIcons.ts
@@ -1,0 +1,5 @@
+import { Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe } from 'lucide-react';
+
+export const iconMap: Record<string, React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
+  Compass, FolderOpen, FileText, Shield, Cpu, GitMerge, GitBranch, GitFork, Globe,
+};

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -651,15 +651,17 @@ function cmdGrep(state: TerminalState, args: string[]): OutputLine[] {
 function cmdHeadTail(state: TerminalState, args: string[], cmd: 'head' | 'tail'): OutputLine[] {
   let n = 10;
   let filePath = '';
+  const parseN = (raw: string) => { const p = parseInt(raw, 10); if (!Number.isNaN(p)) n = p; };
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '-n' && args[i + 1]) { n = parseInt(args[i + 1]) || 10; i++; }
-    else if (args[i].startsWith('-n')) { n = parseInt(args[i].slice(2)) || 10; }
+    if (args[i] === '-n' && args[i + 1]) { parseN(args[i + 1]); i++; }
+    else if (args[i].startsWith('-n')) { parseN(args[i].slice(2)); }
     else filePath = args[i];
   }
-  if (!filePath) return [{ text: `${cmd}: missing file operand`, type: 'error' }];
+  const pfx = `${cmd}:`;
+  if (!filePath) return [{ text: `${pfx} missing file operand`, type: 'error' }];
   const node = getNode(state.root, resolvePath(state, filePath));
-  if (!node) return [{ text: `${cmd}: cannot open '${filePath}': No such file or directory`, type: 'error' }];
-  if (node.type === 'directory') return [{ text: `${cmd}: ${filePath}: Is a directory`, type: 'error' }];
+  if (!node) return [{ text: `${pfx} cannot open '${filePath}': No such file or directory`, type: 'error' }];
+  if (node.type === 'directory') return [{ text: `${pfx} ${filePath}: Is a directory`, type: 'error' }];
   const lines = node.content.split('\n');
   return (cmd === 'head' ? lines.slice(0, n) : lines.slice(-n)).map((line) => ({ text: line, type: 'output' as const }));
 }

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -648,7 +648,7 @@ function cmdGrep(state: TerminalState, args: string[]): OutputLine[] {
   }));
 }
 
-function cmdHead(state: TerminalState, args: string[]): OutputLine[] {
+function cmdHeadTail(state: TerminalState, args: string[], cmd: 'head' | 'tail'): OutputLine[] {
   let n = 10;
   let filePath = '';
   for (let i = 0; i < args.length; i++) {
@@ -656,27 +656,20 @@ function cmdHead(state: TerminalState, args: string[]): OutputLine[] {
     else if (args[i].startsWith('-n')) { n = parseInt(args[i].slice(2)) || 10; }
     else filePath = args[i];
   }
-  if (!filePath) return [{ text: 'head: missing file operand', type: 'error' }];
+  if (!filePath) return [{ text: `${cmd}: missing file operand`, type: 'error' }];
   const node = getNode(state.root, resolvePath(state, filePath));
-  if (!node) return [{ text: `head: cannot open '${filePath}': No such file or directory`, type: 'error' }];
-  if (node.type === 'directory') return [{ text: `head: ${filePath}: Is a directory`, type: 'error' }];
-  return node.content.split('\n').slice(0, n).map((line) => ({ text: line, type: 'output' as const }));
+  if (!node) return [{ text: `${cmd}: cannot open '${filePath}': No such file or directory`, type: 'error' }];
+  if (node.type === 'directory') return [{ text: `${cmd}: ${filePath}: Is a directory`, type: 'error' }];
+  const lines = node.content.split('\n');
+  return (cmd === 'head' ? lines.slice(0, n) : lines.slice(-n)).map((line) => ({ text: line, type: 'output' as const }));
+}
+
+function cmdHead(state: TerminalState, args: string[]): OutputLine[] {
+  return cmdHeadTail(state, args, 'head');
 }
 
 function cmdTail(state: TerminalState, args: string[]): OutputLine[] {
-  let n = 10;
-  let filePath = '';
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '-n' && args[i + 1]) { n = parseInt(args[i + 1]) || 10; i++; }
-    else if (args[i].startsWith('-n')) { n = parseInt(args[i].slice(2)) || 10; }
-    else filePath = args[i];
-  }
-  if (!filePath) return [{ text: 'tail: missing file operand', type: 'error' }];
-  const node = getNode(state.root, resolvePath(state, filePath));
-  if (!node) return [{ text: `tail: cannot open '${filePath}': No such file or directory`, type: 'error' }];
-  if (node.type === 'directory') return [{ text: `tail: ${filePath}: Is a directory`, type: 'error' }];
-  const lines = node.content.split('\n');
-  return lines.slice(-n).map((line) => ({ text: line, type: 'output' as const }));
+  return cmdHeadTail(state, args, 'tail');
 }
 
 function cmdWc(state: TerminalState, args: string[]): OutputLine[] {

--- a/src/app/hooks/useLessonSEO.ts
+++ b/src/app/hooks/useLessonSEO.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { Module, Lesson } from '../data/curriculum';
+
+const DEFAULT_TITLE = 'Terminal Learning — Apprends le terminal pas à pas';
+const DEFAULT_DESCRIPTION = 'Apprends les commandes du terminal gratuitement. 8 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source.';
+const DEFAULT_URL = 'https://terminallearning.dev/';
+
+function setMeta(sel: string, attr: string, val: string) {
+  const el = document.querySelector(sel);
+  if (el) el.setAttribute(attr, val);
+}
+
+export function useLessonSEO(mod: Module, lesson: Lesson, moduleId: string, lessonId: string) {
+  useEffect(() => {
+    const title = `${lesson.title} — ${mod.title} | Terminal Learning`;
+    const description = lesson.description
+      || `Apprends ${lesson.title} dans le module ${mod.title}. Exercice interactif avec émulateur terminal. Gratuit, open source.`;
+    const url = `https://terminallearning.dev/app/learn/${moduleId}/${lessonId}`;
+
+    document.title = title;
+    setMeta('meta[name="description"]', 'content', description);
+    setMeta('link[rel="canonical"]', 'href', url);
+    setMeta('meta[property="og:title"]', 'content', title);
+    setMeta('meta[property="og:description"]', 'content', description);
+    setMeta('meta[property="og:url"]', 'content', url);
+    setMeta('meta[name="twitter:title"]', 'content', title);
+    setMeta('meta[name="twitter:description"]', 'content', description);
+
+    return () => {
+      document.title = DEFAULT_TITLE;
+      setMeta('meta[name="description"]', 'content', DEFAULT_DESCRIPTION);
+      setMeta('link[rel="canonical"]', 'href', DEFAULT_URL);
+      setMeta('meta[property="og:title"]', 'content', DEFAULT_TITLE);
+      setMeta('meta[property="og:description"]', 'content', DEFAULT_DESCRIPTION);
+      setMeta('meta[property="og:url"]', 'content', DEFAULT_URL);
+      setMeta('meta[name="twitter:title"]', 'content', DEFAULT_TITLE);
+      setMeta('meta[name="twitter:description"]', 'content', DEFAULT_DESCRIPTION);
+    };
+  }, [mod, lesson, moduleId, lessonId]);
+}


### PR DESCRIPTION
## Summary

- **THI-60** — Fusionne `cmdHead` et `cmdTail` en un helper partagé `cmdHeadTail`. Les deux fonctions deviennent des wrappers d'1 ligne. Élimine la duplication du parsing `-n` et de la gestion d'erreurs.
- **THI-66** — Centralise `iconMap` dans `src/app/data/moduleIcons.ts` avec un type unifié. `Dashboard.tsx` et `Sidebar.tsx` importent depuis ce fichier au lieu de redéfinir la même map.

## Test plan

- [x] 579/579 tests passent (`npm test`)
- [ ] Validation visuelle Vercel Preview (Thierry — Dashboard + Sidebar rendus correctement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactoriser les commandes de terminal `head`/`tail` pour partager une implémentation commune et centraliser les mappages d’icônes de modules afin de les réutiliser dans le tableau de bord et la barre latérale.

Améliorations :
- Unifier les commandes de terminal `head` et `tail` derrière un helper partagé qui standardise l’analyse des arguments et la gestion des erreurs.
- Centraliser le mappage des icônes de modules dans un fichier de données dédié et faire en sorte que le tableau de bord et la barre latérale consomment cette map partagée.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor terminal head/tail commands to share a common implementation and centralize module icon mappings for reuse across the dashboard and sidebar.

Enhancements:
- Unify head and tail terminal commands behind a shared helper that standardizes argument parsing and error handling.
- Centralize the module icon mapping in a dedicated data file and have Dashboard and Sidebar consume this shared map.

</details>