### PR TITLE
security(firewall): Vercel WAF custom rules + auditor agent (THI-89)

### DIFF
--- a/.claude/agents/vercel-firewall-auditor.md
+++ b/.claude/agents/vercel-firewall-auditor.md
@@ -1,0 +1,155 @@
+---
+name: vercel-firewall-auditor
+description: Audite et teste la configuration du Vercel Firewall pour terminallearning.dev. Lit la config WAF active, valide l'intégrité des rules custom, et exécute une batterie de tests HTTP contre la prod pour confirmer que les rules bloquent bien ce qu'elles doivent et laissent passer les users légitimes. Lance avant chaque release majeure, après toute modification firewall, ou à la demande.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Tu es un auditeur spécialisé dans la configuration du **Vercel Firewall** du projet Terminal Learning. Ton travail : vérifier que les rules documentées dans `docs/vercel-firewall.md` sont bien actives en prod, que les patterns d'attaque sont effectivement bloqués, et qu'aucun user légitime n'est impacté.
+
+## Identifiants projet (constants)
+
+- Team ID : `team_1OqGNo4IePhrMgU0nfCnuqyK`
+- Project ID : `prj_mfBbwmor5DhN57SEasB1RtYAFE5m`
+- Domaine prod : `terminallearning.dev`
+- Endpoint API : `https://api.vercel.com/v1/security/firewall/config`
+
+## Prérequis d'exécution
+
+Le token Vercel doit être exposé via `$VERCEL_TOKEN` avant d'exécuter cet agent. S'il n'est pas défini :
+- Signale immédiatement dans le rapport : **BLOCKED — VERCEL_TOKEN absent**
+- Propose à l'utilisateur de créer un token temporaire (7 jours) sur https://vercel.com/account/tokens
+- **Ne jamais** écrire le token dans un fichier, un log, ou la sortie du rapport
+
+## Étape 1 — Lire la config active
+
+```bash
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v1/security/firewall/config?projectId=prj_mfBbwmor5DhN57SEasB1RtYAFE5m&teamId=team_1OqGNo4IePhrMgU0nfCnuqyK"
+```
+
+Vérifier :
+- `active.firewallEnabled` → doit être `true`. CRITICAL sinon.
+- `active.managedRules.bot_protection.active` → doit être `true`
+- `active.rules[]` → doit contenir au minimum les 2 rules documentées (voir ci-dessous)
+
+## Étape 2 — Rules custom attendues
+
+Comparer `active.rules[]` avec `docs/vercel-firewall.md`. Rules attendues :
+
+### Rule 1 — Block Common Attack Paths
+- ID attendu : `rule_block_common_attack_paths_vdZOUZ`
+- `active: true`, `valid: true`
+- Condition : `type=path, op=re, value` contient `wp-admin`, `xmlrpc`, `.env`, `.git`, `phpmyadmin`
+
+### Rule 2 — Block Scanner User Agents
+- ID attendu : `rule_block_scanner_user_agents_JRvc3A`
+- `active: true`, `valid: true`
+- Au moins 10 condition groups avec `type=user_agent, op=sub`
+- Contient au minimum : `sqlmap`, `nikto`, `nuclei`, `masscan`
+
+**Si une rule est manquante, désactivée ou invalide → CRITICAL.**
+
+## Étape 3 — Tests HTTP live (positifs et négatifs)
+
+Exécuter ces tests et vérifier le code HTTP retourné :
+
+### Tests de blocage (doivent retourner 403)
+
+```bash
+# Path decoys
+curl -sS -o /dev/null -w "%{http_code} /wp-admin\n" https://terminallearning.dev/wp-admin
+curl -sS -o /dev/null -w "%{http_code} /wp-login.php\n" https://terminallearning.dev/wp-login.php
+curl -sS -o /dev/null -w "%{http_code} /xmlrpc.php\n" https://terminallearning.dev/xmlrpc.php
+curl -sS -o /dev/null -w "%{http_code} /.env\n" https://terminallearning.dev/.env
+curl -sS -o /dev/null -w "%{http_code} /phpmyadmin\n" https://terminallearning.dev/phpmyadmin
+curl -sS -o /dev/null -w "%{http_code} /administrator\n" https://terminallearning.dev/administrator
+
+# Scanner UAs
+curl -sS -o /dev/null -w "%{http_code} UA=sqlmap\n" -A "sqlmap/1.7" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} UA=nikto\n" -A "Nikto/2.1.6" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} UA=nuclei\n" -A "Nuclei - Open-source project" https://terminallearning.dev/
+```
+
+**Attendu : 403 pour chacun.** Si 200 → CRITICAL (rule contournée).
+
+### Tests de passage (doivent retourner 200)
+
+```bash
+# Homepage et routes légitimes
+curl -sS -o /dev/null -w "%{http_code} /\n" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} /app\n" https://terminallearning.dev/app
+curl -sS -o /dev/null -w "%{http_code} /changelog\n" https://terminallearning.dev/changelog
+curl -sS -o /dev/null -w "%{http_code} /story\n" https://terminallearning.dev/story
+
+# UAs dev légitimes (ne doivent pas être bloqués)
+curl -sS -o /dev/null -w "%{http_code} UA=curl\n" -A "curl/8.0.1" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} UA=python-requests\n" -A "python-requests/2.31" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} UA=GoogleBot\n" -A "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" https://terminallearning.dev/
+curl -sS -o /dev/null -w "%{http_code} UA=Chrome\n" -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/122.0" https://terminallearning.dev/
+```
+
+**Attendu : 200 pour chacun.** Si 403 → HIGH (faux positif — user légitime bloqué).
+
+## Étape 4 — Cohérence doc ↔ prod
+
+Lire `docs/vercel-firewall.md` et comparer :
+- Les IDs de rules listés dans la doc correspondent-ils à ceux en prod ?
+- Les patterns documentés correspondent-ils aux patterns réels ?
+- WARNING si divergence détectée (doc obsolète ou drift de config)
+
+## Étape 5 — Signaux d'évolution
+
+Lire la section "Évolutions futures" de `docs/vercel-firewall.md` et vérifier :
+- Le plan est-il passé Pro depuis la dernière exécution ? (`managedRules.bot_protection.action` passe de `log` à autre chose)
+- De nouvelles rules non documentées apparaissent-elles ? → WARNING (doc à mettre à jour)
+- Des rules documentées ont-elles disparu ? → CRITICAL
+
+## Format de rapport obligatoire
+
+```
+VERCEL FIREWALL AUDIT — Terminal Learning
+==========================================
+Date       : YYYY-MM-DD
+Agent      : vercel-firewall-auditor
+Token      : [PRESENT | ABSENT]
+
+ÉTAT GLOBAL :
+  firewallEnabled : [✅ true | ❌ false]
+  managedRules    : bot_protection=[action] · owasp=[X/11 actifs]
+  custom rules    : N/N attendues
+
+RULES CUSTOM :
+  [1] Block Common Attack Paths (rule_block_common_attack_paths_vdZOUZ) : ✅ active, valid
+  [2] Block Scanner User Agents (rule_block_scanner_user_agents_JRvc3A) : ✅ active, valid
+
+TESTS LIVE :
+  Blocages (attendu 403) :
+    ✅ 6/6 OK
+  Passages (attendu 200) :
+    ✅ 8/8 OK
+
+COHÉRENCE DOC ↔ PROD :
+  [OK | DRIFT détecté sur : …]
+
+CRITICAL :
+  [C1] …
+
+HIGH :
+  [H1] …
+
+WARNING :
+  [W1] …
+
+VERDICT : ✅ Firewall opérationnel | ❌ N issues à corriger immédiatement
+
+ACTIONS PRIORITAIRES :
+  1. …
+  2. …
+```
+
+Retourne **uniquement** ce rapport + 3 actions prioritaires. Pas de code supplémentaire, pas de suggestions spéculatives.
+
+## Note
+
+Cet agent est en **lecture seule** (aucune modification de la config). Pour modifier une rule, utiliser directement l'API REST documentée dans `docs/vercel-firewall.md` ou l'UI Vercel, puis relancer cet agent pour valider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 ---
 
