### PR TITLE
test(validators): add 29 ai-help tests + tighten validatePing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ---
 
+## 900 tests unitaires — couverture complète du curriculum
+*13 avril 2026 · PR #112*
+
+**Le milestone :** Le projet atteint **900 tests unitaires** (+ 20 tests RBAC d'intégration skippés en CI, en attente d'un env staging Supabase). C'est le résultat naturel de l'architecture multi-environnement : chaque commande est testée sur Linux, macOS et Windows.
+
+**Anatomie des 900 tests :**
+- **terminalEngine** (~295) — chaque commande × chaque OS × cas positifs/négatifs (ex: `ls` sur Linux, `dir` sur Windows, `Get-ChildItem` sur PowerShell)
+- **validators** (242) — les 67 fonctions `validate()` : acceptation, rejet, injection XSS/SQL, DoS, casse et espaces
+- **curriculumEnvAwareness** (~200) — cohérence structurelle de chaque leçon × chaque environnement
+- **unlocking** (~50) — graphe de prérequis : modules accessibles dans le bon ordre, zéro dépendance circulaire
+- **progressSync** (~40) — synchronisation localStorage ↔ Supabase : merge, delta, conflits, mode offline
+- **divers** (~53) — routing, helpers, edge cases
+
+**Aussi dans cette PR :** `validatePing` resserré — rejetait auparavant n'importe quel contenu après `ping `, accepte maintenant uniquement des hostnames valides (`[a-zA-Z0-9._-]`).
+
+---
+
 ## Phase 4c — Bundle Optimization : motion/react retiré, 22 deps nettoyées
 *13 avril 2026 · THI-87 · PR #108*
 

