### PR TITLE
docs: post-PR#108 — motion removal, ui-auditor protocol, shadcn debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@
 
 ---
 
+## Phase 4c — Bundle Optimization : motion/react retiré, 22 deps nettoyées
+*13 avril 2026 · THI-87 · PR #108*
+
+**Le défi :** Le bundle Landing pesait ~65 kB gzip, principalement à cause de `motion/react` (~40 kB gzip / 124 kB raw) chargé pour des animations d'entrée et de scroll-reveal. Plus grave : en auditant les dépendances, on a découvert que **22 packages npm étaient installés mais jamais importés** dans le code source — vestiges de sessions précédentes qui n'ont pas nettoyé derrière elles. Et que **8 composants shadcn/ui** dépendaient de ces packages fantômes.
+
+**Pourquoi c'est important :** Ce projet est une vitrine pédagogique pour des enseignants et élèves. Des dépendances inutilisées, c'est du poids mort qui ralentit l'installation, augmente la surface d'attaque, et envoie le mauvais signal aux contributeurs qui lisent le `package.json`. On ne peut pas enseigner les bonnes pratiques si on ne les applique pas soi-même.
+
+**Ce qu'on a fait :**
+- Remplacé `motion/react` par des CSS `@keyframes` + un hook `useInView` (IntersectionObserver natif) — même rendu visuel, zéro dépendance externe
+- Migré 3 composants : `Landing.tsx` (7 sections), `TerminalPreview.tsx`, `NotFound.tsx` (5 animations)
+- Supprimé 22 dépendances inutilisées (MUI, Emotion, canvas-confetti, react-dnd, recharts, cmdk, vaul, etc.)
+- Supprimé 8 composants shadcn/ui dormants qui ne compilaient plus après le nettoyage
+- Créé l'agent `ui-auditor` pour détecter automatiquement ce type de dette à l'avenir
+
+**Impact :** Landing chunk ~65 kB → ~25 kB gzip. `package-lock.json` allégé de ~1 400 lignes. Installation npm significativement plus rapide. Zéro régression visuelle confirmée par comparaison screenshots prod vs preview (desktop + mobile).
+
+**Leçon tirée :** Un agent d'audit (ui-auditor) a été créé et ajouté au protocole de session obligatoire. Il doit être exécuté avant toute PR touchant l'UI — les CRITICAL bloquent le merge. C'est un garde-fou structurel, pas une vérification ponctuelle.
+
+---
+
 ## Audit sécurité — Durcissement post-Phase 7
 *13 avril 2026 · PR #104*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 
 ## Stack
 - Vite 6 + React 18 + React Router v7 + TypeScript strict
