### PR TITLE
security(csp): replace Sentry wildcard with exact ingest host

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://o4511149685080064.ingest.de.sentry.io https://jdnukbpkjyyyjpuwgxhv.supabase.co https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- Replace `*.ingest.sentry.io` + `*.ingest.de.sentry.io` wildcards in CSP `connect-src` with exact host `o4511149685080064.ingest.de.sentry.io`
- All Sentry traffic already goes through `/api/sentry-tunnel` — CSP entry is fallback only
- Eliminates potential exfiltration vector via attacker-controlled `*.ingest.sentry.io` subdomains

## Also investigated (no action needed)
- **H1 `unsafe-inline` in `style-src`**: ~25 React components use inline `style={{}}` attributes (progress bars, dynamic colors, animationDelay). Cannot remove without migrating to CSS classes — planned for THI-85.
- **H3 sentry-tunnel rate limiting**: Created THI-88 on Linear for Vercel KV migration.

## Test plan
- [ ] Verify Sentry errors still arrive in dashboard after merge (tunnel path unchanged)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorations :
- Remplacer les caractères génériques larges de l’ingestion Sentry dans la CSP par l’hôte d’ingestion exact afin de réduire le risque potentiel d’exfiltration de données.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace broad Sentry ingest wildcards in CSP with the exact ingest host to reduce potential data exfiltration risk.

</details>