### PR TITLE
refactor: generate getHelpText from CMD_HELP + extract Landing static data (THI-61/62)

### DIFF
--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -2,11 +2,22 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { motion } from 'motion/react';
 import {
-  Terminal, ChevronRight, Github, BookOpen, Zap, Shield, Heart,
-  CheckCircle2, Clock, Star, Coffee, ShieldCheck, Lock, Infinity,
-  Compass, FolderOpen, FileText, Cpu, GitMerge, GitBranch, GitFork, Globe,
-  Monitor, LogIn, Share2, Check,
+  Terminal, ChevronRight, Github, BookOpen,
+  CheckCircle2, Zap, Clock, Star, Coffee, Heart,
+  Compass, Monitor, LogIn, Share2, Check,
 } from 'lucide-react';
+import { TerminalPreview } from './landing/TerminalPreview';
+import { useAuth } from '../context/AuthContext';
+import { useProgress } from '../context/ProgressContext';
+import { UserMenu } from './auth/UserMenu';
+import { LoginModal } from './auth/LoginModal';
+import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
+import {
+  TOTAL_LESSONS, TOTAL_COMMANDS,
+  FEATURES, ROADMAP_AVAILABLE, ROADMAP_IN_PROGRESS, ROADMAP_PLANNED,
+  SUPPORTERS, TRUST_BADGES, MODULE_ICONS, LEVEL_BADGE, STATS, ENV_LEVELS,
+} from '../data/landingContent';
+import { curriculum } from '../data/curriculum';
 
 // ── Environment icon helper ──────────────────────────────────────────────────
 
