### PR TITLE
fix(a11y): aria-label + role/keyboard nav on module cards (THI-69)

### DIFF
--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -146,13 +146,27 @@ export function Dashboard() {
               ? 'border-[#30363d]'
               : (MODULE_BORDER[mod.id] ?? 'border-gray-500/30 hover:border-gray-500/60');
 
+            const ariaLabel = locked
+              ? `${mod.title} — verrouillé, Niv. ${unlockStatus?.level}`
+              : `${mod.title} — ${completed}/${total} leçons`;
+
             return (
               <div
                 key={mod.id}
+                role={locked ? undefined : 'button'}
+                tabIndex={locked ? undefined : 0}
+                aria-label={ariaLabel}
+                aria-disabled={locked ? true : undefined}
                 className={`relative bg-gradient-to-br ${gradient} border ${border} rounded-xl p-4 transition-all duration-200 group ${
                   locked ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
                 }`}
                 onClick={() => !locked && navigate(`/app/learn/${mod.id}/${mod.lessons[0].id}`)}
+                onKeyDown={locked ? undefined : (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    navigate(`/app/learn/${mod.id}/${mod.lessons[0].id}`);
+                  }
+                }}
               >
                 <div className="flex items-start justify-between mb-3">
                   <div className="flex items-center gap-3">

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -132,6 +132,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 {/* Module header */}
                 <button
                   onClick={() => !locked && toggleModule(mod.id)}
+                  aria-disabled={locked ? true : undefined}
+                  aria-label={locked
+                    ? `${mod.title} — verrouillé, Niv. ${unlockStatus?.level}`
+                    : `${mod.title} — ${completed}/${total} leçons`}
                   className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors group ${
                     locked
                       ? 'cursor-not-allowed text-[#8b949e]'


### PR DESCRIPTION
## Summary

- **Dashboard** module cards: ajout `role=button`, `tabIndex={0}`, `onKeyDown` (Enter/Space), `aria-label` incluant titre + progression (`Navigation — 0/5 leçons`), `aria-disabled=true` sur modules verrouillés
- **Sidebar** module buttons: ajout `aria-label` cohérent avec le texte visible + `aria-disabled=true` sur modules verrouillés
- Résout la violation axe-core **label-content-name-mismatch** (WCAG 2.5.3 Label in Name)

## Test plan

- [ ] Vérifier visuellement Dashboard + Sidebar (aucun changement visuel attendu)
- [ ] Tester navigation clavier sur les cartes modules (Tab → Enter/Space)
- [ ] Lancer audit Lighthouse accessibility — score ≥ 97 attendu
- [ ] Vérifier axe-core : zéro violation label-content-name-mismatch

Closes THI-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)