### PR TITLE
fix(auth): defer Supabase sync outside onAuthStateChange lock

### DIFF
--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -102,9 +102,58 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
   // ── Sync on auth change ────────────────────────────────────────────────────
   useEffect(() => {
     if (!supabase) return;
-    const client = supabase; // narrow to non-null for TypeScript in async callbacks
+    const client = supabase;
+    let cancelled = false;
 
-    const { data: { subscription } } = client.auth.onAuthStateChange(async (event, session) => {
+    const syncWithRemote = async (userId: string) => {
+      setSyncStatus('syncing');
+      // Abort if Supabase doesn't respond within 5 s — prevents a long yellow dot.
+      // Free-tier cold starts are typically < 3 s; 5 s gives a safe margin.
+      const controller = new AbortController();
+      const abortTimer = setTimeout(() => controller.abort(), 5_000);
+      try {
+        const { data: remote, error } = await client
+          .from('progress')
+          .select('lesson_id, completed')
+          .eq('user_id', userId)
+          .abortSignal(controller.signal);
+        clearTimeout(abortTimer);
+
+        if (cancelled) return;
+        if (error) throw error;
+
+        const local = loadProgress();
+        const merged = mergeProgress(local.completedLessons, remote ?? []);
+        const mergedState: ProgressState = { completedLessons: merged };
+
+        const delta = getDelta(local.completedLessons, remote ?? []);
+        if (delta.length > 0) {
+          const upserts = delta.map((lesson_id) => ({
+            user_id: userId,
+            lesson_id,
+            completed: true as const,
+            completed_at: new Date().toISOString(),
+          }));
+          await client.from('progress').upsert(upserts, { onConflict: 'user_id,lesson_id' });
+        }
+
+        if (cancelled) return;
+        saveProgress(mergedState);
+        setProgress(mergedState);
+        setSyncStatus('synced');
+      } catch {
+        clearTimeout(abortTimer);
+        if (!cancelled) setSyncStatus('error');
+      }
+    };
+
+    // The callback must NOT be async: gotrue-js holds an internal lock while it
+    // runs, and any awaited Supabase call inside deadlocks until a 5 s timeout
+    // — visible as "Lock not released within 5000ms" in the console and a
+    // multi-second delay on first profile sync. Defer async work with
+    // setTimeout so it runs outside the lock scope.
+    // https://supabase.com/docs/reference/javascript/auth-onauthstatechange
+    const { data: { subscription } } = client.auth.onAuthStateChange((event, session) => {
       if (!session?.user) {
         setSyncStatus('local');
         return;
@@ -115,47 +164,16 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
       // that would cause "sync..." to flash every ~50 min while the user is active.
       if (event !== 'INITIAL_SESSION' && event !== 'SIGNED_IN') return;
 
-      setSyncStatus('syncing');
-      // Abort if Supabase doesn't respond within 5 s — prevents a long yellow dot.
-      // Free-tier cold starts are typically < 3 s; 5 s gives a safe margin.
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 5_000);
-      try {
-        const { data: remote, error } = await client
-          .from('progress')
-          .select('lesson_id, completed')   // only the two columns we actually use
-          .eq('user_id', session.user.id)
-          .abortSignal(controller.signal);
-        clearTimeout(timeout);
-
-        if (error) throw error;
-
-        const local = loadProgress();
-        const merged = mergeProgress(local.completedLessons, remote ?? []);
-        const mergedState: ProgressState = { completedLessons: merged };
-
-        // Push local-only lessons to Supabase
-        const delta = getDelta(local.completedLessons, remote ?? []);
-        if (delta.length > 0) {
-          const upserts = delta.map((lesson_id) => ({
-            user_id: session.user.id,
-            lesson_id,
-            completed: true as const,
-            completed_at: new Date().toISOString(),
-          }));
-          await client.from('progress').upsert(upserts, { onConflict: 'user_id,lesson_id' });
-        }
-
-        saveProgress(mergedState);
-        setProgress(mergedState);
-        setSyncStatus('synced');
-      } catch {
-        clearTimeout(timeout);
-        setSyncStatus('error');
-      }
+      const userId = session.user.id;
+      setTimeout(() => {
+        if (!cancelled) void syncWithRemote(userId);
+      }, 0);
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
   }, []);
 
   // ── Complete a lesson + upsert to Supabase ─────────────────────────────────

--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -104,22 +104,34 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
     if (!supabase) return;
     const client = supabase;
     let cancelled = false;
+    let activeController: AbortController | null = null;
+    let activeUserId: string | null = null;
 
     const syncWithRemote = async (userId: string) => {
+      // Supersede any previous in-flight sync (rapid account switches).
+      activeController?.abort();
+      const controller = new AbortController();
+      activeController = controller;
+      activeUserId = userId;
+
       setSyncStatus('syncing');
+
       // Abort if Supabase doesn't respond within 5 s — prevents a long yellow dot.
       // Free-tier cold starts are typically < 3 s; 5 s gives a safe margin.
-      const controller = new AbortController();
       const abortTimer = setTimeout(() => controller.abort(), 5_000);
+
+      // Bail out silently if the sync was cancelled by unmount, sign-out, or
+      // a newer sync — those paths already set the correct syncStatus.
+      const superseded = () => cancelled || activeUserId !== userId;
+
       try {
         const { data: remote, error } = await client
           .from('progress')
           .select('lesson_id, completed')
           .eq('user_id', userId)
           .abortSignal(controller.signal);
-        clearTimeout(abortTimer);
 
-        if (cancelled) return;
+        if (superseded()) return;
         if (error) throw error;
 
         const local = loadProgress();
@@ -137,13 +149,15 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
           await client.from('progress').upsert(upserts, { onConflict: 'user_id,lesson_id' });
         }
 
-        if (cancelled) return;
+        if (superseded()) return;
         saveProgress(mergedState);
         setProgress(mergedState);
         setSyncStatus('synced');
       } catch {
+        if (superseded()) return;
+        setSyncStatus('error');
+      } finally {
         clearTimeout(abortTimer);
-        if (!cancelled) setSyncStatus('error');
       }
     };
 
@@ -155,6 +169,11 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
     // https://supabase.com/docs/reference/javascript/auth-onauthstatechange
     const { data: { subscription } } = client.auth.onAuthStateChange((event, session) => {
       if (!session?.user) {
+        // Sign-out or no session: abort any in-flight sync so it can't
+        // write stale state after the user has logged out.
+        activeController?.abort();
+        activeController = null;
+        activeUserId = null;
         setSyncStatus('local');
         return;
       }
@@ -172,6 +191,7 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
 
     return () => {
       cancelled = true;
+      activeController?.abort();
       subscription.unsubscribe();
     };
   }, []);


### PR DESCRIPTION
## Summary

- **Root cause** — `onAuthStateChange` callback was `async` and awaited two Supabase operations inside its body (`progress.select` + `progress.upsert`). gotrue-js holds an internal lock while the callback runs, so these awaits deadlocked until the 5 s timeout.
- **Symptom** — Console warning `Lock 'lock:sb-...-auth-token' was not released within 5000ms. Forcefully acquiring the lock to recover.` + visible slowness on first profile sync after sign-in.
- **Fix** — Keep the callback synchronous, defer async work with `setTimeout(..., 0)` so it runs outside the lock scope. Add a `cancelled` flag to skip state updates if the provider unmounts mid-sync. Pattern recommended by [Supabase docs](https://supabase.com/docs/reference/javascript/auth-onauthstatechange).

## Why a comment in the code

The deadlock is completely non-obvious — any dev later adding `async` back to "fix a type error" or to `await` another supabase call will silently re-introduce the 5 s delay. The comment explains the lock behaviour and links the docs so the constraint survives future edits.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run test` — 579/579 pass
- [x] `npm run build` — main chunk still 16.4 kB (no regression vs #77)
- [ ] Manual: sign in on preview, check console is clean (no lock warning) and syncStatus transitions local → syncing → synced in < 1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Empêcher les blocages de changement d’état d’authentification en reportant le travail de synchronisation de la progression Supabase en dehors du callback `onAuthStateChange` et en ajoutant une gestion sécurisée de l’annulation.

Corrections de bugs :
- Résout un blocage et un délai de 5 secondes causés par l’attente (`await`) d’appels Supabase directement à l’intérieur du verrou d’authentification `onAuthStateChange`.

Améliorations :
- Extrait la logique de synchronisation de la progression dans un utilitaire dédié avec gestion de l’abandon/de l’annulation afin de rendre la synchronisation de progression pilotée par l’authentification plus robuste.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent auth state change deadlocks by deferring Supabase progress sync work outside the onAuthStateChange callback and adding cancellation safety.

Bug Fixes:
- Resolve a deadlock and 5-second delay caused by awaiting Supabase calls directly inside the onAuthStateChange auth lock.

Enhancements:
- Extract progress sync logic into a dedicated helper with abort/cancellation handling to make auth-driven progress syncing more robust.

</details>