@@ -15,202 +26,6 @@ function EnvIcon({ envId, size = 14 }: { envId: SelectedEnvironment; size?: numb
   if (envId === 'macos') return <span className="text-[13px] leading-none select-none" aria-hidden="true"></span>;
   return <span className="text-[11px] leading-none select-none" aria-hidden="true">⊞</span>;
 }
-import { curriculum } from '../data/curriculum';
-import { commandCatalogue } from '../data/commandCatalogue';
-import { ENVIRONMENTS } from '../types/curriculum';
-import { TerminalPreview } from './landing/TerminalPreview';
-import { useAuth } from '../context/AuthContext';
-import { useProgress } from '../context/ProgressContext';
-import { UserMenu } from './auth/UserMenu';
-import { LoginModal } from './auth/LoginModal';
-import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
-
-// ── Static data ──────────────────────────────────────────────────────────────
-
-const TOTAL_LESSONS = curriculum.reduce((sum, mod) => sum + mod.lessons.length, 0);
-const TOTAL_COMMANDS = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
-const ACTIVE_ENVIRONMENTS = ENVIRONMENTS.filter((e) => e.status === 'active');
-
-const FEATURES = [
-  {
-    icon: Terminal,
-    title: 'Émulateur terminal réel',
-    description: 'Pratique les commandes dans un vrai terminal interactif — pas de la théorie, de la pratique.',
-    color: 'text-emerald-400',
-    border: 'border-emerald-500/20',
-    bg: 'bg-emerald-500/5',
-  },
-  {
-    icon: BookOpen,
-    title: `${TOTAL_COMMANDS}+ commandes documentées`,
-    description: 'Chaque commande avec syntaxe, exemples, erreurs courantes et variantes par environnement.',
-    color: 'text-blue-400',
-    border: 'border-blue-500/20',
-    bg: 'bg-blue-500/5',
-  },
-  {
-    icon: Zap,
-    title: 'Progression sauvegardée',
-    description: "Reprends exactement où tu t'es arrêté. Connexion optionnelle pour synchroniser entre appareils.",
-    color: 'text-amber-400',
-    border: 'border-amber-500/20',
-    bg: 'bg-amber-500/5',
-  },
-  {
-    icon: Shield,
-    title: '100% gratuit & open source',
-    description: "Pas d'inscription obligatoire, pas de paywall, pas de tracking agressif. Juste apprendre.",
-    color: 'text-purple-400',
-    border: 'border-purple-500/20',
-    bg: 'bg-purple-500/5',
-  },
-];
-
-const ROADMAP_AVAILABLE = [
-  '10 modules progressifs (navigation → GitHub)',
-  'Terminal interactif avec validation',
-  'Dashboard de progression',
-  'Sauvegarde locale + cloud (optionnel)',
-  `Référence enrichie (${TOTAL_COMMANDS}+ commandes)`,
-  'Parcours guidé par niveaux',
-  'Sélection d\'environnement Linux / macOS / Windows',
-  'Adaptation des commandes par OS',
-];
-
-const ROADMAP_IN_PROGRESS = [
-  "Plus d'exercices pratiques",
-  'Quiz par section',
-  'Agent IA tuteur (BYOK)',
-  'Terminal Sentinel — audit sécurité automatisé',
-];
-
-const ROADMAP_PLANNED = [
-  'Mode histoire narratif',
-  'Multilingue (EN / NL)',
-  'Badges et défis',
-  'Révisions intelligentes',
-  'Parcours avancés (Docker, scripting, IA)',
-];
-
-const SUPPORTERS: string[] = [
-  // Populated when Hall of Fame is active
-];
-
-const TRUST_BADGES = [
-  { icon: ShieldCheck, label: 'A+ Security Rating', href: undefined },
-  {
-    icon: Github,
-    label: '100% Open Source',
-    href: 'https://github.com/thierryvm/TerminalLearning',
-  },
-  { icon: Infinity, label: 'Free Forever', href: undefined },
-  { icon: Lock, label: 'GDPR Compliant', href: undefined },
-] as const;
-
-const MODULE_ICONS: Record<string, React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
-  Compass,
-  FolderOpen,
-  FileText,
-  Shield,
-  Cpu,
-  GitMerge,
-  GitBranch,
-  GitFork,
-  Globe,
-};
-
-const LEVEL_BADGE: Record<number, { label: string; text: string; border: string; bg: string }> = {
-  1: { label: 'Niveau 1', text: 'text-emerald-400', border: 'border-emerald-500/30', bg: 'bg-emerald-500/10' },
-  2: { label: 'Niveau 2', text: 'text-blue-400', border: 'border-blue-500/30', bg: 'bg-blue-500/10' },
-};
-
-const STATS = [
-  { value: String(curriculum.length), label: 'Modules', icon: BookOpen },
-  { value: String(TOTAL_LESSONS), label: 'Leçons', icon: FileText },
-  { value: `${TOTAL_COMMANDS}+`, label: 'Commandes', icon: Terminal },
-  { value: String(ACTIVE_ENVIRONMENTS.length), label: 'Environnements', icon: Monitor },
-];
-
-/** Competency levels showcased per environment in the hero */
-const ENV_LEVELS: Record<SelectedEnvironment, {
-  level: number;
-  label: string;
-  description: string;
-  commands: string[];
-  color: string;
-  bg: string;
-  border: string;
-}[]> = {
-  linux: [
-    {
-      level: 1,
-      label: 'Navigation & fichiers',
-      description: 'Tu te déplaces, crées, copies et lis des fichiers — tu n\'es plus perdu dans un terminal.',
-      commands: ['pwd', 'ls', 'ls -la', 'cd', 'mkdir', 'touch', 'cp', 'mv', 'rm', 'cat', 'less', 'echo'],
-      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
-    },
-    {
-      level: 2,
-      label: 'Système & recherche',
-      description: 'Tu surveilles les processus, filtres les contenus et chaînes les commandes — usage développeur quotidien.',
-      commands: ['chmod', 'chown', 'ps aux', 'grep', 'grep -r', 'find', 'kill', 'killall', '|', '>', '>>', 'wc -l'],
-      color: 'text-blue-400', bg: 'bg-blue-500/5', border: 'border-blue-500/20',
-    },
-    {
-      level: 3,
-      label: 'Automatisation & réseau',
-      description: 'Tu scripts, te connectes à distance et déploies — workflows de professionnel Linux.',
-      commands: ['ssh', 'scp', 'curl', 'wget', 'git', 'bash script.sh', 'export', 'env', 'tar -czf', 'cron', 'systemctl'],
-      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
-    },
-  ],
-  macos: [
-    {
-      level: 1,
-      label: 'Navigation & fichiers',
-      description: 'Tu te déplaces dans le système de fichiers macOS et ouvres des apps depuis le terminal.',
-      commands: ['pwd', 'ls', 'ls -la', 'cd', 'mkdir', 'touch', 'cp', 'mv', 'rm', 'cat', 'open', 'echo'],
-      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
-    },
-    {
-      level: 2,
-      label: 'Système & outils macOS',
-      description: 'Tu contrôles les processus, searches dans les fichiers et utilises les outils natifs macOS.',
-      commands: ['chmod', 'ps aux', 'grep', 'grep -r', 'find', 'kill', '|', '>', 'open -a', 'pbcopy', 'pbpaste', 'defaults read'],
-      color: 'text-violet-400', bg: 'bg-violet-500/5', border: 'border-violet-500/20',
-    },
-    {
-      level: 3,
-      label: 'Homebrew & automatisation',
-      description: 'Tu gères les packages, configures le système et automatises tes workflows macOS.',
-      commands: ['brew install', 'brew update', 'brew list', 'ssh', 'git', 'launchctl', 'caffeinate', 'defaults write', 'xcode-select', 'curl', 'xargs'],
-      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
-    },
-  ],
-  windows: [
-    {
-      level: 1,
-      label: 'Navigation & fichiers',
-      description: 'Tu navigues dans PowerShell, crées et lis des fichiers — les bases solides de Windows.',
-      commands: ['Get-Location', 'Set-Location', 'Get-ChildItem', 'dir', 'mkdir', 'New-Item', 'Get-Content', 'Copy-Item', 'Move-Item', 'Remove-Item', 'Write-Host', 'Clear-Host'],
-      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
-    },
-    {
-      level: 2,
-      label: 'Système & recherche',
-      description: 'Tu gères les processus, services, filtres les données et rediriges les flux PowerShell.',
-      commands: ['Get-Process', 'Stop-Process', 'Get-Service', 'Start-Service', 'Select-String', 'Where-Object', '|', 'Out-File', 'Set-ExecutionPolicy', 'Get-Acl', 'tasklist', 'netstat'],
-      color: 'text-sky-400', bg: 'bg-sky-500/5', border: 'border-sky-500/20',
-    },
-    {
-      level: 3,
-      label: 'Développeur & automatisation',
-      description: 'Tu installes des outils, scriptes des tâches et maîtrises l\'environnement développeur Windows.',
-      commands: ['winget install', 'Invoke-WebRequest', 'ssh', 'git', '$env:PATH', 'Set-Item env:', 'Start-Job', 'Get-EventLog', 'Register-ScheduledTask', 'Invoke-Expression', 'New-PSDrive'],
-      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
-    },
-  ],
-};
 
 // ── Component ────────────────────────────────────────────────────────────────
 

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -1,0 +1,209 @@
+import type { ComponentType } from 'react';
+import {
+  Terminal, BookOpen, Zap, Shield,
+  ShieldCheck, Github, Infinity, Lock,
+  Compass, FolderOpen, FileText, Cpu, GitMerge, GitBranch, GitFork, Globe,
+  Monitor,
+} from 'lucide-react';
+import { curriculum } from './curriculum';
+import { commandCatalogue } from './commandCatalogue';
+import { ENVIRONMENTS } from '../types/curriculum';
+import type { SelectedEnvironment } from '../context/EnvironmentContext';
+
+// ── Computed totals ───────────────────────────────────────────────────────────
+
+export const TOTAL_LESSONS = curriculum.reduce((sum, mod) => sum + mod.lessons.length, 0);
+export const TOTAL_COMMANDS = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
+export const ACTIVE_ENVIRONMENTS = ENVIRONMENTS.filter((e) => e.status === 'active');
+
+// ── Features ──────────────────────────────────────────────────────────────────
+
+export const FEATURES = [
+  {
+    icon: Terminal,
+    title: 'Émulateur terminal réel',
+    description: 'Pratique les commandes dans un vrai terminal interactif — pas de la théorie, de la pratique.',
+    color: 'text-emerald-400',
+    border: 'border-emerald-500/20',
+    bg: 'bg-emerald-500/5',
+  },
+  {
+    icon: BookOpen,
+    title: `${TOTAL_COMMANDS}+ commandes documentées`,
+    description: 'Chaque commande avec syntaxe, exemples, erreurs courantes et variantes par environnement.',
+    color: 'text-blue-400',
+    border: 'border-blue-500/20',
+    bg: 'bg-blue-500/5',
+  },
+  {
+    icon: Zap,
+    title: 'Progression sauvegardée',
+    description: "Reprends exactement où tu t'es arrêté. Connexion optionnelle pour synchroniser entre appareils.",
+    color: 'text-amber-400',
+    border: 'border-amber-500/20',
+    bg: 'bg-amber-500/5',
+  },
+  {
+    icon: Shield,
+    title: '100% gratuit & open source',
+    description: "Pas d'inscription obligatoire, pas de paywall, pas de tracking agressif. Juste apprendre.",
+    color: 'text-purple-400',
+    border: 'border-purple-500/20',
+    bg: 'bg-purple-500/5',
+  },
+];
+
+// ── Roadmap ───────────────────────────────────────────────────────────────────
+
+export const ROADMAP_AVAILABLE = [
+  '10 modules progressifs (navigation → GitHub)',
+  'Terminal interactif avec validation',
+  'Dashboard de progression',
+  'Sauvegarde locale + cloud (optionnel)',
+  `Référence enrichie (${TOTAL_COMMANDS}+ commandes)`,
+  "Sélection d'environnement Linux / macOS / Windows",
+  'Adaptation des commandes par OS',
+  'Parcours guidé par niveaux',
+];
+
+export const ROADMAP_IN_PROGRESS = [
+  "Plus d'exercices pratiques",
+  'Quiz par section',
+  'Agent IA tuteur (BYOK)',
+  'Terminal Sentinel — audit sécurité automatisé',
+];
+
+export const ROADMAP_PLANNED = [
+  'Mode histoire narratif',
+  'Multilingue (EN / NL)',
+  'Badges et défis',
+  'Révisions intelligentes',
+  'Parcours avancés (Docker, scripting, IA)',
+];
+
+// ── Supporters (Hall of Fame) ─────────────────────────────────────────────────
+
+export const SUPPORTERS: string[] = [
+  // Populated when Hall of Fame is active
+];
+
+// ── Trust badges ──────────────────────────────────────────────────────────────
+
+export const TRUST_BADGES = [
+  { icon: ShieldCheck, label: 'A+ Security Rating', href: undefined },
+  { icon: Github, label: '100% Open Source', href: 'https://github.com/thierryvm/TerminalLearning' },
+  { icon: Infinity, label: 'Free Forever', href: undefined },
+  { icon: Lock, label: 'GDPR Compliant', href: undefined },
+] as const;
+
+// ── Module icons map ──────────────────────────────────────────────────────────
+
+export const MODULE_ICONS: Record<string, ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
+  Compass,
+  FolderOpen,
+  FileText,
+  Shield,
+  Cpu,
+  GitMerge,
+  GitBranch,
+  GitFork,
+  Globe,
+};
+
+// ── Level badge styles ────────────────────────────────────────────────────────
+
+export const LEVEL_BADGE: Record<number, { label: string; text: string; border: string; bg: string }> = {
+  1: { label: 'Niveau 1', text: 'text-emerald-400', border: 'border-emerald-500/30', bg: 'bg-emerald-500/10' },
+  2: { label: 'Niveau 2', text: 'text-blue-400', border: 'border-blue-500/30', bg: 'bg-blue-500/10' },
+};
+
+// ── Stats bar ─────────────────────────────────────────────────────────────────
+
+export const STATS = [
+  { value: String(curriculum.length), label: 'Modules', icon: BookOpen },
+  { value: String(TOTAL_LESSONS), label: 'Leçons', icon: FileText },
+  { value: `${TOTAL_COMMANDS}+`, label: 'Commandes', icon: Terminal },
+  { value: String(ACTIVE_ENVIRONMENTS.length), label: 'Environnements', icon: Monitor },
+];
+
+// ── Competency levels per environment (hero section) ─────────────────────────
+
+export const ENV_LEVELS: Record<SelectedEnvironment, {
+  level: number;
+  label: string;
+  description: string;
+  commands: string[];
+  color: string;
+  bg: string;
+  border: string;
+}[]> = {
+  linux: [
+    {
+      level: 1,
+      label: 'Navigation & fichiers',
+      description: "Tu te déplaces, crées, copies et lis des fichiers — tu n'es plus perdu dans un terminal.",
+      commands: ['pwd', 'ls', 'ls -la', 'cd', 'mkdir', 'touch', 'cp', 'mv', 'rm', 'cat', 'less', 'echo'],
+      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
+    },
+    {
+      level: 2,
+      label: 'Système & recherche',
+      description: 'Tu surveilles les processus, filtres les contenus et chaînes les commandes — usage développeur quotidien.',
+      commands: ['chmod', 'chown', 'ps aux', 'grep', 'grep -r', 'find', 'kill', 'killall', '|', '>', '>>', 'wc -l'],
+      color: 'text-blue-400', bg: 'bg-blue-500/5', border: 'border-blue-500/20',
+    },
+    {
+      level: 3,
+      label: 'Automatisation & réseau',
+      description: 'Tu scripts, te connectes à distance et déploies — workflows de professionnel Linux.',
+      commands: ['ssh', 'scp', 'curl', 'wget', 'git', 'bash script.sh', 'export', 'env', 'tar -czf', 'cron', 'systemctl'],
+      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
+    },
+  ],
+  macos: [
+    {
+      level: 1,
+      label: 'Navigation & fichiers',
+      description: 'Tu te déplaces dans le système de fichiers macOS et ouvres des apps depuis le terminal.',
+      commands: ['pwd', 'ls', 'ls -la', 'cd', 'mkdir', 'touch', 'cp', 'mv', 'rm', 'cat', 'open', 'echo'],
+      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
+    },
+    {
+      level: 2,
+      label: 'Système & outils macOS',
+      description: 'Tu contrôles les processus, searches dans les fichiers et utilises les outils natifs macOS.',
+      commands: ['chmod', 'ps aux', 'grep', 'grep -r', 'find', 'kill', '|', '>', 'open -a', 'pbcopy', 'pbpaste', 'defaults read'],
+      color: 'text-violet-400', bg: 'bg-violet-500/5', border: 'border-violet-500/20',
+    },
+    {
+      level: 3,
+      label: 'Homebrew & automatisation',
+      description: 'Tu gères les packages, configures le système et automatises tes workflows macOS.',
+      commands: ['brew install', 'brew update', 'brew list', 'ssh', 'git', 'launchctl', 'caffeinate', 'defaults write', 'xcode-select', 'curl', 'xargs'],
+      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
+    },
+  ],
+  windows: [
+    {
+      level: 1,
+      label: 'Navigation & fichiers',
+      description: 'Tu navigues dans PowerShell, crées et lis des fichiers — les bases solides de Windows.',
+      commands: ['Get-Location', 'Set-Location', 'Get-ChildItem', 'dir', 'mkdir', 'New-Item', 'Get-Content', 'Copy-Item', 'Move-Item', 'Remove-Item', 'Write-Host', 'Clear-Host'],
+      color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20',
+    },
+    {
+      level: 2,
+      label: 'Système & recherche',
+      description: 'Tu gères les processus, services, filtres les données et rediriges les flux PowerShell.',
+      commands: ['Get-Process', 'Stop-Process', 'Get-Service', 'Start-Service', 'Select-String', 'Where-Object', '|', 'Out-File', 'Set-ExecutionPolicy', 'Get-Acl', 'tasklist', 'netstat'],
+      color: 'text-sky-400', bg: 'bg-sky-500/5', border: 'border-sky-500/20',
+    },
+    {
+      level: 3,
+      label: 'Développeur & automatisation',
+      description: "Tu installes des outils, scriptes des tâches et maîtrises l'environnement développeur Windows.",
+      commands: ['winget install', 'Invoke-WebRequest', 'ssh', 'git', '$env:PATH', 'Set-Item env:', 'Start-Job', 'Get-EventLog', 'Register-ScheduledTask', 'Invoke-Expression', 'New-PSDrive'],
+      color: 'text-purple-400', bg: 'bg-purple-500/5', border: 'border-purple-500/20',
+    },
+  ],
+};

