### PR TITLE
docs: add security audit entry to changelog and story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 
 ---
 
+## Audit sécurité — Durcissement post-Phase 7
+*13 avril 2026 · PR #104*
+
+**Le défi :** Après trois semaines de développement intensif — RBAC, 5 migrations Supabase, 4 agents automatisés, 11 modules de curriculum — le moment était venu de regarder le projet avec les yeux d'un attaquant. Pas une checklist théorique : un audit black-hat complet, comme si le repo venait d'être cloné par quelqu'un qui cherche des failles.
+
+**Ce qu'on a trouvé et corrigé :**
+- CSP `img-src` trop permissive — un wildcard `https:` autorisait le chargement d'images depuis n'importe quel domaine. Restreint aux trois CDN réellement utilisés (avatars GitHub, Google, Vercel Live)
+- GitHub Actions sur tags mutables (`@v4`) — vulnérables à une compromission de tag upstream. Les 6 actions des deux workflows CI et security-sentinel sont maintenant épinglées par SHA de commit
+- 5 comptes de test RBAC avec mots de passe exposés dans l'historique git (migration 006). Mots de passe rotés en production via l'API Supabase — bcrypt cost 12, 64 caractères aléatoires
+- 4 agents d'audit améliorés après analyse des faux positifs : le `content-auditor` ne signale plus les commandes simulées identiques sur tous les OS, le `security-auditor` scanne désormais l'historique git complet
+
+**Impact :** Score de sécurité maintenu à 7.5/10. Les vulnérabilités restantes (CSP `unsafe-inline` pour Motion, rate limiting Sentry tunnel) sont documentées et planifiées — aucune n'est exploitable en l'état.
+
+**Sous le capot :**
+- `vercel.json` — directive `img-src` restreinte à `'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live`
+- `.github/workflows/ci.yml` + `security-sentinel.yml` — 6 actions épinglées par SHA
+- `ARCHITECTURE.md` + `SECURITY.md` mis à jour (stats curriculum, phases, tables RBAC)
+- Agents : règles anti-faux-positifs, scan historique git étendu, vérification couverture validators
+
+---
+
 ## Phase 7 — RBAC & Infrastructure institutionnelle
 *Avril 2026 · THI-37, THI-76, THI-80*
 

--- a/STORY.md
+++ b/STORY.md
@@ -230,6 +230,15 @@ Le dernier module du curriculum de base. 12 leçons qui couvrent tout le spectre
 **Page `/changelog` et `/story` ✅ (THI-84 — 13 avril 2026)**
 Ce que vous êtes en train de lire est maintenant accessible directement dans l'app, avec un design narratif cohérent.
 
+**Audit sécurité — deuxième passe ✅ (13 avril 2026 · PR #104)**
+Trois semaines de développement intensif, onze modules, cinq migrations Supabase, quatre agents automatisés. On s'est arrêtés et on a regardé le projet comme quelqu'un qui vient de le découvrir sur GitHub — avec de mauvaises intentions.
+
+C'est la deuxième fois qu'on fait cet exercice. La première avait révélé 6 bugs RLS et un endpoint Sentry exploitable. Cette fois, le problème le plus sérieux était invisible à l'œil nu : des mots de passe de test en clair dans l'historique git. Le fichier HEAD était propre — un placeholder inoffensif. Mais `git log -p` racontait une autre histoire. L'historique public d'un repo open source est aussi lisible que le HEAD. C'est une évidence qu'on oublie facilement.
+
+L'autre découverte : les agents qu'on avait construits pour automatiser la vigilance généraient eux-mêmes des faux positifs. Le `content-auditor` signalait 12 leçons du Module 11 comme "CRITICAL" — parce que `ai-help` est une commande simulée identique sur tous les OS, et l'agent ne savait pas faire cette distinction. Corriger les outils qui corrigent le code : c'est une boucle qui finit par converger, mais il faut accepter de la parcourir.
+
+Ce qu'on retient : un audit n'est pas un événement. C'est une discipline. La sécurité ne s'améliore pas en corrigeant des failles — elle s'améliore en rendant la détection automatique.
+
 ### Ce sur quoi on travaille maintenant
 
 **Admin Panel institutionnel (Phase 9)**
@@ -267,4 +276,4 @@ Ce journal continuera d'être écrit tant que le projet continue d'être constru
 ---
 
 *Terminal Learning est un projet open source, construit bénévolement en Belgique.*
-*Dernière mise à jour : 12 avril 2026*
+*Dernière mise à jour : 13 avril 2026*


### PR DESCRIPTION
## Summary
- **CHANGELOG.md**: new entry for the security audit of 13 April 2026 (PR #104) — CSP `img-src` hardening, SHA-pinned GitHub Actions, rotated test passwords, improved audit agents
- **STORY.md**: enriched Partie V with the second security audit narrative — git history credential exposure, agent false positives, and iterative security as discipline. Updated date to 13 April 2026.

## Test plan
- [ ] Verify `/changelog` renders the new entry correctly (markdown, code blocks, lists)
- [ ] Verify `/story` renders the new paragraph in Partie V
- [ ] Check date at bottom of STORY.md shows "13 avril 2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Documenter le deuxième audit de sécurité et ses résultats dans le changelog et l’historique du projet, en mettant à jour les dates pour refléter le dernier audit.

Documentation :
- Ajouter une entrée détaillée dans le changelog décrivant les conclusions du deuxième audit de sécurité post-Phase 7, les mesures de mitigation et les impacts techniques.
- Étendre le récit du STORY avec une nouvelle section sur le deuxième audit de sécurité, incluant les leçons apprises concernant l’exposition de l’historique git et les faux positifs des agents, et mettre à jour la date de dernière mise à jour au 13 avril 2026.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the second security audit and its outcomes in the changelog and project story, updating dates to reflect the latest audit.

Documentation:
- Add a detailed changelog entry describing the second post-Phase 7 security audit findings, mitigations, and technical impacts.
- Extend the STORY narrative with a new section about the second security audit, including lessons learned about git history exposure and agent false positives, and update the last-updated date to 13 April 2026.

</details>