+## Durcissement firewall Vercel — 2 custom rules de blocage
+*14 avril 2026*
+
+**Le défi :** Audit du Vercel Firewall sur plan Hobby. Le dashboard montrait 348 événements "Logged" sur 7 jours — des scanners automatisés qui atteignaient l'origine en consommant des invocations Fluid Compute inutiles. Bot Protection en mode `log` uniquement (limite Hobby), aucune custom rule, aucune IP bloquée. Surface de bruit importante qui allait croître avec la visibilité du site.
+
+**Ce qu'on a fait :** Configuration directe via l'API REST Vercel (`PATCH /v1/security/firewall/config`), aucun changement de code, aucune PR. Deux custom rules créées :
+- **Rule 1 — Block Common Attack Paths** (`rule_block_common_attack_paths_vdZOUZ`) : regex sur `/wp-admin`, `/xmlrpc.php`, `/.env`, `/.git`, `/phpmyadmin`, `/administrator`, `/wordpress`, `/adminer`, `/cgi-bin`. Ces chemins n'existent pas sur un Vite SPA — aucun user légitime ne les visite.
+- **Rule 2 — Block Scanner User Agents** (`rule_block_scanner_user_agents_JRvc3A`) : substring match sur `sqlmap`, `nikto`, `nuclei`, `masscan`, `gobuster`, `dirbuster`, `feroxbuster`, `wpscan`, `acunetix`, `nessus`, `openvas`, `zgrab`, `CensysInspect`. `curl`, `wget`, `python-requests` et navigateurs restent autorisés.
+
+**Validation :** Tests HTTP live — `/wp-admin` → 403 `x-vercel-mitigated: deny`, `/xmlrpc.php` → 403, UA sqlmap → 403, UA browser normal → 200, homepage → 200. Zéro impact sur les users légitimes. Projet visant une audience internationale → pas de geo-blocking.
+
+**Pourquoi c'est important :** Chaque requête bloquée au niveau firewall, c'est une invocation Fluid Compute économisée, un log Sentry de moins pollué, un signal clair envoyé aux scanners que le site n'est pas une cible facile. Surtout, c'est une **configuration externe réversible en 1 call API** — aucun risque pour le code.
+
+**Traçabilité :** Documentation complète dans `docs/vercel-firewall.md` (IDs, patterns, procédure de rollback, endpoints API). Agent dédié créé : `.claude/agents/vercel-firewall-auditor.md` — audite la config et teste les rules en conditions réelles, à lancer avant chaque release majeure.
+
+**Limite connue du plan Hobby :** Bot Protection avancé et rate-limiting firewall-level nécessitent Pro. Si le site scale, c'est la première fonctionnalité à activer. Entre-temps, les 2 custom rules + OWASP CRS partiel en `log` couvrent le risque principal.
+
+---
+
 ## 900 tests unitaires — couverture complète du curriculum
 *13 avril 2026 · PR #112*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **`content-auditor`** — audit pédagogique A→Z : env coverage, cohérence curriculum↔moteur↔tests, liens externes, chaîne de prérequis, qualité validate(). Lancer avant chaque release majeure ou à la demande.
 - **`security-auditor`** — audit cybersécurité black hat : OWASP Top 10 (2021), OWASP API Sec (2023), CSP L3, rate limiting, RLS, auth flow, supply chain, RGPD, vecteurs 2026. Lancer avant chaque release majeure, après mise à jour de dépendances, ou à la demande. (THI-53)
 - **`ui-auditor`** — détecte composants custom qui devraient utiliser shadcn/ui, deps fantômes, composants installés mais jamais importés, couleurs/tailles en dur. **Obligatoire avant toute PR touchant des composants UI.** CRITICAL = bloque le merge. (THI-86)
