### PR TITLE
content(landing): update roadmap sections

### DIFF
--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -64,11 +64,13 @@ export const ROADMAP_AVAILABLE = [
   "Sélection d'environnement Linux / macOS / Windows",
   'Adaptation des commandes par OS',
   'Parcours guidé par niveaux',
+  'Partage natif (Web Share API)',
 ];
 
 export const ROADMAP_IN_PROGRESS = [
-  "Plus d'exercices pratiques",
-  'Quiz par section',
+  "Extension du curriculum — nouveaux modules & exercices",
+  "Plus d'exercices pratiques & quiz par section",
+  'Guide d\'installation PWA (iOS / Android / Desktop)',
   'Agent IA tuteur (BYOK)',
   'Terminal Sentinel — audit sécurité automatisé',
 ];


### PR DESCRIPTION
## Summary
- Add "Partage natif (Web Share API)" to **Disponible** — reflects THI-75 shipped feature
- Merge "Quiz par section" into "Plus d'exercices pratiques & quiz par section"
- Add "Extension du curriculum" and "Guide d'installation PWA (iOS / Android / Desktop)" to **En cours**

## Why
The "En cours" section was sparse relative to what's actively being built (Phase 5 curriculum expansion, THI-74 PWA guide). This brings the roadmap in line with current development priorities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)