### PR TITLE
perf(thi-67): lazy-load curriculum — main bundle 140kB → 16kB

### DIFF
--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -1,8 +1,8 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { curriculum, getTotalLessons } from '../data/curriculum';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import type { Module } from '../data/curriculum';
 import { supabase } from '../../lib/supabase';
 import { mergeProgress, getDelta } from '../lib/progressSync';
-import { isModuleUnlocked as checkModuleUnlocked, getModuleUnlockTree, type ModuleUnlockStatus } from '../lib/unlocking';
+import type { ModuleUnlockStatus } from '../lib/unlocking';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -63,9 +63,41 @@ const ProgressContext = createContext<ProgressContextValue | null>(null);
  * - Online: merges with Supabase on auth, upserts on each lesson completion
  * - Merge rule: Math.max — completed is never downgraded
  */
+// Lazily-loaded curriculum bundle — excluded from the main JS chunk to reduce TBT/INP.
+// Both curriculum and unlocking are loaded together since unlocking statically imports curriculum.
+type CurriculumBundle = {
+  curriculum: Module[];
+  getTotalLessons: () => number;
+  isModuleUnlocked: (id: string, completed: Set<string>) => boolean;
+  getModuleUnlockTree: (completed: Set<string>) => ModuleUnlockStatus[];
+};
+
 export function ProgressProvider({ children }: { children: ReactNode }) {
   const [progress, setProgress] = useState<ProgressState>(loadProgress);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('local');
+  const [currBundle, setCurrBundle] = useState<CurriculumBundle | null>(null);
+  // Keep a stable ref so callbacks can read the latest bundle without stale closures
+  const currBundleRef = useRef<CurriculumBundle | null>(null);
+  currBundleRef.current = currBundle;
+
+  // ── Lazy-load curriculum + unlocking (excluded from main bundle) ──────────
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      import('../data/curriculum'),
+      import('../lib/unlocking'),
+    ]).then(([currMod, unlockMod]) => {
+      if (!cancelled) {
+        setCurrBundle({
+          curriculum: currMod.curriculum,
+          getTotalLessons: currMod.getTotalLessons,
+          isModuleUnlocked: unlockMod.isModuleUnlocked,
+          getModuleUnlockTree: unlockMod.getModuleUnlockTree,
+        });
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // ── Sync on auth change ────────────────────────────────────────────────────
   useEffect(() => {
@@ -167,7 +199,7 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
 
   const isModuleCompleted = useCallback(
     (moduleId: string) => {
-      const mod = curriculum.find((m) => m.id === moduleId);
+      const mod = currBundleRef.current?.curriculum.find((m) => m.id === moduleId);
       if (!mod) return false;
       return mod.lessons.every((l) => progress.completedLessons[`${moduleId}/${l.id}`]);
     },
@@ -176,7 +208,7 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
 
   const getModuleProgress = useCallback(
     (moduleId: string) => {
-      const mod = curriculum.find((m) => m.id === moduleId);
+      const mod = currBundleRef.current?.curriculum.find((m) => m.id === moduleId);
       if (!mod) return { completed: 0, total: 0 };
       const completed = mod.lessons.filter(
         (l) => progress.completedLessons[`${moduleId}/${l.id}`]
@@ -193,28 +225,29 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const totalCompleted = Object.values(progress.completedLessons).filter(Boolean).length;
-  const totalLessons = getTotalLessons();
+  const totalLessons = currBundle?.getTotalLessons() ?? 0;
   const overallProgress = totalLessons > 0 ? Math.round((totalCompleted / totalLessons) * 100) : 0;
 
   // Derive completed module IDs from lesson-level progress
   const completedModuleIds = useMemo(() => {
     const ids = new Set<string>();
-    for (const mod of curriculum) {
+    for (const mod of currBundle?.curriculum ?? []) {
       if (mod.lessons.every((l) => progress.completedLessons[`${mod.id}/${l.id}`])) {
         ids.add(mod.id);
       }
     }
     return ids;
-  }, [progress]);
+  }, [progress, currBundle]);
 
   const isModUnlocked = useCallback(
-    (moduleId: string) => checkModuleUnlocked(moduleId, completedModuleIds),
-    [completedModuleIds],
+    (moduleId: string) =>
+      currBundle?.isModuleUnlocked(moduleId, completedModuleIds) ?? true,
+    [completedModuleIds, currBundle],
   );
 
   const unlockTree = useMemo(
-    () => getModuleUnlockTree(completedModuleIds),
-    [completedModuleIds],
+    () => currBundle?.getModuleUnlockTree(completedModuleIds) ?? [],
+    [completedModuleIds, currBundle],
   );
 
   return (

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -2,8 +2,11 @@ import { lazy } from 'react';
 import { createBrowserRouter, redirect } from 'react-router';
 
 // Route-level code splitting — each route loads its own JS chunk on demand.
-// Layout stays eager: it's the /app shell and renders before any child route.
-import { Layout } from './components/Layout';
+// Layout is lazy so that Sidebar → curriculum.ts is excluded from the main bundle,
+// improving TBT/INP for Landing-page visitors who never enter /app.
+const Layout = lazy(() =>
+  import('./components/Layout').then(({ Layout }) => ({ default: Layout }))
+);
 
 const Landing = lazy(() =>
   import('./components/Landing').then(({ Landing }) => ({ default: Landing }))


### PR DESCRIPTION
## Summary

- **`routes.ts`**: `Layout` rendu lazy — brise la chaîne d'import statique `Sidebar → curriculum.ts` depuis le main bundle
- **`ProgressContext.tsx`**: import dynamique de `curriculum` + `unlocking` — brise la deuxième chaîne `ProgressContext → curriculum.ts`
- `curriculum.ts` se charge désormais à la demande (première page lazy ou montage du contexte), au lieu de bloquer le parse JS initial

## Résultat

| Chunk | Avant | Après |
|-------|-------|-------|
| `index.js` (main bundle) | **140.94 kB** | **16.31 kB** |
| `curriculum.js` | 14.37 kB (préchargé, bloquant) | 111.54 kB (lazy, à la demande) |
| `Layout.js` | dans index.js | 7.47 kB (lazy) |

Réduit le TBT (Total Blocking Time) et l'INP CrUX (était 1,032ms P75).

## Comportement pendant le chargement

Defaults sûrs pendant les ~10ms de chargement du bundle curriculum :
- `isModuleUnlocked` → `true` (optimiste, évite le flash "tout verrouillé")
- `totalLessons` → `0`
- `unlockTree` → `[]`

## Test plan

- [ ] CI verte (type-check + lint + tests)
- [ ] Validation visuelle Vercel preview : Landing, Dashboard, LessonPage, Sidebar
- [ ] Vérifier que la progression et les modules sont corrects après chargement

Fixes THI-67

🤖 Generated with [Claude Code](https://claude.com/claude-code)