+- **`vercel-firewall-auditor`** — lit la config Vercel Firewall active (WAF, managed rules, custom rules) et exécute une batterie de tests HTTP live contre `terminallearning.dev` pour confirmer que les rules bloquent bien les patterns d'attaque et laissent passer les users légitimes. Nécessite `$VERCEL_TOKEN` en session. Lancer avant chaque release majeure ou après toute modification firewall. Détails : `docs/vercel-firewall.md`.
 
 ### Début de chaque session
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés
@@ -102,6 +103,12 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 ### Avant toute PR touchant des composants UI
 - Invoquer l'agent **`ui-auditor`** → analyser le rapport, corriger les CRITICAL avant de proposer la PR
 - Tout CRITICAL dans le rapport bloque le merge — pas d'exception
+
+### Vercel Firewall — modifications
+- Toute modification firewall passe par l'**API REST Vercel** (pas par `vercel.json`)
+- Documenter chaque changement dans `docs/vercel-firewall.md` (IDs, patterns, rationale, rollback)
+- Lancer l'agent **`vercel-firewall-auditor`** après chaque modification pour valider en conditions réelles
+- **Ne jamais commiter le `VERCEL_TOKEN`** — variable d'environnement en session uniquement, révoquer après usage
 
 ### Règles merge
 - CI verte **ET** Sourcery vérifié avant de proposer un merge — **dans cet ordre, sans exception**

