### PR TITLE
security(audit): harden CSP, pin CI actions, update docs & agents

### DIFF
--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -21,6 +21,7 @@ Analyse en profondeur l'ensemble du curriculum et produis un rapport structuré 
 ### 1. Couverture des environnements
 Pour chaque leçon, vérifier la présence de `instructionByEnv`, `hintByEnv` et `contentByEnv` couvrant `linux`, `macos`, `windows`.
 - CRITICAL si un env manque sans raison légitime
+- **INFO (pas CRITICAL)** si la commande de l'exercice est une **commande simulée identique sur tous les OS** (ex: `ai-help`, `about`, `donate`, `hall-of-fame`, `help`). Ces commandes n'ont pas besoin d'`instructionByEnv` car elles fonctionnent pareil partout.
 - WARNING si une leçon est volontairement mono-OS. Heuristique : classer en WARNING (pas CRITICAL) si la commande appartient à l'une des listes suivantes :
   - Windows-only : `taskkill`, `Get-Help`, `Get-Command`, `Get-Member`, `Get-ChildItem`, `Invoke-WebRequest`, `iwr`, `Resolve-DnsName`, `wevtutil`, `Get-EventLog`
   - Linux/macOS-only : `man`, `whatis`, `apropos`, `brew`, `apt`, `dpkg`
@@ -48,6 +49,7 @@ Pour chaque exercice, la fonction `validate()` doit être non-triviale :
 - Regex trop permissive : `/.*cmd.*/` — WARNING
 - Validate toujours `true` — CRITICAL
 - Validate vide ou absente — CRITICAL
+- **IMPORTANT** : avant de signaler un validator comme "assigné à la mauvaise leçon", lire l'`instruction` de l'exercice. Si l'instruction demande une commande X et que le validator vérifie X, c'est cohérent même si le nom du validator ne correspond pas au titre de la leçon. Exemple : un exercice dans la leçon "kill" peut demander d'exécuter `ps aux` pour identifier les processus — le validator vérifie `ps`, c'est correct.
 
 ### 7. Liens externes (best-effort, limité)
 Si des URLs apparaissent dans `contentByEnv` ou `hintByEnv`, tenter une requête WebFetch sur les **10 premières URLs distinctes** uniquement.

--- a/.claude/agents/curriculum-validator.md
+++ b/.claude/agents/curriculum-validator.md
@@ -15,7 +15,8 @@ Analyse `src/app/data/curriculum.ts` et `src/test/terminalEngine.test.ts`, puis 
 2. **IDs uniques** : aucun `lessonId` ou `moduleId` dupliqué
 3. **Tests présents** : chaque commande référencée dans curriculum.ts a-t-elle un test dans terminalEngine.test.ts ?
 4. **Completeness** : modules sans leçons, leçons sans exercices, exercices sans solution attendue
-5. **ExerciseTypes (Phase 5b — futur)** : si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement : `fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`. Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.
+5. **SuccessMessage count** : le nombre de `successMessage` doit correspondre au nombre de leçons. WARNING si différent.
+6. **ExerciseTypes (Phase 5b — futur)** : si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement : `fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`. Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.
 
 ## Format de rapport obligatoire
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -186,7 +186,13 @@ Remediation attendue :
 Scanner aussi git log pour detecter des credentials anterieurement supprimes mais encore dans l'historique :
   git log --all -p -- supabase/migrations/ 2>/dev/null | grep -i "crypt(\|password\s*=" | head -20
 
-WARNING si un credential figure dans l'historique git meme si deja supprime du HEAD.
+CRITICAL si un credential figure dans l'historique git meme si deja supprime du HEAD — l'historique public est aussi exploitable que le HEAD.
+
+### Scan git history etendu (au-dela des migrations)
+Executer :
+  git log --all -p -- "*.ts" "*.tsx" "*.json" "*.env*" 2>/dev/null | grep -iE "password|secret|token|apikey|service_role" | grep -v "PLACEHOLDER\|EXAMPLE\|import.meta.env\|process.env\|test\(" | head -30
+
+WARNING si des patterns suspects apparaissent dans l'historique.
 
 ---
 
@@ -222,6 +228,20 @@ Executer :
 - npm ci utilise en CI (pas npm install) ?
 - Scripts postinstall/preinstall dans les deps directes ?
 - Packages aux noms proches de dependances reelles (typosquatting) ?
