### PR TITLE
refactor(ui): migrate Landing chunk A to shadcn Button (THI-92)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
 >
   <url>
     <loc>https://terminallearning.dev/</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -17,287 +17,287 @@
 
   <url>
     <loc>https://terminallearning.dev/app</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/reference</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/privacy</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/pwd</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls-la</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/cd</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mkdir</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/touch</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/cp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mv</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/rm</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/cat</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/head-tail</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/grep</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/wc</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/comprendre-permissions</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chmod</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chown</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/sudo</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/security-permissions</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/ps</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/kill</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/top</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/background</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/redirection-sortie</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/pipes</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/stderr</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/tee</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/env-vars</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/path-variable</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/shell-config</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/dotenv</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/scripts</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/cron</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ping</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/curl</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/wget</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/dns</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ssh</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/scp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -604,7 +604,7 @@ export function Landing() {
             <Terminal size={14} className="text-emerald-400" aria-hidden="true" />
             Terminal Learning · MIT License
           </div>
-          <div className="flex items-center gap-6 text-sm text-[#8b949e]">
+          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-[#8b949e]">
             <Button variant="nav-link" size="link-inline" onClick={() => navigate('/app')}>Application</Button>
             <a href="https://github.com/thierryvm/TerminalLearning" target="_blank" rel="noopener noreferrer" className="hover:text-[#e6edf3] transition-colors">GitHub</a>
             <span className="text-[#7d8590] cursor-not-allowed" title="Bientôt disponible" aria-disabled="true">Ko-fi</span>

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -598,20 +598,36 @@ export function Landing() {
       )}
 
       {/* ── FOOTER ──────────────────────────────────────────────── */}
