### PR TITLE
feat(ui): enhance 404 page with useful links + mobile fix (THI-85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - THI-87 ✅ Bundle optimization — motion/react retiré, 22 deps inutilisées supprimées, 8 composants shadcn dormants supprimés (PR #108, 13 avril 2026)
 - Phase 4c ✅ Bundle Optimization complète — Landing chunk ~65kB→~25kB gzip
 - THI-90 ✅ INP fix — `setEnvironment` wrappé dans `startTransition`, lab CPU 4× : 515ms → 26ms (−95%) sur env switcher (PR #114, 14 avril 2026)
-- THI-85 🔄 shadcn migration — NotFound.tsx ✅ (PR #116, 14 avril 2026, variantes `emerald`/`ghost-gh`/`pill-*`, pixel-perfect desktop + mobile). Reste : Dashboard, LessonPage, Landing, ChangelogPage, StoryPage, CommandReference.
+- THI-85 🔄 shadcn migration — NotFound.tsx ✅ (PR #116, 14 avril 2026, variantes `emerald`/`ghost-gh`/`pill-*`, pixel-perfect desktop + mobile) + Enhance 404 (PR #117, 14 avril 2026, bloc "Pages utiles" crawlable + fix contraste footer iPhone 14). Reste : Dashboard, LessonPage, Landing, ChangelogPage, StoryPage, CommandReference.
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -58,7 +58,7 @@
 | THI-83 | perf | INP 592ms fix — instant scroll + MAX_LINES cap + startTransition (PR #99) ✅ Done |
 | THI-84 | content | Trust badges cliquables (securityheaders.com + GitHub Actions) + badge "876 tests · CI verte" (PR #100) + CHANGELOG.md + STORY.md (PR #101) + routes /changelog et /story avec SEO/OG (PR #102) ✅ Done |
 | THI-87 | perf | Remove motion/react (~40 kB gzip) — CSS animations + IntersectionObserver + cleanup 22 deps inutilisées + 8 composants shadcn dormants supprimés (PR #108) ✅ Done |
-| THI-85 | tech-debt | Migrer composants custom vers shadcn/ui — page par page. NotFound.tsx ✅ (PR #116, 14 avril 2026 — variantes `emerald` / `ghost-gh` / `pill-*`). Reste : Dashboard, LessonPage, Landing, ChangelogPage, StoryPage, CommandReference 🔄 In Progress |
+| THI-85 | tech-debt | Migrer composants custom vers shadcn/ui — page par page. NotFound.tsx ✅ (PR #116, 14 avril 2026 — variantes `emerald` / `ghost-gh` / `pill-*`). Enhance 404 (PR #117, 14 avril 2026) — bloc "Pages utiles" SEO/GEO crawlable + fix contraste footer iPhone 14 (`#484f58` → `#8b949e`). Reste : Dashboard, LessonPage, Landing, ChangelogPage, StoryPage, CommandReference 🔄 In Progress |
 | THI-86 | agents | Ajouter ui-auditor au protocole de session obligatoire + CLAUDE.md 🔮 Backlog |
 | THI-77 | Phase 9 | Heatmap activité élève — vue enseignant (GitHub-style) 🔮 Backlog |
 | THI-78 | Phase 9 | Heatmap adoption plateforme — vue super_admin/institution_admin 🔮 Backlog |

--- a/src/app/components/NotFound.tsx
+++ b/src/app/components/NotFound.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router';
-import { Terminal, Home, Github, BookOpen, Zap, Shield, Heart, Clock } from 'lucide-react';
+import { Terminal, Home, Github, BookOpen, Zap, Shield, Heart, Clock, type LucideIcon } from 'lucide-react';
 import { curriculum } from '../data/curriculum';
 import { commandCatalogue } from '../data/commandCatalogue';
 import { ENVIRONMENTS } from '../types/curriculum';
@@ -20,14 +20,14 @@ const TERMINAL_LINES = [
 
 type PillVariant = 'pill-emerald' | 'pill-blue' | 'pill-amber' | 'pill-purple';
 
-const PILLS: Array<{ icon: typeof BookOpen; label: string; variant: PillVariant }> = [
+const PILLS: Array<{ icon: LucideIcon; label: string; variant: PillVariant }> = [
   { icon: BookOpen, label: `${TOTAL_LESSONS} leçons`, variant: 'pill-emerald' },
   { icon: Terminal, label: `${TOTAL_COMMANDS}+ commandes`, variant: 'pill-blue' },
   { icon: Zap, label: `${ACTIVE_ENVIRONMENTS} environnements`, variant: 'pill-amber' },
   { icon: Shield, label: '100% gratuit', variant: 'pill-purple' },
 ];
 
-const USEFUL_LINKS: Array<{ icon: typeof BookOpen; to: string; label: string; desc: string }> = [
+const USEFUL_LINKS: Array<{ icon: LucideIcon; to: string; label: string; desc: string }> = [
   { icon: BookOpen, to: '/reference', label: 'Référence', desc: 'Toutes les commandes expliquées' },
   { icon: Heart, to: '/story', label: 'L\u2019histoire', desc: 'Pourquoi cette app existe' },
   { icon: Clock, to: '/changelog', label: 'Changelog', desc: 'Nouveautés et mises à jour' },

--- a/src/app/components/NotFound.tsx
+++ b/src/app/components/NotFound.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { Terminal, Home, Github, BookOpen, Zap, Shield } from 'lucide-react';
+import { useNavigate, Link } from 'react-router';
+import { Terminal, Home, Github, BookOpen, Zap, Shield, Heart, Clock } from 'lucide-react';
 import { curriculum } from '../data/curriculum';
 import { commandCatalogue } from '../data/commandCatalogue';
 import { ENVIRONMENTS } from '../types/curriculum';
@@ -25,6 +25,13 @@ const PILLS: Array<{ icon: typeof BookOpen; label: string; variant: PillVariant 
   { icon: Terminal, label: `${TOTAL_COMMANDS}+ commandes`, variant: 'pill-blue' },
   { icon: Zap, label: `${ACTIVE_ENVIRONMENTS} environnements`, variant: 'pill-amber' },
   { icon: Shield, label: '100% gratuit', variant: 'pill-purple' },
+];
+
+const USEFUL_LINKS: Array<{ icon: typeof BookOpen; to: string; label: string; desc: string }> = [
+  { icon: BookOpen, to: '/reference', label: 'Référence', desc: 'Toutes les commandes expliquées' },
+  { icon: Heart, to: '/story', label: 'L\u2019histoire', desc: 'Pourquoi cette app existe' },
+  { icon: Clock, to: '/changelog', label: 'Changelog', desc: 'Nouveautés et mises à jour' },
+  { icon: Shield, to: '/privacy', label: 'Confidentialité', desc: 'Tes données, ta vie privée' },
 ];
 
 /** Animated terminal line — types character by character */
@@ -163,16 +170,43 @@ export function NotFound() {
           </Button>
         </div>
 
+        {/* Useful links — nav de secours (SEO crawlable + UX) */}
+        <nav
+          aria-label="Navigation de secours"
+          className="animate-fade-in-up mt-8"
+          style={{ animationDelay: '650ms' }}
+        >
+          <h2 className="text-center text-[#8b949e] text-xs font-mono mb-4 uppercase tracking-wider">
+            Pages utiles
+          </h2>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 list-none p-0 m-0">
+            {USEFUL_LINKS.map(({ icon: Icon, to, label, desc }) => (
+              <li key={to}>
+                <Link
+                  to={to}
+                  className="flex items-start gap-3 p-3 rounded-lg border border-[#30363d] bg-[#161b22]/50 hover:border-emerald-500/40 hover:bg-[#161b22] transition-all"
+                >
+                  <Icon size={16} aria-hidden="true" className="size-[16px] text-emerald-400 shrink-0 mt-0.5" />
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-[#e6edf3] text-sm font-medium">{label}</span>
+                    <span className="block text-[#8b949e] text-xs mt-0.5">{desc}</span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
         {/* Open source mention */}
         <div
           className="animate-fade-in text-center mt-8"
-          style={{ animationDelay: '700ms' }}
+          style={{ animationDelay: '800ms' }}
         >
           <a
             href="https://github.com/thierryvm/TerminalLearning"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-[#484f58] hover:text-[#8b949e] text-xs font-mono transition-colors"
+            className="inline-flex items-center gap-1.5 text-[#8b949e] hover:text-[#e6edf3] text-xs font-mono transition-colors"
           >
             <Github size={12} aria-hidden="true" />
             open source · 100% gratuit · pour débutants


### PR DESCRIPTION
## Summary

- Ajoute un bloc `<nav>` "Pages utiles" sous les CTAs existants de la page 404 avec 4 `<Link>` crawlables vers `/reference`, `/story`, `/changelog`, `/privacy` (UX + SEO/GEO/LLM).
- Fix contraste footer iPhone 14 : `#484f58` (WCAG fail sur `#0d1117`) → `#8b949e` avec hover `#e6edf3`.
- Tous les éléments existants (terminal animé, 404, pills, CTAs primaires) restent strictement identiques.
- Structure sémantique : `<nav aria-label>`, `<h2>`, `<ul>/<li>`.

**Scope** : additif uniquement — s'inscrit dans la migration THI-85 shadcn/ui page par page (suite de PR #116).

## Test plan

- [x] Type-check ✅
- [x] Lint ✅
- [x] Build local ✅ (4.12s)
- [x] `ui-auditor` — VERDICT **CLEAN**, pas de CRITICAL bloquant
- [ ] Preview Vercel : pixel-perfect desktop 1440×900 + mobile iPhone 14 390×844
- [ ] CI verte + Sourcery check
- [ ] Validation visuelle Thierry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Amélioration de la page 404 avec un nouveau bloc de navigation de liens utiles et amélioration du contraste du pied de page pour une meilleure accessibilité, tout en mettant à jour la documentation du projet pour référencer ce travail.

Nouvelles fonctionnalités :
- Ajout d’une section de navigation « Pages utiles » sur la page 404, avec des liens vers des routes clés comme reference, story, changelog et privacy.

Améliorations :
- Ajustement des couleurs de texte du pied de page de la page 404 pour respecter les exigences de contraste, en particulier sur les appareils mobiles.
- Mise à jour de CLAUDE.md et docs/plan.md pour documenter les nouvelles améliorations de la page 404 et leur relation avec l’effort de migration THI-85.

Documentation :
- Documentation des nouvelles améliorations de la page 404 et de la PR associée dans CLAUDE.md et docs/plan.md.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the 404 page with a new useful-links navigation block and improve footer contrast for better accessibility, while updating project docs to reference this work.

New Features:
- Add a "Pages utiles" navigation section on the 404 page linking to key routes like reference, story, changelog, and privacy.

Enhancements:
- Adjust 404 page footer text colors to meet contrast requirements, especially on mobile devices.
- Update CLAUDE.md and docs/plan.md to document the new 404 enhancements and their relation to the THI-85 migration effort.

Documentation:
- Document the new 404 enhancements and associated PR in CLAUDE.md and docs/plan.md.

</details>