### PR TITLE
security(csp): remove Pusher from prod CSP + cap cmdEcho env var length

### DIFF
--- a/src/app/data/terminalEngine.ts
+++ b/src/app/data/terminalEngine.ts
@@ -437,15 +437,21 @@ function cmdCat(state: TerminalState, args: string[]): OutputLine[] {
   return lines;
 }
 
+const MAX_ENV_VAR_LENGTH = 1024;
+
 function cmdEcho(args: string[], envVars?: Record<string, string>): OutputLine[] {
   const text = args.join(' ');
   if (!envVars) return [{ text, type: 'output' }];
   // Interpolate $env:VAR (PowerShell) and $VAR (bash) from envVars
-  const expanded = text.replace(/\$env:([A-Za-z_][A-Za-z0-9_]*)/g, (_, name) =>
-    Object.prototype.hasOwnProperty.call(envVars, name) ? envVars[name] : ''
-  ).replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, name) =>
-    Object.prototype.hasOwnProperty.call(envVars, name) ? envVars[name] : ''
-  );
+  // Values are capped at MAX_ENV_VAR_LENGTH to prevent terminal flooding [H3]
+  const safeVal = (name: string) => {
+    if (!Object.prototype.hasOwnProperty.call(envVars, name)) return '';
+    const v = envVars[name];
+    return v.length > MAX_ENV_VAR_LENGTH ? v.slice(0, MAX_ENV_VAR_LENGTH) + '…' : v;
+  };
+  const expanded = text
+    .replace(/\$env:([A-Za-z_][A-Za-z0-9_]*)/g, (_, name) => safeVal(name))
+    .replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, name) => safeVal(name));
   return [{ text: expanded, type: 'output' }];
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live wss://ws-us3.pusher.com https://sockjs-mt1.pusher.com; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary

- **[H2]** `vercel.json` — remove `wss://ws-us3.pusher.com` and `https://sockjs-mt1.pusher.com` from `connect-src`: these are Vercel Live preview-only WebSocket connections, not needed in production (Vercel Live injects these via its own platform layer, not via the app's CSP)
- **[H3]** `terminalEngine.ts` — add `MAX_ENV_VAR_LENGTH = 1024` cap on `$VAR` / `$env:VAR` expansion in `cmdEcho`: prevents terminal flooding via crafted env variable values

## Note on H1 (CSP unsafe-inline)

`style-src 'unsafe-inline'` cannot be removed without a full migration of Motion animations to CSS-based animations. Motion applies inline `style` attributes on DOM elements at runtime — these cannot be nonced (nonces only cover `<style>` tags, not `style` attributes). Tracked in security backlog for a dedicated refactor sprint.

## Test plan

- [ ] `terminalEngine.test.ts` — 280/280 ✅
- [ ] CI type-check + lint + test + build
- [ ] Verify Vercel preview deploys correctly (Vercel Live toolbar still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)