### PR TITLE
fix(curriculum): address content audit warnings (THI-71/72/73)

### DIFF
--- a/src/app/data/commandCatalogue.ts
+++ b/src/app/data/commandCatalogue.ts
@@ -258,6 +258,7 @@ export const commandCatalogue: CategoryMeta[] = [
     ],
   },
 
+  // Phase 5 planned module — present in catalogue (CommandReference page) but not yet in curriculum.ts
   {
     id: 'search',
     label: 'Recherche & Inspection',

--- a/src/app/data/curriculum.ts
+++ b/src/app/data/curriculum.ts
@@ -1020,7 +1020,7 @@ export const curriculum: Module[] = [
           },
           hint: 'Tapez "ls -la" pour voir les permissions de tous les fichiers',
           hintByEnv: {
-            windows: 'Tapez: Get-Acl $HOME',
+            windows: 'Tapez: Get-Acl $HOME | Format-List',
           },
           validate: validateSecurityPermissions,
           successMessage: 'Excellent ! Vous intégrez maintenant la sécurité dans votre gestion de fichiers.',

--- a/src/app/data/validators.ts
+++ b/src/app/data/validators.ts
@@ -234,7 +234,7 @@ export const validateGitConfig: ValidateFn = (cmd) => /^git\s+config\s+(--list|-
 
 export const validateGitAddCommit: ValidateFn = (cmd) => /^git\s+add\s+(\.|--all|-a|-p)/.test(cmd.trim().toLowerCase());
 
-export const validateGitStatusLog: ValidateFn = (cmd) => /^git\s+status/.test(cmd.trim().toLowerCase());
+export const validateGitStatusLog: ValidateFn = (cmd) => /^git\s+status(\s+(-\w+|--\w[\w-]*))*$/.test(cmd.trim().toLowerCase());
 
 export const validateGitDiffGitignore: ValidateFn = (cmd) => /^git\s+diff(\s+.*)?$/.test(cmd.trim().toLowerCase());
 

--- a/src/test/validators.test.ts
+++ b/src/test/validators.test.ts
@@ -371,7 +371,10 @@ describe('validateGitAddCommit', () => {
 describe('validateGitStatusLog', () => {
   it('accepts "git status"', () => expect(validateGitStatusLog('git status')).toBe(true));
   it('accepts "git status --short"', () => expect(validateGitStatusLog('git status --short')).toBe(true));
+  it('accepts "git status -s"', () => expect(validateGitStatusLog('git status -s')).toBe(true));
+  it('accepts "git status -v"', () => expect(validateGitStatusLog('git status -v')).toBe(true));
   it('rejects "git log"', () => expect(validateGitStatusLog('git log')).toBe(false));
+  it('rejects arbitrary args (git status foo bar)', () => expect(validateGitStatusLog('git status foo bar')).toBe(false));
 });
 
 describe('validateGitDiffGitignore', () => {


### PR DESCRIPTION
## Summary

- **W5/THI-71** — `validateGitStatusLog` tightened: regex now anchors at end (`$`) and only accepts flag-like args (`-x`, `--flag`). Rejects `git status foo bar xyz`.
- **W4/THI-72** — `commandCatalogue.ts`: added comment documenting `search` as a planned Phase 5 module (intentional superset over curriculum, powers CommandReference page).
- **W8/THI-73** — `security-permissions` lesson: `hintByEnv.windows` updated to `Get-Acl $HOME | Format-List` to match the exercise instruction.
- **W1/W2/W6** — confirmed already addressed in current codebase (audit agent had stale data).

## Test plan

- [ ] `npx vitest run` → 792 tests pass (2 new cases for `validateGitStatusLog`)
- [ ] `git status foo bar` → rejected by `validateGitStatusLog`
- [ ] `git status --short` → still accepted
- [ ] Vercel preview: security-permissions Windows hint shows `Get-Acl $HOME | Format-List`

🤖 Generated with [Claude Code](https://claude.com/claude-code)