-      <footer className="border-t border-[#30363d]/50 px-6 py-8">
+      <footer className="border-t border-[#30363d]/50 px-6 py-8 pb-[max(2rem,env(safe-area-inset-bottom))]">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-2 text-[#8b949e] text-sm font-mono">
             <Terminal size={14} className="text-emerald-400" aria-hidden="true" />
             Terminal Learning · MIT License
           </div>
-          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-[#8b949e]">
-            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/app')}>Application</Button>
-            <a href="https://github.com/thierryvm/TerminalLearning" target="_blank" rel="noopener noreferrer" className="hover:text-[#e6edf3] transition-colors">GitHub</a>
-            <span className="text-[#7d8590] cursor-not-allowed" title="Bientôt disponible" aria-disabled="true">Ko-fi</span>
-            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/changelog')}>Changelog</Button>
-            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/story')}>Notre histoire</Button>
-            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/privacy')}>Confidentialité</Button>
-          </div>
+          <nav
+            aria-label="Pied de page"
+            className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm text-[#8b949e]"
+          >
+            <Button variant="nav-link" size="footer-link" onClick={() => navigate('/app')}>Application</Button>
+            <a
+              href="https://github.com/thierryvm/TerminalLearning"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center min-h-11 px-2 hover:text-[#e6edf3] transition-colors"
+            >
+              GitHub
+            </a>
+            <span
+              className="inline-flex items-center min-h-11 px-2 text-[#7d8590] cursor-not-allowed"
+              title="Bientôt disponible"
+              aria-disabled="true"
+            >
+              Ko-fi
+            </span>
+            <Button variant="nav-link" size="footer-link" onClick={() => navigate('/changelog')}>Changelog</Button>
+            <Button variant="nav-link" size="footer-link" onClick={() => navigate('/story')}>Notre histoire</Button>
+            <Button variant="nav-link" size="footer-link" onClick={() => navigate('/privacy')}>Confidentialité</Button>
+          </nav>
           <p className="text-[#8b949e] text-xs flex items-center gap-1">
             Fait avec <Heart size={10} className="text-pink-400" aria-hidden="true" /> en Belgique
           </p>

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../context/AuthContext';
 import { useProgress } from '../context/ProgressContext';
 import { UserMenu } from './auth/UserMenu';
 import { LoginModal } from './auth/LoginModal';
+import { Button } from './ui/button';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import {
   TOTAL_LESSONS, TOTAL_COMMANDS,
@@ -90,21 +91,25 @@ export function Landing() {
           {user ? (
             <UserMenu syncStatus={syncStatus} variant="compact" />
           ) : (
-            <button
+            <Button
+              variant="nav-link"
+              size="link-inline"
               onClick={() => setLoginOpen(true)}
-              className="text-[#8b949e] hover:text-[#e6edf3] text-sm font-mono transition-colors flex items-center gap-1.5"
               aria-label="Se connecter"
+              className="gap-1.5 text-sm font-mono"
             >
               <LogIn size={18} className="sm:hidden" aria-hidden="true" />
               <span className="hidden sm:inline">Se connecter</span>
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="emerald-nav"
+            size="nav-pill"
             onClick={() => navigate('/app')}
-            className="flex items-center gap-1 sm:gap-1.5 px-3 sm:px-4 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] text-xs sm:text-sm font-medium transition-colors whitespace-nowrap shrink-0"
+            className="gap-1 sm:gap-1.5 shrink-0"
           >
             Commencer <ChevronRight size={14} aria-hidden="true" />
-          </button>
+          </Button>
         </div>
       </nav>
 
@@ -212,29 +217,33 @@ export function Landing() {
           {/* CTAs */}
           <div className="flex flex-col items-stretch sm:items-center gap-3 sm:gap-4">
             {/* Primary CTA */}
-            <button
+            <Button
+              variant="emerald"
+              size="cta-hero"
               onClick={() => navigate('/app')}
-              className="flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold text-base transition-all hover:scale-[1.02] active:scale-[0.98] shadow-lg shadow-emerald-500/20 sm:self-center"
               aria-label="Commencer l'apprentissage gratuitement"
+              className="shadow-lg shadow-emerald-500/20 sm:self-center"
             >
               <Terminal size={18} aria-hidden="true" />
               Commencer l'apprentissage
               <ChevronRight size={16} aria-hidden="true" />
-            </button>
+            </Button>
 
             {/* Secondary CTAs */}
             <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 items-stretch sm:items-center sm:justify-center">
-            <button
+            <Button
+              variant="ghost-gh"
+              size="cta-pill"
               onClick={() => document.getElementById('roadmap')?.scrollIntoView({ behavior: 'smooth' })}
-              className="flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium text-sm transition-all"
             >
               <Compass size={15} aria-hidden="true" />
               Voir la roadmap
-            </button>
+            </Button>
 
-            <button
+            <Button
+              variant="ghost-gh-neutral"
+              size="cta-pill"
               onClick={handleShare}
-              className="flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl border border-[#30363d] hover:border-[#8b949e]/40 text-[#8b949e] hover:text-[#e6edf3] font-medium text-sm transition-all"
               aria-label="Partager Terminal Learning"
             >
               {shared ? (
@@ -248,17 +257,18 @@ export function Landing() {
                   Partager
                 </>
               )}
-            </button>
+            </Button>
 
             {!isInstalled && (
-              <button
+              <Button
+                variant="ghost-gh"
+                size="cta-pill"
                 onClick={() => setShowPWAModal(true)}
-                className="flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium text-sm transition-all"
                 aria-label="Installer l'application"
               >
                 <Download size={15} aria-hidden="true" />
                 Installer l'app
-              </button>
+              </Button>
             )}
             </div>
           </div>
@@ -576,13 +586,15 @@ export function Landing() {
 
       {/* ── SCROLL TO TOP ───────────────────────────────────────── */}
       {showScrollTop && (
-        <button
+        <Button
+          variant="floating"
+          size="icon-round"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           aria-label="Retour en haut"
-          className="fixed bottom-6 right-6 p-3 rounded-full bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 transition-colors shadow-lg z-50"
+          className="fixed bottom-6 right-6 z-50"
         >
           <ArrowUp size={18} />
-        </button>
+        </Button>
       )}
 
       {/* ── FOOTER ──────────────────────────────────────────────── */}
@@ -593,12 +605,12 @@ export function Landing() {
             Terminal Learning · MIT License
           </div>
           <div className="flex items-center gap-6 text-sm text-[#8b949e]">
-            <button onClick={() => navigate('/app')} className="hover:text-[#e6edf3] transition-colors">Application</button>
+            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/app')}>Application</Button>
             <a href="https://github.com/thierryvm/TerminalLearning" target="_blank" rel="noopener noreferrer" className="hover:text-[#e6edf3] transition-colors">GitHub</a>
             <span className="text-[#7d8590] cursor-not-allowed" title="Bientôt disponible" aria-disabled="true">Ko-fi</span>
-            <button onClick={() => navigate('/changelog')} className="hover:text-[#e6edf3] transition-colors">Changelog</button>
-            <button onClick={() => navigate('/story')} className="hover:text-[#e6edf3] transition-colors">Notre histoire</button>
-            <button onClick={() => navigate('/privacy')} className="hover:text-[#e6edf3] transition-colors">Confidentialité</button>
+            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/changelog')}>Changelog</Button>
+            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/story')}>Notre histoire</Button>
+            <Button variant="nav-link" size="link-inline" onClick={() => navigate('/privacy')}>Confidentialité</Button>
           </div>
           <p className="text-[#8b949e] text-xs flex items-center gap-1">
             Fait avec <Heart size={10} className="text-pink-400" aria-hidden="true" /> en Belgique

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -24,6 +24,15 @@ const buttonVariants = cva(
           "bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold hover:scale-[1.02] active:scale-[0.98]",
         "ghost-gh":
           "border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium",
+        // Terminal Learning — Landing nav + footer variants (THI-92)
+        "emerald-nav":
+          "bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-medium transition-colors",
+        "ghost-gh-neutral":
+          "border border-[#30363d] hover:border-[#8b949e]/40 text-[#8b949e] hover:text-[#e6edf3] font-medium",
+        "nav-link":
+          "text-[#8b949e] hover:text-[#e6edf3] transition-colors",
+        floating:
+          "bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 transition-colors shadow-lg",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -32,6 +41,11 @@ const buttonVariants = cva(
         icon: "size-9 rounded-md",
         // Terminal Learning — CTA pill matching legacy px-6 py-2.5 rounded-xl
         "cta-pill": "h-auto rounded-xl px-6 py-2.5 text-sm",
+        // Terminal Learning — Landing sizes (THI-92)
+        "nav-pill": "h-auto rounded-lg px-3 sm:px-4 py-1.5 text-xs sm:text-sm whitespace-nowrap",
+        "cta-hero": "h-auto rounded-xl px-8 py-3.5 text-base",
+        "icon-round": "size-auto rounded-full p-3",
+        "link-inline": "h-auto p-0",
       },
     },
     defaultVariants: {

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -46,6 +46,7 @@ const buttonVariants = cva(
         "cta-hero": "h-auto rounded-xl px-8 py-3.5 text-base",
         "icon-round": "size-auto rounded-full p-3",
         "link-inline": "h-auto p-0",
+        "footer-link": "h-auto min-h-11 px-2",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

- Migre la nav, les CTAs du hero, le bouton scroll-to-top et les liens du footer de `<button>` natif vers `<Button>` shadcn.
- Ajoute 4 variantes custom (`emerald-nav`, `ghost-gh-neutral`, `nav-link`, `floating`) et 4 sizes (`nav-pill`, `cta-hero`, `icon-round`, `link-inline`) documentées en commentaire dans `button.tsx`.
- Préserve 1:1 tous les `aria-label`, handlers, et états dynamiques (`shared`, `isInstalled`, `showScrollTop`).

Linear : [THI-92](https://linear.app/thierryvm/issue/THI-92) (parent : THI-91).

## Scope

- Nav lignes 73-109 : "Se connecter" + "Commencer"
- Hero CTAs lignes 213-264 : primaire + "Voir la roadmap" + "Partager" + "Installer l'app"
- Scroll-to-top flottant
- Footer : 4 boutons (Application, Changelog, Notre histoire, Confidentialité)

**Hors scope** (chunks B/C — issues séparées) : env selector, cards trust/stats/features/roadmap/support, badges, module previews.

## Validation locale

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run build` ✅ — Landing chunk 88.37 kB raw / **24.80 kB gzip** (stable)
- `test-runner` agent : **900 pass / 0 fail / 20 skip** ✅
- `ui-auditor` agent (scope in-PR) : VERDICT ✅ **Clean**

## Test plan

- [ ] CI : type-check + lint + 900 tests + build verts
- [ ] Sourcery : vérifier commentaires / rate limit SKIPPED acceptable
- [ ] Vercel preview : regression visuelle desktop 1440×900 (Chrome)
- [ ] Vercel preview : regression visuelle mobile iPhone 14 (390×844)
- [ ] Vérifier états dynamiques : partage (copie → "Lien copié !"), scroll-to-top apparition > 600px, PWA modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactoriser les contrôles interactifs de la page d’accueil pour utiliser le composant partagé `Button` de shadcn avec des variantes et des tailles dédiées pour la navigation, les CTA du hero, le bouton retour en haut de page et les liens de pied de page.

Nouvelles fonctionnalités :
- Introduire des variantes de `Button` spécifiques à la Landing pour la navigation, le ghost neutre, les liens de navigation et les actions flottantes.
- Ajouter des tailles de `Button` spécifiques à la Landing pour les « pills » de navigation, les CTA du hero, les boutons icône ronds et les liens en ligne.

Améliorations :
- Remplacer les éléments natifs `button` dans la navigation de la Landing, le hero, le contrôle de retour en haut de page et le pied de page par le composant centralisé `Button` tout en préservant les comportements existants et l’accessibilité.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Landing page interactive controls to use the shared shadcn Button component with dedicated variants and sizes for navigation, hero CTAs, scroll-to-top, and footer links.

New Features:
- Introduce Landing-specific Button variants for nav, neutral ghost, nav links, and floating actions.
- Add Landing-specific Button sizes for nav pills, hero CTAs, round icon buttons, and inline links.

Enhancements:
- Replace native button elements in the Landing nav, hero, scroll-to-top control, and footer with the centralized Button component while preserving existing behaviors and accessibility.

</details>