+
+### Versions des dependances critiques
+Verifier les versions actuelles des packages de securite :
+  grep -E '"@supabase/supabase-js"|"@sentry/react"|"vite"|"react-router"' package.json
+
+- @supabase/supabase-js : verifier les advisories recentes sur GitHub
+- Vite : verifier les CVEs recentes (GHSA)
+- CRITICAL si une version avec CVE connue et fix disponible est utilisee
+
+### GitHub Actions — SHA pins
+Verifier que les actions dans .github/workflows/*.yml utilisent des SHA commits (pas des tags mutables comme @v4) :
+  grep -rn "uses:" .github/workflows/ | grep -v "#" | grep "@v[0-9]"
+
+WARNING si des actions utilisent des tags mutables sans SHA pin.
 
 ---
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -186,10 +186,10 @@ Remediation attendue :
 Scanner aussi git log pour detecter des credentials anterieurement supprimes mais encore dans l'historique :
   git log --all -p -- supabase/migrations/ 2>/dev/null | grep -i "crypt(\|password\s*=" | head -20
 
-CRITICAL si un credential figure dans l'historique git meme si deja supprime du HEAD — l'historique public est aussi exploitable que le HEAD.
+CRITICAL si un credential figure dans l'historique git même si déjà supprimé du HEAD — l'historique public est aussi exploitable que le HEAD.
 
-### Scan git history etendu (au-dela des migrations)
-Executer :
+### Scan git history étendu (au-delà des migrations)
+Exécuter :
   git log --all -p -- "*.ts" "*.tsx" "*.json" "*.env*" 2>/dev/null | grep -iE "password|secret|token|apikey|service_role" | grep -v "PLACEHOLDER\|EXAMPLE\|import.meta.env\|process.env\|test\(" | head -30
 
 WARNING si des patterns suspects apparaissent dans l'historique.
@@ -229,13 +229,13 @@ Executer :
 - Scripts postinstall/preinstall dans les deps directes ?
 - Packages aux noms proches de dependances reelles (typosquatting) ?
 
-### Versions des dependances critiques
-Verifier les versions actuelles des packages de securite :
+### Versions des dépendances critiques
+Vérifier les versions actuelles des packages de sécurité :
   grep -E '"@supabase/supabase-js"|"@sentry/react"|"vite"|"react-router"' package.json
 
-- @supabase/supabase-js : verifier les advisories recentes sur GitHub
-- Vite : verifier les CVEs recentes (GHSA)
-- CRITICAL si une version avec CVE connue et fix disponible est utilisee
+- @supabase/supabase-js : vérifier les advisories récentes sur GitHub
+- Vite : vérifier les CVEs récentes (GHSA)
+- CRITICAL si une version avec CVE connue et fix disponible est utilisée
 
 ### GitHub Actions — SHA pins
 Verifier que les actions dans .github/workflows/*.yml utilisent des SHA commits (pas des tags mutables comme @v4) :

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -23,9 +23,19 @@ Extrait uniquement :
 - Tests skippés si > 5
 - Si 0 failures : confirme "✅ All N tests pass"
 
-## Étape 3 — Vérifier la couverture
+## Étape 3 — Vérifier la couverture commandes
 
 Identifie les commandes présentes dans `src/app/data/curriculum.ts` qui n'ont aucun test correspondant dans `src/test/terminalEngine.test.ts`. Compare par nom de commande (ex: `ping`, `curl`, `ssh`).
+
+## Étape 4 — Vérifier la couverture validators
+
+Identifie les fonctions `validate*` exportées dans `src/app/data/validators.ts` qui n'ont aucun test correspondant dans `src/test/validators.test.ts`. Lister les fonctions manquantes.
+
+```bash
+grep "^export const validate" src/app/data/validators.ts | sed 's/export const //' | sed 's/:.*//'
+```
+
+Comparer avec les describe/it dans validators.test.ts.
 
 ## Format de rapport obligatoire
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/security-sentinel.yml
+++ b/.github/workflows/security-sentinel.yml
@@ -20,9 +20,9 @@ jobs:
     outputs:
       status: ${{ steps.audit.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: npm-audit-report
           path: /tmp/npm-audit.json
@@ -69,13 +69,13 @@ jobs:
     outputs:
       status: ${{ steps.result.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0   # Full history required for gitleaks
 
       - name: Run gitleaks
         id: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
 - Phase 5 🔄 Curriculum expansion — 11 modules, 64 leçons, 891 tests unitaires + 176 E2E Playwright (en cours)
+- Phase 5.5 ✅ Terminal Sentinel — agents sécurité + contenu automatisés (PR #90, 12 avril 2026)
+- Phase 7 ✅ RBAC complet — student/teacher/institution_admin/super_admin + RLS + audit log (PR #92, 12 avril 2026)
 - THI-29 ✅ Module 11 — L'IA comme outil dev (12 leçons, `ai-help` + 11 sous-commandes, PR #103, 13 avril 2026)
 - THI-84 ✅ Changelog public — CHANGELOG.md + STORY.md + routes /changelog /story + SEO (PRs #100–102, 13 avril 2026)
 
@@ -67,7 +69,6 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 ## Tech debt
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
   → à terme : déplacer vers `src/types/database.ts`
-- `Dashboard.tsx` lignes 51 + 204 : `navigate('/learn/...')` → `navigate('/app/learn/...')` (redirect actif mais incohérent)
 
 ## Protocole de session — OBLIGATOIRE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
 - Phase 5 🔄 Curriculum expansion — 11 modules, 64 leçons, 891 tests unitaires + 176 E2E Playwright (en cours)
-- Phase 5.5 ✅ Terminal Sentinel — agents sécurité + contenu automatisés (PR #90, 12 avril 2026)
+- Phase 5.5 ✅ Terminal Sentinel — agents sécurité + contenus automatisés (PR #90, 12 avril 2026)
 - Phase 7 ✅ RBAC complet — student/teacher/institution_admin/super_admin + RLS + audit log (PR #92, 12 avril 2026)
 - THI-29 ✅ Module 11 — L'IA comme outil dev (12 leçons, `ai-help` + 11 sous-commandes, PR #103, 13 avril 2026)
 - THI-84 ✅ Changelog public — CHANGELOG.md + STORY.md + routes /changelog /story + SEO (PRs #100–102, 13 avril 2026)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,18 +52,22 @@ You will receive an acknowledgement within 72 hours.
 - Dependabot alerts enabled on the repository
 - Proactive CVE patching — critical vulnerabilities in build tooling are patched as soon as a fix is available
 
-## Planned Security Enhancements
-
-### Phase 5.5 — Terminal Sentinel (THI-36)
+### Terminal Sentinel (Phase 5.5 — live, THI-36, PR #90)
 Automated security audit tool running on two levels:
-- **GitHub Actions weekly**: npm audit, gitleaks (secret scanning), HTTP security headers, cookie flags
+- **GitHub Actions weekly** (`security-sentinel.yml`): npm audit, gitleaks (secret scanning), HTTP security headers, cookie flags — SHA-pinned actions
 - **Playwright local script** (pre-release): auth error message genericity, rate limiting, RBAC route guards, absence of stack traces in production
+- Results stored in `security_audit_logs` Supabase table (RLS: service_role only)
 
-### Phase 7 — RBAC + Audit Log (THI-37)
+### RBAC + Audit Log (Phase 7 — live, THI-37, PR #92)
 - Role-based access control: `super_admin`, `institution_admin`, `teacher`, `student`, `public`
+- `get_my_role()` security definer — prevents RLS recursion
+- `prevent_role_escalation` trigger — blocks unauthorized role changes
 - Teacher identity verified via admin approval flow (no document upload — GDPR)
-- Insert-only `audit_log` table: every privileged action recorded with actor, action, target, IP, timestamp
-- RLS extended to all new tables — principle of least privilege
+- Insert-only `admin_audit_log` table: every privileged action recorded with actor, action, target, metadata, timestamp
+- RLS on all new tables (institutions, classes, enrollments) — principle of least privilege
+- 20 integration tests + 4 RLS bugs fixed during implementation
+
+## Planned Security Enhancements
 
 ### Phase 9 — Admin Panel Security Center
 - Real-time anomaly detection: failed logins, rate-limit hits, terminal fuzzing patterns

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Terminal Learning
 
-> Last updated: 10 April 2026
+> Last updated: 13 April 2026
 
 ## Stack
 
@@ -23,6 +23,8 @@
 ```
 /                        → Landing.tsx          (public, SEO)
 /privacy                 → PrivacyPolicy.tsx     (GDPR)