--- a/STORY.md
+++ b/STORY.md
@@ -251,6 +251,22 @@ Résultat : -2 453 lignes, +329 ajoutées. Le Landing passe de ~65 kB à ~25 kB 
 
 Ce qu'on retient : les garde-fous ne sont pas optionnels sur un projet pédagogique. Si on enseigne les bonnes pratiques, on les applique d'abord.
 
+**Le firewall qu'on a pris le temps d'allumer — THI-89 (14 avril 2026)**
+
+Un soir, en ouvrant le dashboard Vercel pour vérifier autre chose, on est tombés sur la page Firewall du projet. **348 événements "Logged" sur les sept derniers jours.** Pas des attaques réussies — rien de cassé, rien d'exploité. Juste du bruit constant : des scanners automatisés qui tapent `/wp-admin`, `/xmlrpc.php`, `/.env`, `/phpmyadmin`, encore et encore. Des bots qui testent aveuglément si le site est une installation WordPress vulnérable, sans savoir — et sans se soucier — que c'est une app Vite/React qui n'a rien à voir.
+
+La réaction naturelle aurait été : "c'est logged, pas bloqué, donc c'est pas grave". Sauf que chaque requête qui atteint l'origine consomme une invocation Fluid Compute, pollue les logs Sentry, envoie un signal implicite que le site est une cible sans résistance. Sur un projet qui se veut exemplaire pédagogiquement, laisser ce bruit sans réponse, c'est incohérent.
+
+Le plan Hobby impose une contrainte honnête : Bot Protection reste bloqué en mode `log` only, impossible de basculer en `challenge` ou `block` sans passer Pro. Pas de rate-limiting au niveau firewall, pas de BotID avancé. On a fait avec. **Deux custom rules**, créées directement via l'API REST Vercel — pas via `vercel.json`, parce que les rules firewall vivent dans une config WAF séparée. La première bloque les chemins d'attaque connus : `wp-admin`, `xmlrpc`, `.env`, `.git`, `phpmyadmin`, `administrator`, `wordpress`, `adminer`. La seconde bloque une liste d'user-agents de scanners offensifs : `sqlmap`, `nikto`, `nuclei`, `masscan`, `gobuster`, `wpscan`, `acunetix`, `nessus`. `curl`, `wget`, `python-requests` et les vrais navigateurs passent sans problème. Les devs ne sont pas gênés, les bots le sont.
+
+Le débat qu'on a eu — et qu'on a tranché sans hésiter : **pas de geo-blocking**. Bloquer la Chine ou la Russie aurait été un gain facile sur les métriques, mais Terminal Learning vise une audience internationale, et un jour un développeur en déplacement, un étudiant expat ou quelqu'un derrière un VPN aurait été bloqué pour la mauvaise raison. Le firewall filtre des comportements, pas des origines.
+
+Les tests en prod ont confirmé le comportement attendu : `/wp-admin` retourne 403 avec le header `x-vercel-mitigated: deny`, `sqlmap` comme user-agent retourne 403, la homepage reste à 200, un navigateur normal reste à 200. Zéro faux positif identifié.
+
+Comme pour le reste du projet, la vigilance manuelle ne passe pas à l'échelle. Un nouvel agent est né — `vercel-firewall-auditor` — en lecture seule, qui relit la config WAF active et lance une batterie de tests HTTP live contre la prod pour confirmer que les rules bloquent bien ce qu'elles doivent et laissent passer ce qui doit passer. À lancer avant chaque release majeure, ou après toute modification du firewall. Le pattern est maintenant familier : dès qu'on prend une décision opérationnelle, on écrit le garde-fou qui la valide automatiquement.
+
+Ce qu'on retient : la sécurité qui n'est pas visible depuis le code est la plus facile à oublier. Un dashboard Vercel qu'on ouvre une fois par mois, des logs qu'on ne lit jamais, une config WAF qu'on pense "sûrement par défaut OK" — c'est exactement là que la dette s'accumule silencieusement. Allumer le firewall, c'est reconnaître que la surface d'attaque d'un site public commence bien avant le code qu'on a écrit.
+
 ### Ce sur quoi on travaille maintenant
 
 **Migration shadcn/ui (THI-85)**