--- a/src/app/data/validators.ts
+++ b/src/app/data/validators.ts
@@ -193,7 +193,7 @@ export const validateScripts: ValidateFn = (cmd, env) => {
 
 export const validateCron: ValidateFn = (cmd) => cmd.trim().toLowerCase() === 'crontab -l';
 
-export const validatePing: ValidateFn = (cmd) => /^ping\s+.+/.test(cmd.trim().toLowerCase());
+export const validatePing: ValidateFn = (cmd) => /^ping\s+[a-zA-Z0-9._-]+$/.test(cmd.trim().toLowerCase());
 
 export const validateCurl: ValidateFn = (cmd, env) => {
     const c = cmd.trim().toLowerCase();

--- a/src/test/validators.test.ts
+++ b/src/test/validators.test.ts
@@ -52,6 +52,18 @@ import {
   validatePullRequests,
   validateConflicts,
   validateGithubActions,
+  validateAiHelp,
+  validateAiHelpCapabilities,
+  validateAiHelpLimits,
+  validateAiHelpPrompts,
+  validateAiHelpContext,
+  validateAiHelpValidate,
+  validateAiHelpDebug,
+  validateAiHelpSecurity,
+  validateAiHelpClaudeCli,
+  validateAiHelpCareers,
+  validateAiHelpSenior,
+  validateAiHelpWorkflow,
 } from '../app/data/validators';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -429,6 +441,72 @@ describe('validateConflicts', () => {
 describe('validateGithubActions', () => {
   it('accepts "git status"', () => expect(validateGithubActions('git status')).toBe(true));
   it('rejects "git push"', () => expect(validateGithubActions('git push')).toBe(false));
+});
+
+// ── AI Help (Module 11) ──────────────────────────────────────────────────────
+describe('validateAiHelp', () => {
+  it('accepts "ai-help"', () => expect(validateAiHelp('ai-help')).toBe(true));
+  it('accepts "ai-help capabilities"', () => expect(validateAiHelp('ai-help capabilities')).toBe(true));
+  it('rejects "help"', () => expect(validateAiHelp('help')).toBe(false));
+  it('rejects empty', () => expect(validateAiHelp('')).toBe(false));
+});
+
+describe('validateAiHelpCapabilities', () => {
+  it('accepts "ai-help capabilities"', () => expect(validateAiHelpCapabilities('ai-help capabilities')).toBe(true));
+  it('rejects "ai-help"', () => expect(validateAiHelpCapabilities('ai-help')).toBe(false));
+  it('rejects "ai-help limits"', () => expect(validateAiHelpCapabilities('ai-help limits')).toBe(false));
+});
+
+describe('validateAiHelpLimits', () => {
+  it('accepts "ai-help limits"', () => expect(validateAiHelpLimits('ai-help limits')).toBe(true));
+  it('rejects "ai-help capabilities"', () => expect(validateAiHelpLimits('ai-help capabilities')).toBe(false));
+});
+
+describe('validateAiHelpPrompts', () => {
+  it('accepts "ai-help prompts"', () => expect(validateAiHelpPrompts('ai-help prompts')).toBe(true));
+  it('rejects "ai-help context"', () => expect(validateAiHelpPrompts('ai-help context')).toBe(false));
+});
+
+describe('validateAiHelpContext', () => {
+  it('accepts "ai-help context"', () => expect(validateAiHelpContext('ai-help context')).toBe(true));
+  it('rejects "ai-help prompts"', () => expect(validateAiHelpContext('ai-help prompts')).toBe(false));
+});
+
+describe('validateAiHelpValidate', () => {
+  it('accepts "ai-help validate"', () => expect(validateAiHelpValidate('ai-help validate')).toBe(true));
+  it('rejects "ai-help debug"', () => expect(validateAiHelpValidate('ai-help debug')).toBe(false));
+});
+
+describe('validateAiHelpDebug', () => {
+  it('accepts "ai-help debug"', () => expect(validateAiHelpDebug('ai-help debug')).toBe(true));
+  it('rejects "ai-help validate"', () => expect(validateAiHelpDebug('ai-help validate')).toBe(false));
+});
+
+describe('validateAiHelpSecurity', () => {
+  it('accepts "ai-help security"', () => expect(validateAiHelpSecurity('ai-help security')).toBe(true));
+  it('rejects "ai-help debug"', () => expect(validateAiHelpSecurity('ai-help debug')).toBe(false));
+});
+
+describe('validateAiHelpClaudeCli', () => {
+  it('accepts "ai-help claude-cli"', () => expect(validateAiHelpClaudeCli('ai-help claude-cli')).toBe(true));
+  it('rejects "ai-help security"', () => expect(validateAiHelpClaudeCli('ai-help security')).toBe(false));
+});
+
+describe('validateAiHelpCareers', () => {
+  it('accepts "ai-help careers"', () => expect(validateAiHelpCareers('ai-help careers')).toBe(true));
+  it('rejects "ai-help senior"', () => expect(validateAiHelpCareers('ai-help senior')).toBe(false));
+});
+
+describe('validateAiHelpSenior', () => {
+  it('accepts "ai-help senior"', () => expect(validateAiHelpSenior('ai-help senior')).toBe(true));
+  it('rejects "ai-help careers"', () => expect(validateAiHelpSenior('ai-help careers')).toBe(false));
+});
+
+describe('validateAiHelpWorkflow', () => {
+  it('accepts "ai-help workflow"', () => expect(validateAiHelpWorkflow('ai-help workflow')).toBe(true));
+  it('rejects "ai-help senior"', () => expect(validateAiHelpWorkflow('ai-help senior')).toBe(false));
+  it('handles case insensitivity', () => expect(validateAiHelpWorkflow('AI-HELP WORKFLOW')).toBe(true));
+  it('handles leading/trailing spaces', () => expect(validateAiHelpWorkflow('  ai-help workflow  ')).toBe(true));
 });
 
 // ── Security: injection attempts ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add unit tests for all 12 `ai-help` subcommand validators (Module 11 — THI-29)
- Tighten `validatePing` regex to reject flags and special characters (content-auditor W2)
- Test count: 871 → 900 (+29)

## Context
The test-runner agent flagged 12 `ai-help` validators without dedicated tests. The content-auditor flagged `validatePing` as too permissive (`/^ping\s+.+/` accepted anything).

## Test plan
- [x] `npx vitest run` — 900 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)