--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -1127,6 +1127,28 @@ const CMD_HELP: Record<string, CmdHelp> = {
       macos: ['crontab -l', 'crontab -e'],
     },
   },
+  uname: {
+    synopsis: 'uname [-a]',
+    description: 'Affiche les informations du système (nom, version, architecture).',
+    examples: {
+      linux: ['uname', 'uname -a'],
+    },
+  },
+  date: {
+    synopsis: 'date',
+    description: 'Affiche la date et l\'heure courante.',
+    examples: {
+      linux: ['date'],
+      macos: ['date'],
+    },
+  },
+  pbcopy: {
+    synopsis: 'pbcopy / pbpaste',
+    description: 'Copie stdin vers / colle depuis le presse-papiers (macOS).',
+    examples: {
+      macos: ['echo "texte" | pbcopy', 'pbpaste'],
+    },
+  },
 };
 
 // Alias map: maps PS cmdlet names / aliases back to CMD_HELP keys
@@ -1147,125 +1169,91 @@ const CMD_HELP_ALIASES: Record<string, string> = {
   'tee-object': 'tee',
 };
 
+function toPascalCase(s: string): string {
+  return s.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('-');
+}
+
 function getHelpText(env: TerminalEnv = 'linux'): string {
-  if (env === 'windows') {
-    return `Commandes disponibles — PowerShell / Windows:
-  Get-Location (gl)           Afficher le répertoire courant
-  Set-Location (sl) [path]    Changer de répertoire
-  Get-ChildItem (dir)         Lister les fichiers et dossiers
-  Get-Content (gc) [file]     Afficher le contenu d'un fichier
-  New-Item (ni) [name]        Créer un fichier ou dossier
-  Copy-Item (copy) src dst    Copier un fichier
-  Move-Item (move) src dst    Déplacer / renommer
-  Remove-Item (del) [file]    Supprimer un fichier
-  Write-Host [texte]          Afficher du texte (supporte $env:VAR)
-  $env:VAR = "val"            Définir une variable d'environnement
-  Get-ChildItem Env:          Lister toutes les variables d'env
-  Start-Job { ... }           Lancer un job en arrière-plan
-  Get-Job / Stop-Job          Gérer les jobs PowerShell
-  Tee-Object -FilePath f      Afficher ET sauvegarder la sortie
-  Get-Process (gps)           Lister les processus
-  Stop-Process -Name [nom]    Arrêter un processus
-  Select-String pat file      Rechercher dans un fichier
-  Clear-Host (cls)            Effacer le terminal
-  history                     Historique des commandes
-  winget install|list         Gestionnaire de paquets
-  help [commande]             Aide sur une commande
-  about                       Informations sur le projet
-
-─────────────────────────────────────────────────────────────
-💡 Dans un vrai PowerShell, cherche de l'aide avec :
-  Get-Help <commande>   # aide complète (ex: Get-Help Get-ChildItem)
-  <commande> -?         # aide rapide
-  Get-Command           # lister toutes les commandes disponibles
-  Get-Member            # explorer les propriétés et méthodes d'un objet`;
+  // Reverse alias map: CMD_HELP key → list of PS aliases (insertion order preserved)
+  const reverseAliases: Record<string, string[]> = {};
+  for (const [alias, key] of Object.entries(CMD_HELP_ALIASES)) {
+    (reverseAliases[key] ??= []).push(alias);
   }
-  if (env === 'macos') {
-    return `Commandes disponibles — macOS / zsh:
-  pwd              Afficher le répertoire courant
-  ls [-la] [path]  Lister les fichiers (-l: détails, -a: cachés)
-  cd [chemin]      Changer de répertoire
-  mkdir [-p] [nom] Créer un répertoire
-  touch [nom]      Créer un fichier
-  cat [file]       Afficher le contenu d'un fichier
-  echo [texte]     Afficher du texte (supporte $VAR)
-  rm [-r] [file]   Supprimer un fichier
-  cp [-r] src dst  Copier
-  mv src dst       Déplacer / renommer
-  grep [-ni] p f   Rechercher dans un fichier
-  head / tail      Début / fin d'un fichier (-n N)
-  wc [-lwc] [file] Compter lignes/mots/octets
-  chmod m file     Changer les permissions
-  export [VAR=val] Définir une variable d'environnement
-  env / printenv   Afficher les variables d'environnement
-  source ~/.zshrc  Recharger la configuration shell
-  crontab [-l|-e]  Gérer les tâches planifiées
-  chown u[:g] f    Changer le propriétaire d'un fichier
-  sudo commande    Exécuter avec les droits root
-  top / htop       Monitoring processus en temps réel
-  jobs / fg / bg   Gérer les processus en arrière-plan
-  tee [-a] fichier Afficher ET sauvegarder la sortie
-  open [file|URL]  Ouvrir avec l'app par défaut
-  pbcopy/pbpaste   Presse-papiers
-  brew install|list Gestionnaire de paquets Homebrew
-  ps [aux]         Lister les processus
-  kill [PID]       Arrêter un processus
-  history          Historique des commandes
-  clear            Effacer le terminal
-  help [commande]  Aide sur une commande
-  about            Informations sur le projet
 
-─────────────────────────────────────────────────────────────
-💡 Dans un vrai terminal macOS, cherche de l'aide avec :
-  man <commande>       # manuel complet (q pour quitter)
-  <commande> --help    # aide rapide
-  whatis <commande>    # description en une ligne
-  apropos <mot-clé>    # trouver une commande par description`;
+  const COL = 28;
+  // Commands whose bash synopsis would be misleading in Windows context —
+  // they are covered by the specialByEnv.windows entries instead
+  const SKIP_WINDOWS = new Set(['jobs', 'export', 'env', 'printenv', 'source']);
+
+  const cmdLines: string[] = [];
+  for (const [key, entry] of Object.entries(CMD_HELP)) {
+    if (!entry.examples?.[env]) continue;
+    if (env === 'windows' && SKIP_WINDOWS.has(key)) continue;
+
+    let synopsis: string;
+    if (env === 'windows') {
+      const aliases = reverseAliases[key] ?? [];
+      const fullName = aliases.find((a) => a.includes('-'));
+      const shortAlias = aliases.find((a) => !a.includes('-'));
+      synopsis = fullName
+        ? shortAlias ? `${toPascalCase(fullName)} (${shortAlias})` : toPascalCase(fullName)
+        : entry.synopsis;
+    } else {
+      synopsis = entry.synopsis;
+    }
+    cmdLines.push(`  ${synopsis.padEnd(COL)}${entry.description}`);
   }
-  // linux (default)
-  return `Commandes disponibles — Linux / bash:
-  pwd              Afficher le répertoire courant
-  ls [-la] [path]  Lister les fichiers (-l: détails, -a: cachés)
-  cd [chemin]      Changer de répertoire
-  mkdir [-p] [nom] Créer un répertoire
-  touch [nom]      Créer un fichier
-  cat [file]       Afficher le contenu d'un fichier
-  echo [texte]     Afficher du texte (supporte $VAR)
-  rm [-r] [file]   Supprimer un fichier (-r: répertoire)
-  cp [-r] src dst  Copier un fichier
-  mv src dst       Déplacer / renommer
-  grep [-ni] p f   Rechercher dans un fichier
-  head / tail      Début / fin d'un fichier (-n N)
-  wc [-lwc] [file] Compter lignes/mots/octets
-  chmod m file     Changer les permissions
-  export [VAR=val] Définir une variable d'environnement
-  env / printenv   Afficher les variables d'environnement
-  source fichier   Recharger la configuration shell
-  crontab [-l|-e]  Gérer les tâches planifiées
-  chown u[:g] f    Changer le propriétaire d'un fichier
-  sudo commande    Exécuter avec les droits root
-  top / htop       Monitoring processus en temps réel
-  jobs / fg / bg   Gérer les processus en arrière-plan
-  tee [-a] fichier Afficher ET sauvegarder la sortie
-  whoami           Utilisateur courant
-  date             Date et heure
-  uname [-a]       Informations système
-  ps [aux]         Lister les processus
-  kill [PID]       Arrêter un processus
-  history          Historique des commandes
-  clear            Effacer le terminal
-  man [commande]   Manuel d'une commande
-  help [commande]  Aide sur une commande
-  about            Informations sur le projet
-  donate / support Soutenir le projet
-  hall-of-fame     Liste des contributeurs
 
-─────────────────────────────────────────────────────────────
+  const specialByEnv: Record<TerminalEnv, string[]> = {
+    linux: [
+      `  ${'man [commande]'.padEnd(COL)}Manuel d'une commande`,
+      `  ${'help [commande]'.padEnd(COL)}Aide sur une commande`,
+      `  ${'about'.padEnd(COL)}Informations sur le projet`,
+      `  ${'donate / support'.padEnd(COL)}Soutenir le projet`,
+      `  ${'hall-of-fame'.padEnd(COL)}Liste des contributeurs`,
+    ],
+    macos: [
+      `  ${'help [commande]'.padEnd(COL)}Aide sur une commande`,
+      `  ${'about'.padEnd(COL)}Informations sur le projet`,
+    ],
+    windows: [
+      `  ${'$env:VAR = "val"'.padEnd(COL)}Définir une variable d'environnement`,
+      `  ${'Get-ChildItem Env:'.padEnd(COL)}Lister toutes les variables d'env`,
+      `  ${'Start-Job { ... }'.padEnd(COL)}Lancer un job en arrière-plan`,
+      `  ${'Get-Job / Stop-Job'.padEnd(COL)}Gérer les jobs PowerShell`,
+      `  ${'help [commande]'.padEnd(COL)}Aide sur une commande`,
+      `  ${'about'.padEnd(COL)}Informations sur le projet`,
+    ],
+  };
+
+  const HEADERS: Record<TerminalEnv, string> = {
+    linux:   'Commandes disponibles — Linux / bash:',
+    macos:   'Commandes disponibles — macOS / zsh:',
+    windows: 'Commandes disponibles — PowerShell / Windows:',
+  };
+
+  const TIPS: Record<TerminalEnv, string> = {
+    linux: `─────────────────────────────────────────────────────────────
 💡 Dans un vrai terminal Linux, cherche de l'aide avec :
   man <commande>       # manuel complet (q pour quitter)
   <commande> --help    # aide rapide
   whatis <commande>    # description en une ligne
-  apropos <mot-clé>    # trouver une commande par description`;
+  apropos <mot-clé>    # trouver une commande par description`,
+    macos: `─────────────────────────────────────────────────────────────
+💡 Dans un vrai terminal macOS, cherche de l'aide avec :
+  man <commande>       # manuel complet (q pour quitter)
+  <commande> --help    # aide rapide
+  whatis <commande>    # description en une ligne
+  apropos <mot-clé>    # trouver une commande par description`,
+    windows: `─────────────────────────────────────────────────────────────
+💡 Dans un vrai PowerShell, cherche de l'aide avec :
+  Get-Help <commande>   # aide complète (ex: Get-Help Get-ChildItem)
+  <commande> -?         # aide rapide
+  Get-Command           # lister toutes les commandes disponibles
+  Get-Member            # explorer les propriétés et méthodes d'un objet`,
+  };
+
+  return [HEADERS[env], ...cmdLines, ...specialByEnv[env], '', TIPS[env]].join('\n');
 }
 
 function getCmdHelp(cmdName: string, env: TerminalEnv = 'linux'): OutputLine[] | null {


### PR DESCRIPTION
## Summary

**THI-61 — `getHelpText` dynamique**
- Remplace 120 lignes hardcodées (3 blocs quasi-identiques) par une génération dynamique depuis `CMD_HELP` + `CMD_HELP_ALIASES`
- Ajoute `uname`, `date`, `pbcopy` à `CMD_HELP` (requis par les tests existants)
- Élimine ~90 lignes de duplication — toute nouvelle commande ajoutée à `CMD_HELP` apparaît automatiquement dans `help`

**THI-62 — Extraction `landingContent.ts`**
- Crée `src/app/data/landingContent.ts` avec toutes les constantes statiques : `FEATURES`, `ROADMAP_*`, `TRUST_BADGES`, `MODULE_ICONS`, `LEVEL_BADGE`, `ENV_LEVELS`, `STATS`, totaux calculés
- `Landing.tsx` : 793 → 608 lignes (-23%), purement présentationnel

## Test plan
- [ ] 792/792 tests passent (vérifié localement)
- [ ] 0 erreurs TypeScript
- [ ] Preview Vercel : landing page visuellement identique
- [ ] `help`, `help ls`, `help get-childitem` testés dans le terminal simulé pour les 3 envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)