### PR TITLE
docs: fix typo plan.md (Sourcery) + update ROADMAP header

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Terminal Learning
 
-> Last updated: 12 April 2026 — THI-36 Terminal Sentinel ✅, THI-37 RBAC DB layer ✅, THI-76 RBAC test kit ✅, THI-80 RBAC integration tests ✅ — 10 modules / 52 lessons / 876 tests — perf: main bundle 16kB, FCP 0.6s
+> Last updated: 12 April 2026 — THI-81 Landing −112kB ✅, THI-82 Supabase lazy −194kB ✅, stale-chunk guard (Mobile Safari) ✅ — 10 modules / 52 lessons / 876 tests — perf: main bundle 16kB, FCP 0.6s
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -52,7 +52,7 @@
 | THI-76 | dev | Kit utilisateurs tests RBAC — 5 rôles complets (migration 006) ✅ Done |
 | THI-80 | test | RBAC integration tests (20) + fix 4 RLS bugs + 6 security fixes (PR #94) ✅ Done |
 | THI-81 | perf | Landing : MODULE_PREVIEWS remplace curriculum.map() — −112 kB eager (PR #96) ✅ Done |
-| THI-82 | perf | Dynamic import supabase dans AuthContext + ProgressContext — −194 kB FCP (PR #96) ✅ Done |
+| THI-82 | perf | Dynamic import de supabase dans AuthContext + ProgressContext — −194 kB FCP (PR #96) ✅ Done |
 | THI-83 | perf | INP 592ms regression (Apr 10–11) — investigation en cours 🔍 Backlog |
 | THI-77 | Phase 9 | Heatmap activité élève — vue enseignant (GitHub-style) 🔮 Backlog |
 | THI-78 | Phase 9 | Heatmap adoption plateforme — vue super_admin/institution_admin 🔮 Backlog |


### PR DESCRIPTION
## Summary
- Fix missing preposition in THI-82 description (Sourcery suggestion on PR #97)
- Update ROADMAP.md header to reflect THI-81/82 perf wins and stale-chunk guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Met à jour la documentation pour refléter les récentes améliorations de performance et corriger une petite faute de frappe dans le plan du projet.

Documentation :
- Actualiser l’en-tête de `ROADMAP` pour mettre en avant les optimisations de performance THI-81/82 et le mécanisme de protection contre les blocs obsolètes pour Mobile Safari.
- Corriger une préposition manquante dans l’entrée THI-82 de `plan.md` afin d’améliorer la formulation en français.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect recent performance improvements and correct a minor typo in the project plan.

Documentation:
- Refresh ROADMAP header to highlight THI-81/82 performance optimizations and the stale-chunk guard for Mobile Safari.
- Fix a missing preposition in the THI-82 entry in plan.md for clearer French phrasing.

</details>