### PR TITLE
refactor(ui): migrate NotFound.tsx to shadcn Button + Badge (THI-85)

### DIFF
--- a/src/app/components/NotFound.tsx
+++ b/src/app/components/NotFound.tsx
@@ -4,6 +4,8 @@ import { Terminal, Home, Github, BookOpen, Zap, Shield } from 'lucide-react';
 import { curriculum } from '../data/curriculum';
 import { commandCatalogue } from '../data/commandCatalogue';
 import { ENVIRONMENTS } from '../types/curriculum';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
 
 const TOTAL_LESSONS = curriculum.reduce((sum, mod) => sum + mod.lessons.length, 0);
 const TOTAL_COMMANDS = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
@@ -16,11 +18,13 @@ const TERMINAL_LINES = [
   { prompt: null, command: 'terminal-learning/  commandes/  leçons/', delay: 1800, highlight: true },
 ];
 
-const PILLS = [
-  { icon: BookOpen, label: `${TOTAL_LESSONS} leçons`, color: 'text-emerald-400', border: 'border-emerald-500/30', bg: 'bg-emerald-500/10' },
-  { icon: Terminal, label: `${TOTAL_COMMANDS}+ commandes`, color: 'text-blue-400', border: 'border-blue-500/30', bg: 'bg-blue-500/10' },
-  { icon: Zap, label: `${ACTIVE_ENVIRONMENTS} environnements`, color: 'text-amber-400', border: 'border-amber-500/30', bg: 'bg-amber-500/10' },
-  { icon: Shield, label: '100% gratuit', color: 'text-purple-400', border: 'border-purple-500/30', bg: 'bg-purple-500/10' },
+type PillVariant = 'pill-emerald' | 'pill-blue' | 'pill-amber' | 'pill-purple';
+
+const PILLS: Array<{ icon: typeof BookOpen; label: string; variant: PillVariant }> = [
+  { icon: BookOpen, label: `${TOTAL_LESSONS} leçons`, variant: 'pill-emerald' },
+  { icon: Terminal, label: `${TOTAL_COMMANDS}+ commandes`, variant: 'pill-blue' },
+  { icon: Zap, label: `${ACTIVE_ENVIRONMENTS} environnements`, variant: 'pill-amber' },
+  { icon: Shield, label: '100% gratuit', variant: 'pill-purple' },
 ];
 
 /** Animated terminal line — types character by character */
@@ -136,14 +140,11 @@ export function NotFound() {
           className="animate-fade-in-up flex flex-wrap gap-2 justify-center mb-8"
           style={{ animationDelay: '350ms' }}
         >
-          {PILLS.map(({ icon: Icon, label, color, border, bg }) => (
-            <span
-              key={label}
-              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border ${border} ${bg} ${color} text-xs font-medium`}
-            >
-              <Icon size={12} aria-hidden="true" />
+          {PILLS.map(({ icon: Icon, label, variant }) => (
+            <Badge key={label} variant={variant}>
+              <Icon size={12} aria-hidden="true" className="size-[12px]" />
               {label}
-            </span>
+            </Badge>
           ))}
         </div>
 
@@ -152,20 +153,14 @@ export function NotFound() {
           className="animate-fade-in-up flex flex-col sm:flex-row gap-3 justify-center"
           style={{ animationDelay: '500ms' }}
         >
-          <button
-            onClick={() => navigate('/')}
-            className="flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold text-sm transition-all hover:scale-[1.02] active:scale-[0.98]"
-          >
-            <Home size={15} aria-hidden="true" />
+          <Button variant="emerald" size="cta-pill" onClick={() => navigate('/')}>
+            <Home size={15} aria-hidden="true" className="size-[15px]" />
             Accueil
-          </button>
-          <button
-            onClick={() => navigate('/app')}
-            className="flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium text-sm transition-all"
-          >
-            <Terminal size={15} aria-hidden="true" />
+          </Button>
+          <Button variant="ghost-gh" size="cta-pill" onClick={() => navigate('/app')}>
+            <Terminal size={15} aria-hidden="true" className="size-[15px]" />
             Commencer l'apprentissage
-          </button>
+          </Button>
         </div>
 
         {/* Open source mention */}

--- a/src/app/components/ui/badge.tsx
+++ b/src/app/components/ui/badge.tsx
@@ -17,6 +17,15 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        // Terminal Learning — colored pill variants (THI-85)
+        "pill-emerald":
+          "rounded-full border-emerald-500/30 bg-emerald-500/10 text-emerald-400 gap-1.5 px-3 py-1.5",
+        "pill-blue":
+          "rounded-full border-blue-500/30 bg-blue-500/10 text-blue-400 gap-1.5 px-3 py-1.5",
+        "pill-amber":
+          "rounded-full border-amber-500/30 bg-amber-500/10 text-amber-400 gap-1.5 px-3 py-1.5",
+        "pill-purple":
+          "rounded-full border-purple-500/30 bg-purple-500/10 text-purple-400 gap-1.5 px-3 py-1.5",
       },
     },
     defaultVariants: {

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -19,12 +19,19 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        // Terminal Learning — GitHub-dark theme variants (THI-85)
+        emerald:
+          "bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold hover:scale-[1.02] active:scale-[0.98]",
+        "ghost-gh":
+          "border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9 rounded-md",
+        // Terminal Learning — CTA pill matching legacy px-6 py-2.5 rounded-xl
+        "cta-pill": "h-auto rounded-xl px-6 py-2.5 text-sm",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

First PR of the shadcn/ui migration (THI-85). NotFound.tsx chosen as POC — smallest page, no data dependencies, both `<button>` and `<span>` pill patterns to validate.

**Decision architecturale** (documentée dans `memory/project_thi85_shadcn_migration.md`) :
Le thème shadcn par défaut (`--primary: #030213` quasi-noir) est incompatible avec le design GitHub-dark de Terminal Learning. → Option C retenue : **variantes custom** dans `button.tsx` / `badge.tsx`, pas de modification des CSS tokens. Visuel strictement identique, gains shadcn (Slot, focus-ring a11y, aria, keyboard) préservés.

## Changes

### `src/app/components/ui/button.tsx`
- `variant: "emerald"` — CTA primaire (`bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold` + hover scale)
- `variant: "ghost-gh"` — CTA secondaire GitHub-style (`border-[#30363d] hover:border-emerald-500/40`)
- `size: "cta-pill"` — dimensions Terminal Learning (`rounded-xl px-6 py-2.5`)

### `src/app/components/ui/badge.tsx`
- `variant: "pill-emerald"` / `"pill-blue"` / `"pill-amber"` / `"pill-purple"` — pills colorées (border/10 + bg/10 + texte/400, rounded-full, px-3 py-1.5)

### `src/app/components/NotFound.tsx`
- 2× `<button>` custom → `<Button variant="emerald|ghost-gh" size="cta-pill">`
- 4× `<span>` pills custom → `<Badge variant="pill-*">`
- Lucide icons : `className="size-[15px]"` / `"size-[12px]"` pour contourner le default shadcn 16px (exclusion regex `[class*='size-']`)

## Test plan

- [x] Type-check propre
- [x] 900 tests passent (15 files, 1 skipped)
- [ ] Screenshot visuel prod (`terminallearning.dev/fake`) vs preview Vercel — pixel-perfect
- [ ] `ui-auditor` agent → VERDICT Clean
- [ ] Validation visuelle Thierry sur preview Vercel (desktop + mobile)

## Blast radius

Isolé : uniquement route `/*` (404). Les ajouts de variantes dans `ui/button.tsx` / `ui/badge.tsx` sont additifs (aucune variante existante modifiée) — zero risque de régression sur code utilisant ces fichiers (aucun utilisateur aujourd'hui).

Linear : https://linear.app/thierryvm/issue/THI-85

🤖 Generated with [Claude Code](https://claude.com/claude-code)