### PR TITLE
security(auth): remove hardcoded test password from codebase

### DIFF
--- a/.claude/agents/rbac-flow-tester.md
+++ b/.claude/agents/rbac-flow-tester.md
@@ -31,7 +31,7 @@ SERVICE_KEY=$(supabase projects api-keys --project-ref jdnukbpkjyyyjpuwgxhv --ou
 | pending_teacher    | test.pendingt@terminallearning.dev             | ...111104   |
 | student            | test.student@terminallearning.dev              | ...111105   |
 
-Password: `TerminalLearning2026!`
+Password: `${TEST_PASSWORD}` (from .env.test — never hardcode)
 
 ## Checks to perform (23 total)
 
@@ -59,7 +59,7 @@ Password: `TerminalLearning2026!`
 TOKEN=$(curl -s -X POST "${SUPABASE_URL}/auth/v1/token?grant_type=password" \
   -H "apikey: ${ANON_KEY}" \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"${EMAIL}\",\"password\":\"TerminalLearning2026!\"}" \
+  -d "{\"email\":\"${EMAIL}\",\"password\":\"${TEST_PASSWORD}\"}" \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('access_token','FAIL'))")
 ```
 

--- a/.claude/agents/rbac-flow-tester.md
+++ b/.claude/agents/rbac-flow-tester.md
@@ -31,7 +31,9 @@ SERVICE_KEY=$(supabase projects api-keys --project-ref jdnukbpkjyyyjpuwgxhv --ou
 | pending_teacher    | test.pendingt@terminallearning.dev             | ...111104   |
 | student            | test.student@terminallearning.dev              | ...111105   |
 
-Password: `${TEST_PASSWORD}` (from .env.test — never hardcode)
+Passwords: each account has a unique password in `.env.test` (never hardcode):
+- `TEST_SUPERADMIN_PASSWORD`, `TEST_INSTITUTIONADMIN_PASSWORD`, `TEST_TEACHER_PASSWORD`
+- `TEST_PENDINGTEACHER_PASSWORD`, `TEST_STUDENT_PASSWORD`
 
 ## Checks to perform (23 total)
 
@@ -59,7 +61,7 @@ Password: `${TEST_PASSWORD}` (from .env.test — never hardcode)
 TOKEN=$(curl -s -X POST "${SUPABASE_URL}/auth/v1/token?grant_type=password" \
   -H "apikey: ${ANON_KEY}" \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"${EMAIL}\",\"password\":\"${TEST_PASSWORD}\"}" \
+  -d "{\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\"}" \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('access_token','FAIL'))")
 ```
 

--- a/supabase/migrations/006_test_users_rbac.sql
+++ b/supabase/migrations/006_test_users_rbac.sql
@@ -12,7 +12,7 @@
 --         curl -s -X PUT "https://<ref>.supabase.co/auth/v1/admin/users/$UUID" \
 --           -H "Authorization: Bearer $SERVICE_KEY" -H "apikey: $SERVICE_KEY" \
 --           -H "Content-Type: application/json" \
---           -d '{"password":"TerminalLearning2026!"}'
+--           -d '{"password":"<random-32-chars — see .env.test>"}'
 --       done
 --
 -- ⚠️  GOTRUE COMPAT: direct auth.users inserts require these fields set to '' (not NULL):


### PR DESCRIPTION
## Summary
- Remove hardcoded `TerminalLearning2026!` password from `006_test_users_rbac.sql` comment (line 15) and `rbac-flow-tester.md` agent
- All 5 RBAC test accounts rotated to random 35-char passwords via Supabase Admin API
- New passwords stored in `.env.test` (gitignored, never committed)

## Context
Security audit (C1) flagged that the test password was visible in git history and still present in HEAD comments. While git history cannot be rewritten without breaking forks, the HEAD is now clean and all accounts use unique random passwords.

## Test plan
- [ ] Verify `.env.test` exists locally with rotated passwords
- [ ] Verify no occurrence of `TerminalLearning2026` in codebase (`grep -r "TerminalLearning2026"` returns nothing)
- [ ] CI passes (no runtime code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Supprime les références de mots de passe de test codés en dur dans les outils de test RBAC et la documentation au profit de secrets basés sur l’environnement.

Améliorations :
- Met à jour l’utilitaire de test de flux RBAC pour lire le mot de passe de test à partir de la configuration d’environnement au lieu d’une valeur littérale en ligne.

Documentation :
- Remplace le mot de passe d’exemple codé en dur dans la documentation du testeur de flux RBAC et les commentaires de migration par des références à des mots de passe aléatoires gérés via l’environnement.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove hardcoded test password references from RBAC test tooling and documentation in favor of environment-based secrets.

Enhancements:
- Update RBAC flow tester helper to read the test password from environment configuration instead of an inline literal.

Documentation:
- Replace hardcoded example password in RBAC flow tester documentation and migration comments with references to environment-managed random passwords.

</details>