+/changelog               → ChangelogPage.tsx     (public release notes)
+/story                   → StoryPage.tsx         (public project story)
 /auth/callback           → AuthCallback.tsx      (OAuth PKCE exchange)
 /app                     → Layout.tsx            (app shell)
 /app/                    → Dashboard.tsx         (progress overview)
@@ -69,23 +71,30 @@ src/
 │   │   ├── curriculum.ts         # ENVIRONMENTS, LEVELS, ROADMAP_PRIORITIES, EnvId
 │   │   └── database.ts           # Supabase DB types (Phases 3+)
 │   ├── data/
-│   │   ├── curriculum.ts         # ⚠️ Critical — all modules + lessons (32 lessons, 7 modules)
+│   │   ├── curriculum.ts         # ⚠️ Critical — all modules + lessons (64 lessons, 11 modules)
 │   │   ├── terminalEngine.ts     # Terminal command interpreter (60+ commands, env-aware)
-│   │   └── commandCatalogue.ts   # Command catalogue with level + prerequisites metadata
-│   └── hooks/                    # Custom hooks (currently empty)
+│   │   ├── commandCatalogue.ts   # Command catalogue with level + prerequisites metadata
+│   │   ├── validators.ts         # 44 exercise validation functions (extracted from curriculum)
+│   │   └── landingContent.ts     # Static data for Landing page (MODULE_PREVIEWS)
+│   └── hooks/
+│       └── useLessonSEO.ts       # SEO meta tags hook for lesson pages
 ├── test/
 │   ├── setup.ts
 │   ├── progress.test.tsx         # ProgressContext tests
 │   ├── progressSync.test.ts      # mergeProgress + getDelta (10 tests)