-- Tailwind CSS v4 + shadcn/ui + Motion
+- Tailwind CSS v4 + shadcn/ui (Radix UI) + CSS animations (motion/react retiré PR #108)
 - Supabase (Auth + PostgreSQL + RLS + OAuth GitHub + Google)
 - Vitest (tests unitaires) + Playwright (E2E — 3 suites : accessibility, mobile, seo)
 - Vercel (déploiement auto sur push main)
@@ -55,6 +55,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 7 ✅ RBAC complet — student/teacher/institution_admin/super_admin + RLS + audit log (PR #92, 12 avril 2026)
 - THI-29 ✅ Module 11 — L'IA comme outil dev (12 leçons, `ai-help` + 11 sous-commandes, PR #103, 13 avril 2026)
 - THI-84 ✅ Changelog public — CHANGELOG.md + STORY.md + routes /changelog /story + SEO (PRs #100–102, 13 avril 2026)
+- THI-87 ✅ Bundle optimization — motion/react retiré, 22 deps inutilisées supprimées, 8 composants shadcn dormants supprimés (PR #108, 13 avril 2026)
+- Phase 4c ✅ Bundle Optimization complète — Landing chunk ~65kB→~25kB gzip
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative
@@ -69,6 +71,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 ## Tech debt
 - `src/lib/supabase.ts` importe depuis `src/app/types/` — dépendance inversée
   → à terme : déplacer vers `src/types/database.ts`
+- **shadcn/ui non utilisé** — 39 composants Radix UI installés, mais l'UI est 100% custom Tailwind. THI-85 planifié pour migrer page par page. Ne jamais installer de nouveau composant shadcn sans l'utiliser immédiatement.
 
 ## Protocole de session — OBLIGATOIRE
 
@@ -78,6 +81,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **`test-runner`** — lance vitest, retourne uniquement failures + commandes sans test
 - **`content-auditor`** — audit pédagogique A→Z : env coverage, cohérence curriculum↔moteur↔tests, liens externes, chaîne de prérequis, qualité validate(). Lancer avant chaque release majeure ou à la demande.
 - **`security-auditor`** — audit cybersécurité black hat : OWASP Top 10 (2021), OWASP API Sec (2023), CSP L3, rate limiting, RLS, auth flow, supply chain, RGPD, vecteurs 2026. Lancer avant chaque release majeure, après mise à jour de dépendances, ou à la demande. (THI-53)
+- **`ui-auditor`** — détecte composants custom qui devraient utiliser shadcn/ui, deps fantômes, composants installés mais jamais importés, couleurs/tailles en dur. **Obligatoire avant toute PR touchant des composants UI.** CRITICAL = bloque le merge. (THI-86)
 
 ### Début de chaque session
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés
@@ -94,6 +98,10 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Issue Done + PR non mergée → **In Review**
 - Issue In Progress + PR ouverte → **In Review**
 - Issue In Review + PR mergée → **Done**
+
+### Avant toute PR touchant des composants UI
+- Invoquer l'agent **`ui-auditor`** → analyser le rapport, corriger les CRITICAL avant de proposer la PR
+- Tout CRITICAL dans le rapport bloque le merge — pas d'exception
 
 ### Règles merge
 - CI verte **ET** Sourcery vérifié avant de proposer un merge — **dans cet ordre, sans exception**

--- a/STORY.md
+++ b/STORY.md
@@ -239,16 +239,25 @@ L'autre découverte : les agents qu'on avait construits pour automatiser la vigi
 
 Ce qu'on retient : un audit n'est pas un événement. C'est une discipline. La sécurité ne s'améliore pas en corrigeant des failles — elle s'améliore en rendant la détection automatique.
 
+**Le nettoyage qui a changé les règles — PR #108 (13 avril 2026)**
+
+En optimisant les performances (THI-87), on a tiré un fil qui a révélé un problème plus profond. `motion/react` pesait ~40 kB gzip dans le bundle Landing pour des animations qu'on pouvait reproduire en CSS pur. Mais en auditant les dépendances, la vraie surprise est arrivée : **22 packages npm installés mais jamais utilisés**. MUI, Emotion, canvas-confetti, react-dnd, recharts — tous fantômes. Et 8 composants shadcn/ui qui dépendaient de ces packages.
+
+Comment c'est arrivé ? Probablement des sessions de développement qui ont installé des packages, prototypé, pivoté — et oublié de nettoyer. Aucun agent ne vérifiait ça. Aucune règle ne l'empêchait. C'est le type de dette technique qui s'accumule silencieusement, un `npm install` à la fois.
+
+La correction technique est simple : remplacer motion par des CSS @keyframes, supprimer les deps, supprimer les composants orphelins. Le vrai changement est structurel : un nouvel agent (`ui-auditor`) qui scanne automatiquement les violations du design system — composants custom là où shadcn devrait être utilisé, deps fantômes, incohérences de style. Et une règle dans le protocole : cet agent doit tourner avant toute PR touchant l'UI. Les CRITICAL bloquent le merge.
+
+Résultat : -2 453 lignes, +329 ajoutées. Le Landing passe de ~65 kB à ~25 kB gzip. Zéro régression visuelle — confirmé par comparaison screenshots production vs preview en desktop et mobile.
+
+Ce qu'on retient : les garde-fous ne sont pas optionnels sur un projet pédagogique. Si on enseigne les bonnes pratiques, on les applique d'abord.
+
 ### Ce sur quoi on travaille maintenant
+
+**Migration shadcn/ui (THI-85)**
+39 composants Radix UI sont installés, mais l'UI est 100% custom Tailwind. La migration se fera page par page — Dashboard d'abord, puis LessonPage, puis Landing. L'agent ui-auditor guidera chaque étape.
 
 **Admin Panel institutionnel (Phase 9)**
 Les outils pour les enseignants : vue classe, heatmaps d'activité, suivi de progression par élève. La plateforme peut maintenant accueillir des établissements — il faut maintenant leur donner les outils pour que ça soit utile.
-
-**Dashboard santé super_admin (THI-85)**
-Mode maintenance ON/OFF, graphiques de santé en temps réel, vérification de compatibilité des frameworks. Un vrai cockpit d'administration.
-
-**Système de tickets intégré (THI-86) + capture d'écran intelligente (THI-87)**
-Les enseignants et élèves pourront remonter des bugs, suggestions et corrections directement depuis l'app — avec capture pleine page annotable. Pas besoin d'installer un outil tiers.
 
 ### Les débats ouverts
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Terminal Learning
 
-> Last updated: 13 April 2026 — THI-29 Module 11 "L'IA comme outil dev" ✅ (PR #103) — 11 modules / 64 lessons / 891 tests — perf: main bundle 16kB, FCP 0.6s, INP <200ms — THI-87: motion/react removed (PR #108), THI-85: shadcn/ui migration planned
+> Last updated: 13 April 2026 — Phase 4c Bundle Optimization ✅ (PR #108 merged) — motion/react removed, 22 unused deps cleaned, Landing ~25kB gzip — ui-auditor agent created — 11 modules / 64 lessons / 891 tests — Next: THI-85 shadcn/ui migration page by page
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -55,7 +55,7 @@
 | THI-82 | perf | Dynamic import de supabase dans AuthContext + ProgressContext — −194 kB FCP (PR #96) ✅ Done |
 | THI-83 | perf | INP 592ms fix — instant scroll + MAX_LINES cap + startTransition (PR #99) ✅ Done |
 | THI-84 | content | Trust badges cliquables (securityheaders.com + GitHub Actions) + badge "876 tests · CI verte" (PR #100) + CHANGELOG.md + STORY.md (PR #101) + routes /changelog et /story avec SEO/OG (PR #102) ✅ Done |
-| THI-87 | perf | Remove motion/react (~40 kB gzip) — CSS animations + IntersectionObserver + cleanup 22 deps inutilisées (PR #108) 🔄 In Review |
+| THI-87 | perf | Remove motion/react (~40 kB gzip) — CSS animations + IntersectionObserver + cleanup 22 deps inutilisées + 8 composants shadcn dormants supprimés (PR #108) ✅ Done |
 | THI-85 | tech-debt | Migrer composants custom vers shadcn/ui — page par page (Dashboard, LessonPage, Landing, etc.) 🔮 Backlog |
 | THI-86 | agents | Ajouter ui-auditor au protocole de session obligatoire + CLAUDE.md 🔮 Backlog |
 | THI-77 | Phase 9 | Heatmap activité élève — vue enseignant (GitHub-style) 🔮 Backlog |


### PR DESCRIPTION
## Summary
- CLAUDE.md: stack updated (motion→CSS animations), ui-auditor added to mandatory session protocol, shadcn tech debt documented
- CHANGELOG.md: new entry explaining the -2453 lines cleanup and the lesson learned
- STORY.md: new chapter on the discovery of 22 ghost dependencies and the guardrails created
- ROADMAP.md + plan.md: THI-87 → Done, Phase 4c complete

## Motivation
After PR #108 (motion removal + 22 deps cleanup), all project documentation needs to reflect the changes, explain the decisions, and set guardrails for future sessions. This ensures any Claude model (Sonnet, Opus, Haiku) working on this project understands the rules.

## Changes
- `CLAUDE.md` — Stack, Phases, Tech debt, Agents, Protocol sections
- `CHANGELOG.md` — New top-level entry with context, impact, lesson learned
- `STORY.md` — New chapter + updated "what we're working on" section
- `docs/ROADMAP.md` — Header update
- `docs/plan.md` — THI-87 status

## Test plan
- [ ] CI passes (type-check + lint + test + build)
- [ ] No code changes — docs only, zero risk of regression
- [ ] Validated by Thierry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Travail d’optimisation du bundle de documentation issu de la PR #108, introduction de l’agent ui-auditor, et plan de migration vers shadcn/ui dans l’ensemble de la documentation du projet.

Documentation :
- Étendre `STORY.md` avec un chapitre narratif sur le nettoyage des dépendances de la PR #108 et ajouter du contexte sur la future migration vers shadcn/ui.
- Mettre à jour `CHANGELOG.md` avec une nouvelle entrée décrivant la suppression de `motion/react`, le nettoyage des dépendances inutilisées, ainsi que les enseignements tirés sur la taille du bundle et le processus.
- Réviser `CLAUDE.md` pour refléter la pile frontend mise à jour, le travail de performance terminé (THI-87, Phase 4c), la dette technique documentée liée à shadcn/ui, et le protocole ui-auditor obligatoire pour les changements d’UI.
- Actualiser `ROADMAP.md` et `plan.md` pour marquer THI-87 et la Phase 4c comme terminés, mettre en avant les résultats de l’optimisation du bundle, et indiquer les prochaines étapes pour la migration vers shadcn/ui et l’utilisation de ui-auditor.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document bundle optimization work from PR #108, the introduction of the ui-auditor agent, and the shadcn/ui migration plan across the project docs.

Documentation:
- Extend STORY.md with a narrative chapter on PR #108’s dependency cleanup and add context on the upcoming shadcn/ui migration.
- Update CHANGELOG.md with a new entry describing the removal of motion/react, cleanup of unused dependencies, and the resulting bundle size and process lessons.
- Revise CLAUDE.md to reflect the updated frontend stack, completed performance work (THI-87, Phase 4c), documented shadcn/ui tech debt, and the mandatory ui-auditor protocol for UI changes.
- Refresh ROADMAP.md and plan.md to mark THI-87 and Phase 4c as done, highlight bundle optimization outcomes, and note next steps for shadcn/ui migration and ui-auditor usage.

</details>