### PR TITLE
feat(landing): Share button — Web Share API + clipboard fallback (THI-75)

### DIFF
--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -5,7 +5,7 @@ import {
   Terminal, ChevronRight, Github, BookOpen, Zap, Shield, Heart,
   CheckCircle2, Clock, Star, Coffee, ShieldCheck, Lock, Infinity,
   Compass, FolderOpen, FileText, Cpu, GitMerge, GitBranch, GitFork, Globe,
-  Monitor, LogIn,
+  Monitor, LogIn, Share2, Check,
 } from 'lucide-react';
 
 // ── Environment icon helper ──────────────────────────────────────────────────
@@ -221,6 +221,23 @@ export function Landing() {
   const { syncStatus } = useProgress();
   const [loginOpen, setLoginOpen] = useState(false);
   const { selectedEnv, setEnvironment } = useEnvironment();
+  const [shared, setShared] = useState(false);
+
+  const handleShare = async () => {
+    const url = 'https://terminallearning.dev';
+    const text = 'Apprends le terminal gratuitement — 10 modules interactifs, Linux / macOS / Windows.';
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'Terminal Learning', text, url });
+      } catch {
+        // user cancelled — no action needed
+      }
+    } else {
+      await navigator.clipboard.writeText(url);
+      setShared(true);
+      setTimeout(() => setShared(false), 2000);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]" style={{ fontFamily: 'Inter, sans-serif' }}>
@@ -387,6 +404,24 @@ export function Landing() {
             >
               <Compass size={16} aria-hidden="true" />
               Voir la roadmap
+            </button>
+
+            <button
+              onClick={handleShare}
+              className="flex items-center gap-2 px-6 py-3.5 rounded-xl border border-[#30363d] hover:border-[#8b949e]/40 text-[#8b949e] hover:text-[#e6edf3] font-medium text-base transition-all"
+              aria-label="Partager Terminal Learning"
+            >
+              {shared ? (
+                <>
+                  <Check size={16} className="text-emerald-400" aria-hidden="true" />
+                  <span className="text-emerald-400">Lien copié !</span>
+                </>
+              ) : (
+                <>
+                  <Share2 size={16} aria-hidden="true" />
+                  Partager
+                </>
+              )}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds a **Partager** button in the hero CTA row on the Landing page
- Uses `navigator.share()` on mobile/supported browsers (native share sheet)
- Falls back to `navigator.clipboard.writeText()` on desktop — shows "Lien copié !" with a green checkmark for 2 s
- Zero dependencies, ~18 lines of logic

## Test plan

- [ ] Mobile (Android/iOS): tap Partager → native share sheet opens with URL + text
- [ ] Desktop Chrome/Firefox: click Partager → "Lien copié !" feedback appears for 2 s, URL in clipboard
- [ ] Desktop Safari: same clipboard fallback (navigator.share not available on desktop Safari)
- [ ] Keyboard: button is focusable and activatable via Enter/Space
- [ ] Visual: button aligns correctly in the flex CTA row on all breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)