-│   ├── terminalEngine.test.ts    # Terminal command tests (242 total)
+│   ├── terminalEngine.test.ts    # Terminal command tests (891 total across all suites)
+│   ├── validators.test.ts        # Exercise validator tests
 │   ├── curriculumTypes.test.ts   # Curriculum structure + catalogue consistency
+│   ├── curriculumEnvAwareness.test.ts # Multi-env coverage tests
 │   ├── unlocking.test.ts         # Module unlock / prerequisite logic
+│   ├── auth.test.tsx             # Auth context tests
+│   ├── terminalPreview.test.tsx  # Terminal preview component tests
 │   └── landing.test.tsx          # Landing page module cards
 ├── styles/
 │   ├── index.css                 # Entry CSS
 │   ├── tailwind.css              # Tailwind directives
 │   ├── theme.css                 # CSS custom properties (design tokens)
-│   └── fonts.css                 # JetBrains Mono + Inter via Google Fonts
+│   └── fonts.css                 # Self-hosted Geist (Sans + Mono)
 └── main.tsx                      # App entry point
 ```
 
@@ -185,21 +194,24 @@ progress (user_id uuid FK, lesson_id text, completed bool,
           completed_at timestamptz, score int 0-100) PK: (user_id, lesson_id)
 ```
 
-**Phase 7 (planned — RBAC):**
+**Phase 7 (live — RBAC, migrations 005+006, 12 April 2026):**
 ```sql
-institutions (id, name, domain_whitelist[], admin_id)
-classes (id, teacher_id, institution_id, name)
-class_enrollments (class_id, student_id)  -- PK composite
--- profiles extensions: role, institution_id, display_name, preferred_env
+institutions (id, name, domain_whitelist[], admin_id)         -- ✅ live
+classes (id, teacher_id, institution_id, name)                -- ✅ live
+class_enrollments (class_id, student_id)  -- PK composite    -- ✅ live
+-- profiles extensions: role, institution_id, display_name, preferred_env  -- ✅ live
+admin_audit_log (id, actor_id, action, target_type, target_id, metadata jsonb, created_at)
+-- insert-only — RLS: SELECT for super_admin only            -- ✅ live
+-- get_my_role() security definer — prevents RLS recursion   -- ✅ live
+-- prevent_role_escalation trigger                            -- ✅ live
+```
+
+**Phase 7+ (planned):**
+```sql
 -- progress extensions: time_spent_seconds, attempts_count, hints_used
 badges (user_id, badge_id, earned_at)
 teacher_notes (id, teacher_id, student_id, note)
-audit_log (id, actor_id, action, target_id, metadata jsonb, ip_address, created_at)
--- insert-only — RLS: SELECT for super_admin only
-```
-
-**Phase 9 (planned — Terminal Sentinel):**
-```sql
+tracks (id, title, module_ids[], cefr_target, description)
 security_reports (id, run_at, score int, findings jsonb, component text)
 ```
 
@@ -212,11 +224,12 @@ security_reports (id, run_at, score int, findings jsonb, component text)
 | 2 | ✅ | Vercel Analytics + Sentry |
 | 3 | ✅ | Supabase Auth + progress persistence |
 | 4 | ✅ | Curriculum v2 + multi-environment + terminal profiles (192 tests) |
