### PR TITLE
docs: sync README/STORY/ROADMAP/ARCHITECTURE for THI-90 + 900 tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,14 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
-- Phase 5 🔄 Curriculum expansion — 11 modules, 64 leçons, 891 tests unitaires + 176 E2E Playwright (en cours)
+- Phase 5 🔄 Curriculum expansion — 11 modules, 64 leçons, 900 tests unitaires + 176 E2E Playwright (en cours)
 - Phase 5.5 ✅ Terminal Sentinel — agents sécurité + contenus automatisés (PR #90, 12 avril 2026)
 - Phase 7 ✅ RBAC complet — student/teacher/institution_admin/super_admin + RLS + audit log (PR #92, 12 avril 2026)
 - THI-29 ✅ Module 11 — L'IA comme outil dev (12 leçons, `ai-help` + 11 sous-commandes, PR #103, 13 avril 2026)
 - THI-84 ✅ Changelog public — CHANGELOG.md + STORY.md + routes /changelog /story + SEO (PRs #100–102, 13 avril 2026)
 - THI-87 ✅ Bundle optimization — motion/react retiré, 22 deps inutilisées supprimées, 8 composants shadcn dormants supprimés (PR #108, 13 avril 2026)
 - Phase 4c ✅ Bundle Optimization complète — Landing chunk ~65kB→~25kB gzip
+- THI-90 ✅ INP fix — `setEnvironment` wrappé dans `startTransition`, lab CPU 4× : 515ms → 26ms (−95%) sur env switcher (PR #114, 14 avril 2026)
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No account required. No setup. Just open it and start learning.
 
 - 🖥️ **Interactive terminal** — type real commands, get real feedback (not just theory)
 - 🌍 **Multi-environment** — learn on Linux, macOS, or Windows — the interface adapts
-- 🔒 **Progressive curriculum** — 11 modules, 64 lessons, 891 unit tests
+- 🔒 **Progressive curriculum** — 11 modules, 64 lessons, 900 unit tests
 - 🤖 **AI as a dev tool** — dedicated module on using AI professionally (prompts, validation, limits)
 - 💾 **Progress saved automatically** — locally, or synced to the cloud with a free account
 - 📖 **Contextual help** — `help <command>` returns usage and examples for your environment
@@ -66,7 +66,7 @@ This makes learning more realistic and less confusing — you practice the exact
 | Routing | React Router | 7.x |
 | Styling | Tailwind CSS | 4.x |
 | Components | shadcn/ui (Radix UI) | latest |
-| Animations | Motion (Framer Motion) | 12.x |
+| Animations | CSS keyframes + IntersectionObserver | — |
 | Auth & Database | Supabase (PostgreSQL + RLS) | 2.x |
 | Error Tracking | Sentry (free tier) | 8.x |
 | Tests | Vitest + Playwright | — |
@@ -103,7 +103,7 @@ Full security policy and vulnerability reporting: [SECURITY.md](SECURITY.md)
 | **Phase 2** | ✅ Done | Vercel Analytics + Sentry error monitoring + source maps |
 | **Phase 3** | ✅ Done | Supabase Auth + user progress sync |
 | **Phase 4** | ✅ Done | Curriculum v2 + multi-environment selection + terminal profiles |
-| **Phase 5** | 🔄 In progress | Curriculum expansion: 11 modules, 64 lessons, 891 unit tests + 176 E2E |
+| **Phase 5** | 🔄 In progress | Curriculum expansion: 11 modules, 64 lessons, 900 unit tests + 176 E2E |
 | **Phase 5.5** | ✅ Done | Terminal Sentinel — automated security & content audit agents |
 | **Phase 7** | ✅ Done | RBAC — student / teacher / institution_admin / super_admin roles |
 | **THI-29** | ✅ Done | Module 11 — AI as a dev tool (12 lessons, `ai-help` command) |

--- a/STORY.md
+++ b/STORY.md
@@ -267,6 +267,18 @@ Comme pour le reste du projet, la vigilance manuelle ne passe pas à l'échelle.
 
 Ce qu'on retient : la sécurité qui n'est pas visible depuis le code est la plus facile à oublier. Un dashboard Vercel qu'on ouvre une fois par mois, des logs qu'on ne lit jamais, une config WAF qu'on pense "sûrement par défaut OK" — c'est exactement là que la dette s'accumule silencieusement. Allumer le firewall, c'est reconnaître que la surface d'attaque d'un site public commence bien avant le code qu'on a écrit.
 
+**La régression INP qu'on a fini par mesurer pour de vrai — THI-90 (14 avril 2026)**
+
+Pendant plusieurs jours, Vercel Speed Insights affichait `INP P75 = 536ms (Poor)` sur production desktop. Pas une dégradation soudaine — un plateau persistant, avec un pic à 2000ms le 11 avril sur 197 visites classées "Unknown route". Plusieurs sessions de tentatives d'optimisation n'avaient rien bougé. Le précédent fix INP de mars (le `scrollIntoView → scrollTop` qui avait réduit le terminal de 592ms à 11ms) tenait toujours en place — la régression venait d'ailleurs.
+
+La tentation, dans ce genre de situation, c'est de continuer à supposer. "C'est peut-être le terminal", "c'est peut-être l'animation", "c'est peut-être Sentry". On a forcé une autre approche : **arrêter de supposer, mesurer**. Trace Chrome DevTools sur la prod réelle, puis sous CPU 4× throttling pour reproduire les conditions desktop d'un utilisateur lambda — pas la machine de dev. La trace a sorti un INP de 515ms sur le clic du sélecteur d'environnement (Linux/macOS/Windows). Match parfait avec le P75 prod. Et un breakdown qui ne laisse aucune ambiguïté : 7ms d'input delay, **393ms de processing duration**, 115ms de presentation. Quand le main thread est bloqué 393ms par le processing, c'est presque toujours le même pattern — un setState synchrone sur un sous-arbre lourd.
+
+La cause s'est révélée structurelle. `setEnvironment(envId)` dans `EnvironmentContext` déclenchait un `setSelectedEnvState` synchrone. Cascade : Landing (610 lignes JSX) re-render entièrement, TerminalPreview tue et relance son animation typing, la grille de niveaux remonte à cause d'un `key={selectedEnv}`, tous les `FadeIn` enfants re-render, et sur `/app` le Sidebar (autre consommateur du même context) re-render aussi. Le pointerdown handler restait coincé 393ms avant de rendre la main au navigateur. Les composants étaient pourtant tous "perf-friendly" en surface — useCallback, useMemo, MAX_LINES, le `scrollTop` d'avant. Mais le **state owner** ne demandait pas à React de prioriser ce re-render. Tout partait en une vague synchrone.
+
+Le fix tient en une ligne. Wrapper `setSelectedEnvState` dans `startTransition` au niveau du context. C'est l'API React canonique pour exactement ce cas : "ce changement d'état est important, mais pas urgent — rends-le quand tu peux, libère le main thread d'abord". Un seul changement bénéficie automatiquement aux deux callers (Landing + Sidebar). Validation lab : 515ms → 26ms sur l'env switcher homepage, 20ms sur Sidebar. −95%. Speed Insights confirmera sur prod réelle dans 24-48h.
+
+La leçon, qui mérite d'être inscrite quelque part : **quand un INP vient d'un setState, on n'optimise pas composant par composant**. On wrappe l'update au niveau du context owner et on laisse React faire son travail de scheduling. C'est gratuit, ciblé, et c'est la première chose à essayer avant de partir dans des refactors lourds.
+
 ### Ce sur quoi on travaille maintenant
 
 **Migration shadcn/ui (THI-85)**
@@ -281,7 +293,7 @@ Les outils pour les enseignants : vue classe, heatmaps d'activité, suivi de pro
 Ko-fi et GitHub Sponsors sont techniquement prêts. Les boutons dans l'app sont désactivés en attente d'un accord administratif (mutuelle Solidaris / RIZIV). Ce n'est pas un choix technique — c'est une contrainte réglementaire belge. Quand l'accord arrive, c'est une modification de trois lignes dans le code.
 
 **Multilingue : oui, mais quand ?**
-L'app est en français. L'anglais et le néerlandais sont dans la roadmap. La question n'est pas technique — c'est une question de contenu. Traduire 64 leçons et 891 validations de commandes demande une attention pédagogique qu'on ne peut pas expédier.
+L'app est en français. L'anglais et le néerlandais sont dans la roadmap. La question n'est pas technique — c'est une question de contenu. Traduire 64 leçons et 900 validations de commandes demande une attention pédagogique qu'on ne peut pas expédier.
 
 **Terminal Sentinel en mode public ?**
 L'outil d'audit de sécurité automatisé pourrait être proposé à d'autres projets open source. L'idée est dans les cartons. Elle implique de le documenter, de le rendre configurable, de le maintenir. Ce n'est pas rien.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ src/
 │   ├── setup.ts
 │   ├── progress.test.tsx         # ProgressContext tests
 │   ├── progressSync.test.ts      # mergeProgress + getDelta (10 tests)
-│   ├── terminalEngine.test.ts    # Terminal command tests (891 total across all suites)
+│   ├── terminalEngine.test.ts    # Terminal command tests (900 total across all suites)
 │   ├── validators.test.ts        # Exercise validator tests
 │   ├── curriculumTypes.test.ts   # Curriculum structure + catalogue consistency
 │   ├── curriculumEnvAwareness.test.ts # Multi-env coverage tests
@@ -224,7 +224,7 @@ security_reports (id, run_at, score int, findings jsonb, component text)
 | 2 | ✅ | Vercel Analytics + Sentry |
 | 3 | ✅ | Supabase Auth + progress persistence |
 | 4 | ✅ | Curriculum v2 + multi-environment + terminal profiles (192 tests) |
-| 5 | 🔄 | Curriculum expansion — 11 modules, 64 lessons, 891 unit + 176 E2E tests |
+| 5 | 🔄 | Curriculum expansion — 11 modules, 64 lessons, 900 unit + 176 E2E tests |
 | 5.5 | ✅ | Terminal Sentinel — automated security audit (THI-36, PR #90) |
 | 6 | 🔮 | Terminal multi-session (tabs) |
 | 7 | ✅ | Full RBAC — student/teacher/institution/admin + RLS (THI-37, PR #92) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Terminal Learning
 
-> Last updated: 13 April 2026 — Phase 4c Bundle Optimization ✅ (PR #108 merged) — motion/react removed, 22 unused deps cleaned, Landing ~25kB gzip — ui-auditor agent created — 11 modules / 64 lessons / 891 tests — Next: THI-85 shadcn/ui migration page by page
+> Last updated: 14 April 2026 — INP fix THI-90 ✅ (PR #114 merged) — `setEnvironment` wrappé dans `startTransition`, lab 515ms → 26ms (−95%) — Phase 4c Bundle Optimization ✅ (PR #108 merged) — motion/react removed, 22 unused deps cleaned, Landing ~25kB gzip — ui-auditor agent created — 11 modules / 64 lessons / 900 tests — Next: THI-85 shadcn/ui migration page by page
 
 ---
 
@@ -69,6 +69,7 @@ professionals who leverage AI as a tool, not a replacement.
 - [x] Remove motion/react (~40 kB gzip) — CSS animations + IntersectionObserver (PR #108, THI-87)
 - [x] Remove 22 unused dependencies (MUI, Emotion, canvas-confetti, react-dnd, recharts, etc.)
 - [x] Agent `ui-auditor` — design system compliance guard
+- [x] INP fix — `setEnvironment` wrappé dans `startTransition` au context owner, lab CPU 4× : 515ms → 26ms (−95%) sur env switcher (PR #114, THI-90)
 
 ## Phase 4d — Design System Compliance 🔮 Planned (THI-85)
 - [ ] Migrate custom components to shadcn/ui — page by page (Dashboard → LessonPage → Landing → NotFound)
@@ -76,7 +77,7 @@ professionals who leverage AI as a tool, not a replacement.
 - [ ] Zero custom `<button>`, `<card>`, `<badge>` patterns where shadcn equivalent exists
 
 ## Phase 5 — Curriculum Expansion 🔄 In progress
-Full-stack developer path — 11 modules ✅ (64 lessons, 891 unit tests)
+Full-stack developer path — 11 modules ✅ (64 lessons, 900 unit tests)
 
 ### Modules 1–7 ✅ (Phases 1–4)
 - [x] Navigation, Fichiers & Dossiers, Lecture de fichiers, Permissions, Processus, Redirection & Pipes (Modules 1–6)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
-> Dernière mise à jour : 13 avril 2026
-> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 11 modules ✅, 64 leçons, 891 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale) — **Tech debt identifiée** : composants shadcn/ui installés mais non utilisés (THI-85), agent ui-auditor créé (THI-86)
+> Dernière mise à jour : 14 avril 2026
+> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 11 modules ✅, 64 leçons, 900 tests unitaires + 176 E2E — Architecture stratégique validée (THI-35) : Terminal Sentinel (Phase 5.5), RBAC complet (Phase 7), Admin Panel 7 sections (Phase 9), PWA avancée (Phase finale) — **Tech debt identifiée** : composants shadcn/ui installés mais non utilisés (THI-85), agent ui-auditor créé (THI-86)
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation sync after THI-90 (PR #114 mergée) — pas de changement de code, uniquement de la doc.

- **README.md** : retire la ligne stack obsolète "Motion (Framer Motion)" (motion/react retiré PR #108) ; bump 891 → 900 tests
- **STORY.md** : ajoute la section narrative THI-90 (méthode de mesure, cause racine, fix, leçon) ; bump 891 → 900
- **docs/ROADMAP.md** : ajoute THI-90 à Phase 4c, rafraîchit le header "Last updated", bump 891 → 900
- **docs/ARCHITECTURE.md** : bump 891 → 900 (table des phases + commentaires fichiers critiques)
- **docs/plan.md** : bump date 13 → 14 avril 2026, 891 → 900
- **CLAUDE.md** : ajoute THI-90 à la liste des phases, bump 891 → 900

## Pourquoi

Sourcery / CI / Sentry observent la prod via la doc. Le README mentionnait toujours `Motion (Framer Motion)` comme dépendance principale alors que le package est retiré depuis PR #108 — c'est trompeur pour un nouveau contributeur. Idem pour le compteur de tests resté à 891 alors qu'on est à 900 depuis PR #112.

## Test plan

- [ ] CI verte (lint sur `.md`, build qui consomme `STORY.md` et `CHANGELOG.md` via `?raw` import)
- [ ] Validation visuelle Vercel preview — pages `/changelog` et `/story` rendent correctement la nouvelle section THI-90 (markdown + structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)