### PR TITLE
chore(sitemap): refresh domain and lastmod

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,300 +4,300 @@
   xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
 >
   <url>
-    <loc>https://terminal-learning.vercel.app/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
-      <image:loc>https://terminal-learning.vercel.app/og-image.png</image:loc>
+      <image:loc>https://terminallearning.dev/og-image.png</image:loc>
       <image:title>Terminal Learning — Apprends le terminal pas à pas</image:title>
       <image:caption>Interface de l'application avec émulateur terminal interactif</image:caption>
     </image:image>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/reference</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/reference</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/privacy</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/privacy</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/navigation/pwd</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/navigation/pwd</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/navigation/ls</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/navigation/ls</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/navigation/ls-la</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/navigation/ls-la</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/navigation/cd</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/navigation/cd</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/fichiers/mkdir</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/fichiers/mkdir</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/fichiers/touch</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/fichiers/touch</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/fichiers/cp</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/fichiers/cp</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/fichiers/mv</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/fichiers/mv</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/fichiers/rm</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/fichiers/rm</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/lecture/cat</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/lecture/cat</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/lecture/head-tail</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/lecture/head-tail</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/lecture/grep</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/lecture/grep</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/lecture/wc</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/lecture/wc</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/permissions/comprendre-permissions</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/permissions/comprendre-permissions</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/permissions/chmod</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/permissions/chmod</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/permissions/chown</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/permissions/chown</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/permissions/sudo</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/permissions/sudo</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/permissions/security-permissions</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/permissions/security-permissions</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/processus/ps</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/processus/ps</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/processus/kill</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/processus/kill</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/processus/top</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/processus/top</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/processus/background</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/processus/background</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/redirection/redirection-sortie</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/redirection/redirection-sortie</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/redirection/pipes</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/redirection/pipes</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/redirection/stderr</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/redirection/stderr</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/redirection/tee</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/redirection/tee</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/env-vars</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/env-vars</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/path-variable</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/path-variable</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/shell-config</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/shell-config</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/dotenv</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/dotenv</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/scripts</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/scripts</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/variables/cron</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/variables/cron</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/ping</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/ping</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/curl</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/curl</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/wget</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/wget</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/dns</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/dns</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/ssh</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/ssh</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://terminal-learning.vercel.app/app/learn/reseau/scp</loc>
-    <lastmod>2026-04-10</lastmod>
+    <loc>https://terminallearning.dev/app/learn/reseau/scp</loc>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary

- All 41 entries still pointed to `terminal-learning.vercel.app` — leftover drift from the domain migration to `terminallearning.dev`.
- Bump `lastmod` to 2026-04-11.
- Live canonical tags and `robots.txt` already reference `terminallearning.dev`; this only aligns the sitemap.

## Test plan

- [ ] Validate sitemap after deploy: `curl -s https://terminallearning.dev/sitemap.xml | grep -c terminallearning.dev` → 42 (41 entries + root URL element)
- [ ] Re-submit in Google Search Console if indexing stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)