-| 5 | 🔄 | Curriculum expansion — 7 modules, 32 lessons, 242 unit + 176 E2E tests |
-| 5.5 | 🔮 | Terminal Sentinel — automated security audit (THI-36) |
-| 6 | 🔮 | Terminal multi-session (tabs) + changelog |
-| 7 | 🔮 | Full RBAC — student/teacher/institution/admin + approval flow (THI-37) |
+| 5 | 🔄 | Curriculum expansion — 11 modules, 64 lessons, 891 unit + 176 E2E tests |
+| 5.5 | ✅ | Terminal Sentinel — automated security audit (THI-36, PR #90) |
+| 6 | 🔮 | Terminal multi-session (tabs) |
+| 7 | ✅ | Full RBAC — student/teacher/institution/admin + RLS (THI-37, PR #92) |
 | 8 | 🔮 | Ticket system — in-app bug reports + suggestions |
 | 9 | 🔮 | Admin Panel — 7 sections, Security Center fed by Terminal Sentinel |
 | 10 | 🔮 | Automated content scheduler (new commands every 2 weeks) |
+| 11 | 🔄 | Changelog & Community — /changelog + /story live (THI-84) |
 | Final | 🔮 | PWA advanced — installable, offline, push notifications |

--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- Restrict `img-src` CSP to specific avatar CDNs (GitHub + Google) — no more wildcard `https:`
- Pin all GitHub Actions to SHA commits in `ci.yml` + `security-sentinel.yml` (supply chain protection)
- Update ARCHITECTURE.md with current stats (11 modules, 64 lessons, 891 tests, Phase 5.5 + 7 ✅)
- Update SECURITY.md — Phase 5.5 and Phase 7 moved from "Planned" to "In Place"
- Update CLAUDE.md — add Phase 5.5 ✅ and Phase 7 ✅, remove resolved tech debt
- Improve 4 agents: content-auditor, security-auditor, curriculum-validator, test-runner

## Security fixes applied directly to Supabase (not in this PR)
- Reset 5 RBAC test account passwords (random 64-char, bcrypt cost 12)
- Verified via `execute_sql` — no code change needed

## Test plan
- [ ] CI passes (type-check + lint + test + build)
- [ ] Verify CSP doesn't break avatar display (GitHub + Google OAuth)
- [ ] Verify CI workflow still triggers correctly with SHA-pinned actions
- [ ] Visual validation on Vercel preview (Chrome + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Renforcement des workflows et de la documentation de sécurité, incluant le verrouillage des actions CI, la mise à jour des recommandations de sécurité et l’actualisation des statistiques d’architecture/progression.

Améliorations :
- Verrouiller les GitHub Actions dans les workflows CI et de « security sentinel » sur des SHAs de commits spécifiques pour renforcer la protection de la chaîne d’approvisionnement.
- Étendre les spécifications internes pour la sécurité, le curriculum, le contenu et les agents « test-runner » avec des contrôles supplémentaires pour les secrets, les versions de dépendances, la couverture des validateurs et la gestion du contenu spécifique à chaque environnement.
- Mettre à jour la vue d’ensemble de l’architecture afin de refléter les nouvelles routes, modules, leçons, tests, validateurs et la stratégie de police de caractères, ainsi que les plans révisés des phases RBAC Supabase et les notes de schéma.

CI :
- Renforcer la CI et les audits de sécurité planifiés en verrouillant toutes les GitHub Actions référencées sur des SHAs immuables dans `ci.yml` et `security-sentinel.yml`.

Documentation :
- Actualiser `ARCHITECTURE.md`, `SECURITY.md` et `CLAUDE.md` pour marquer Terminal Sentinel et les phases RBAC comme actives, mettre à jour les décomptes de modules/leçons/tests, documenter les nouvelles routes et consigner les jalons récents en matière de sécurité et de curriculum.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden security workflows and documentation, including CI action pinning, security guidance updates, and refreshed architecture/progress stats.

Enhancements:
- Pin GitHub Actions in CI and security sentinel workflows to specific commit SHAs for stronger supply chain protection.
- Extend internal security, curriculum, content, and test-runner agent specs with additional checks for secrets, dependency versions, validator coverage, and environment-specific content handling.
- Update architectural overview to reflect new routes, modules, lessons, tests, validators, and font strategy, along with revised Supabase RBAC phase plans and schema notes.

CI:
- Strengthen CI and scheduled security audits by pinning all referenced GitHub Actions to immutable SHAs in ci.yml and security-sentinel.yml.

Documentation:
- Refresh ARCHITECTURE.md, SECURITY.md, and CLAUDE.md to mark Terminal Sentinel and RBAC phases as live, update module/lesson/test counts, document new routes, and record recent security and curriculum milestones.

</details>