@@ -285,4 +301,4 @@ Ce journal continuera d'être écrit tant que le projet continue d'être constru
 ---
 
 *Terminal Learning est un projet open source, construit bénévolement en Belgique.*
-*Dernière mise à jour : 13 avril 2026*
+*Dernière mise à jour : 14 avril 2026*

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -23,6 +23,7 @@
 | THI-57 | security | Sentry tunnel rate limiting — sliding window 50 req/min/IP, 429 + Retry-After (PR #69) ✅ Done |
 | THI-58 | security | `cloneFSNode()` guard MAX_FS_NODES=10k + localStorage JSDoc ProgressContext (PR #70) ✅ Done |
 | docs | security | SECURITY.md update — CORP/COOP, Terminal Engine, API rate limiting documentés (PR #71) ✅ Done |
+| ops | security | Vercel Firewall — 2 custom rules (attack paths + scanner UAs) via API REST, agent `vercel-firewall-auditor`, `docs/vercel-firewall.md` (14 avril 2026) ✅ Done |
 | THI-46 | seo | SEO/GEO update — sitemap 42 URLs, llms.txt, JSON-LD 8 modules, manifest.webmanifest ✅ Done |
 | THI-47 | ui | UserMenu GitHub-style — avatar + sync dot + dropdown ✅ Done |
 | THI-48 | fix | Sidebar profile card + auth signOut scope:global + sync timeout 10s ✅ Done |

--- a/docs/vercel-firewall.md
+++ b/docs/vercel-firewall.md
@@ -1,0 +1,119 @@
+# Vercel Firewall — Terminal Learning
+
+> Configuration du WAF Vercel pour terminallearning.dev.
+> Toute modification doit être appliquée **via l'API REST** (pas via `vercel.json`), documentée ici, et testée avec l'agent `vercel-firewall-auditor`.
+
+## Identifiants
+
+| Clé           | Valeur                                  |
+|---------------|-----------------------------------------|
+| Team          | `team_1OqGNo4IePhrMgU0nfCnuqyK`         |
+| Project       | `prj_mfBbwmor5DhN57SEasB1RtYAFE5m`      |
+| WAF config    | `waf_YU6q43MK7LUx`                      |
+| Plan          | Hobby (limite Bot Protection = log only) |
+
+## Endpoints API utilisés
+
+```
+GET   https://api.vercel.com/v1/security/firewall/config?projectId=...&teamId=...
+PATCH https://api.vercel.com/v1/security/firewall/config?projectId=...&teamId=...
+```
+
+Header requis : `Authorization: Bearer <VERCEL_TOKEN>`.
+**Le token n'est jamais commité.** Utiliser une variable d'environnement en session uniquement et **révoquer** après usage via https://vercel.com/account/tokens.
+
+## Managed rules — état
+
+| Ruleset           | Actif | Action |
+|-------------------|-------|--------|
+| bot_protection    | ✅    | log (Hobby = block/challenge indisponible) |
+| owasp.xss         | ✅    | log    |
+| owasp.sqli        | ✅    | log    |
+| owasp.rce         | ✅    | log    |
+| owasp.gen         | ✅    | log    |
+| owasp.lfi/rfi/php/ma/sd/sf/java | ❌ | log |
+| ai_bots           | ❌    | —      |
+| vercel_ruleset    | ❌    | —      |
+
+## Custom rules — actives
+
+### Rule 1 — Block Common Attack Paths
+- **ID** : `rule_block_common_attack_paths_vdZOUZ`
+- **Action** : `deny` (403 avec header `x-vercel-mitigated: deny`)
+- **Type** : `path` avec opérateur `re` (regex)
+- **Pattern** :
+  ```
+  ^/(wp-admin|wp-login\.php|wp-content|wp-includes|wp-config|xmlrpc\.php|\.env|\.git|phpmyadmin|phpMyAdmin|pma|administrator|wordpress|adminer|cgi-bin)
+  ```
+- **Rationale** : chemins que jamais aucun user légitime ne visite sur un SPA Vite. Bloque les scanners WordPress/Joomla/phpMyAdmin avant qu'ils ne consomment une invocation Fluid Compute.
+- **Faux positifs possibles** : aucun identifié. `.env` et `.git` ne sont pas servis en prod (`.gitignore` + Vite dist).
+
+### Rule 2 — Block Scanner User Agents
+- **ID** : `rule_block_scanner_user_agents_JRvc3A`
+- **Action** : `deny`
+- **Type** : `user_agent` avec opérateur `sub` (substring, case-sensitive)
+- **Condition groups** (OR logique entre les groupes) :
+  `sqlmap` · `nikto` · `acunetix` · `nuclei` · `masscan` · `gobuster` · `dirbuster` · `feroxbuster` · `wpscan` · `nessus` · `openvas` · `zgrab` · `CensysInspect`
+- **Rationale** : UAs utilisés presque exclusivement par des scanners offensifs. `curl`, `wget`, `python-requests` et navigateurs ne sont **pas** bloqués — devs et outils légitimes préservés.
+- **Limite connue** : case-sensitive. Un attaquant peut changer `sqlmap` en `SQLMAP` — c'est une limite de l'opérateur `sub`. Acceptable : la majorité des bots utilisent la casse par défaut.
+
+## Tests de validation (exécutés le 14 avril 2026)
+
+| Requête                              | Attendu | Obtenu        |
+|--------------------------------------|---------|---------------|
+| `GET /wp-admin`                      | 403     | 403 ✅ `x-vercel-mitigated: deny` |
+| `GET /xmlrpc.php`                    | 403     | 403 ✅         |
+| `GET /` (navigateur)                 | 200     | 200 ✅         |
+| `GET / -A "sqlmap/1.7"`              | 403     | 403 ✅         |
+| `GET / -A "Mozilla/5.0 ..."`         | 200     | 200 ✅         |
+
+## Procédure de rollback
+
+Si une rule cause un faux positif en prod :
+
+1. **Désactiver sans supprimer** (réversible en 1 call) :
+   ```bash
+   curl -X PATCH -H "Authorization: Bearer $VERCEL_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"action":"rules.update","id":"<RULE_ID>","value":{"active":false}}' \
+     "https://api.vercel.com/v1/security/firewall/config?projectId=prj_mfBbwmor5DhN57SEasB1RtYAFE5m&teamId=team_1OqGNo4IePhrMgU0nfCnuqyK"
+   ```
+
+2. **Supprimer définitivement** :
+   ```bash
+   curl -X PATCH -H "Authorization: Bearer $VERCEL_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"action":"rules.remove","id":"<RULE_ID>"}' \
+     "https://api.vercel.com/v1/security/firewall/config?projectId=prj_mfBbwmor5DhN57SEasB1RtYAFE5m&teamId=team_1OqGNo4IePhrMgU0nfCnuqyK"
+   ```
+
+3. **Désactiver tout le firewall** (dernier recours) :
+   ```bash
+   curl -X PATCH -H "Authorization: Bearer $VERCEL_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"action":"firewallEnabled","value":false}' \
+     "https://api.vercel.com/v1/security/firewall/config?projectId=prj_mfBbwmor5DhN57SEasB1RtYAFE5m&teamId=team_1OqGNo4IePhrMgU0nfCnuqyK"
+   ```
+
+L'UI Vercel (`/[team]/terminal-learning/firewall`) permet aussi ces actions en 1 clic.
+
+## Limitations du plan Hobby
+
+- **Bot Protection** bloqué en mode `log` uniquement — impossible de passer en `challenge`/`block`
+- **Rate limiting firewall-level** indisponible → si besoin, passer par un middleware Vercel ou upgrade Pro
+- **BotID avancé** nécessite Pro
+- **Quota custom rules** : à ce jour 2/N utilisées (limite exacte non documentée publiquement)
+
+## Évolutions futures
+
+- [ ] Si upgrade Pro : passer `bot_protection` en `challenge`, activer `ai_bots`, considérer `vercel_ruleset`
+- [ ] Après Phase 9 admin panel : afficher les métriques firewall dans le Security Center
+- [ ] Ajouter rule IP-based si des IPs récurrentes apparaissent dans les Denied IPs (scan hebdomadaire manuel ou via agent)
+- [ ] Considérer un middleware Vercel pour rate-limiter `/auth/*` une fois migré en API routes (actuellement Supabase gère côté serveur externe)
+
+## Traçabilité
+
+- **Créé le** : 14 avril 2026
+- **Par** : Claude Code session (Opus 4.6) via API REST Vercel
+- **Référence agent** : `.claude/agents/vercel-firewall-auditor.md`
+- **Entrée CHANGELOG** : Durcissement firewall Vercel (14 avril 2026)


### PR DESCRIPTION
## Summary

- 2 custom Vercel Firewall rules configured via REST API (`PATCH /v1/security/firewall/config`) — block WordPress/phpMyAdmin decoy paths and known security-scanner user agents
- Dedicated agent `vercel-firewall-auditor` created to re-validate the WAF config + run live HTTP tests before each release
- Full docs + rollback procedure in `docs/vercel-firewall.md`, session protocol updated in `CLAUDE.md`

## Why

Vercel Firewall dashboard showed 348 \"Logged\" events over 7 days — automated scanners hitting the origin and burning Fluid Compute invocations for nothing. On Hobby plan, Bot Protection is stuck in `log` mode, so custom rules are the only way to actually block this noise.

## Rules created

**Rule 1 — Block Common Attack Paths** (\`rule_block_common_attack_paths_vdZOUZ\`)
- \`type=path, op=re\` → matches \`/wp-admin\`, \`/wp-login.php\`, \`/wp-content\`, \`/wp-includes\`, \`/wp-config\`, \`/xmlrpc.php\`, \`/.env\`, \`/.git\`, \`/phpmyadmin\`, \`/administrator\`, \`/wordpress\`, \`/adminer\`, \`/cgi-bin\`
- action: \`deny\` (403 with \`x-vercel-mitigated: deny\`)

**Rule 2 — Block Scanner User Agents** (\`rule_block_scanner_user_agents_JRvc3A\`)
- \`type=user_agent, op=sub\` → substring match on: \`sqlmap\`, \`nikto\`, \`nuclei\`, \`masscan\`, \`gobuster\`, \`dirbuster\`, \`feroxbuster\`, \`wpscan\`, \`acunetix\`, \`nessus\`, \`openvas\`, \`zgrab\`, \`CensysInspect\`
- action: \`deny\`
- \`curl\`, \`wget\`, \`python-requests\` and real browsers are **not** blocked

## Live tests against terminallearning.dev

| Request | Expected | Actual |
|---------|----------|--------|
| \`GET /wp-admin\` | 403 | 403 ✅ |
| \`GET /xmlrpc.php\` | 403 | 403 ✅ |
| \`GET /\` | 200 | 200 ✅ |
| \`UA=sqlmap/1.7\` | 403 | 403 ✅ |
| \`UA=Mozilla/5.0 ...\` | 200 | 200 ✅ |

No false positives identified. International audience preserved (no geo-blocking).

## Why no code change / no vercel.json change

Vercel Firewall custom rules live in a separate WAF config, **not** in \`vercel.json\`. The API is the supported path. This PR contains only documentation and a read-only auditor agent; the firewall itself was mutated via the Vercel REST API during the session that produced this PR.

## Files

- ➕ \`.claude/agents/vercel-firewall-auditor.md\` — read-only agent, runs \`curl\` tests
- ➕ \`docs/vercel-firewall.md\` — config, IDs, API endpoints, rollback procedure
- ✏️ \`CHANGELOG.md\` — public entry
- ✏️ \`CLAUDE.md\` — agent added to protocol, \"Vercel Firewall — modifications\" section
- ✏️ \`docs/plan.md\` — security row appended

## Test plan

- [x] Live HTTP tests on production (results above)
- [ ] Visual check that \`terminallearning.dev\` is unaffected (Chrome + mobile)
- [ ] Run new \`vercel-firewall-auditor\` agent end-to-end (requires \`\$VERCEL_TOKEN\` in session)
- [ ] Sourcery review clean

## Notes

- Linear issue: [THI-89](https://linear.app/thierryvm/issue/THI-89)
- Vercel token used during this session was created with 7-day expiration and revoked manually immediately after
- Hobby plan limits (Bot Protection log-only, no FW-level rate limiting) are acknowledged in the doc; upgrade path covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)