### PR TITLE
fix(content): align module/lesson counts (10→11, 52→64)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
     <!-- Primary SEO -->
     <title>Terminal Learning — Apprends le terminal pas à pas</title>
-    <meta name="description" content="Apprends les commandes du terminal gratuitement. 10 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source." />
+    <meta name="description" content="Apprends les commandes du terminal gratuitement. 11 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source." />
     <meta name="keywords" content="terminal, bash, linux, apprendre, débutant, commandes, shell, open source, gratuit" />
     <meta name="author" content="Thierry Vanmeeteren" />
     <meta name="robots" content="index, follow" />
@@ -21,7 +21,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://terminallearning.dev/" />
     <meta property="og:title" content="Terminal Learning — Apprends le terminal pas à pas" />
-    <meta property="og:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 10 modules progressifs (Linux, macOS, Windows), émulateur réel. Pour débutants, 100% open source." />
+    <meta property="og:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 11 modules progressifs (Linux, macOS, Windows), émulateur réel. Pour débutants, 100% open source." />
     <meta property="og:image" content="https://terminallearning.dev/og-image.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
@@ -33,7 +33,7 @@
     <!-- Twitter / X Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terminal Learning — Apprends le terminal pas à pas" />
-    <meta name="twitter:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 10 modules (Linux, macOS, Windows), émulateur réel, 100% open source." />
+    <meta name="twitter:description" content="Application interactive gratuite pour apprendre les commandes du terminal. 11 modules (Linux, macOS, Windows), émulateur réel, 100% open source." />
     <meta name="twitter:image" content="https://terminallearning.dev/og-image.png" />
     <meta name="twitter:creator" content="@thierryvm" />
 
@@ -85,7 +85,7 @@
           "@id": "https://terminallearning.dev/#app",
           "name": "Terminal Learning",
           "url": "https://terminallearning.dev/",
-          "description": "Apprends les commandes du terminal dans ton navigateur. 10 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Gratuit, open source, sans installation.",
+          "description": "Apprends les commandes du terminal dans ton navigateur. 11 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Gratuit, open source, sans installation.",
           "applicationCategory": "EducationalApplication",
           "applicationSubCategory": "Terminal / Shell Learning",
           "operatingSystem": "Any (Web Browser)",
@@ -116,7 +116,7 @@
           "@type": "Course",
           "@id": "https://terminallearning.dev/#course",
           "name": "Apprendre le terminal — de zéro à autonome (Linux, macOS, Windows)",
-          "description": "Formation interactive et gratuite aux commandes du terminal. 10 modules progressifs couvrant Linux, macOS et Windows : navigation, fichiers, permissions, processus, redirection, variables, réseau, SSH, Git et GitHub.",
+          "description": "Formation interactive et gratuite aux commandes du terminal. 11 modules progressifs couvrant Linux, macOS et Windows : navigation, fichiers, permissions, processus, redirection, variables, réseau, SSH, Git, GitHub et l'IA comme outil dev.",
           "url": "https://terminallearning.dev/app",
           "inLanguage": "fr",
           "isAccessibleForFree": true,
@@ -131,7 +131,8 @@
             "Variables d'environnement, $PATH, scripts bash, cron",
             "Réseau et SSH (ping, curl, wget, nslookup, ssh, scp)",
             "Git Fondamentaux (git init, add, commit, branch, merge)",
-            "GitHub & Collaboration (push, pull, pull requests, GitHub Actions)"
+            "GitHub & Collaboration (push, pull, pull requests, GitHub Actions)",
+            "L'IA comme outil dev (ai-help, prompt engineering, validation de code généré)"
           ],
           "hasCourseInstance": {
             "@type": "CourseInstance",
@@ -183,7 +184,7 @@
               "name": "Combien de commandes et de leçons sont disponibles ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Terminal Learning propose 52 leçons réparties en 10 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git et GitHub."
+                "text": "Terminal Learning propose 64 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev."
               }
             },
             {
@@ -199,7 +200,7 @@
               "name": "Comment est structuré le curriculum ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Le curriculum comporte 10 modules progressifs : Navigation, Fichiers & Dossiers, Lecture de fichiers, Permissions, Processus, Redirection & Pipes, Variables & Scripts, Réseau & SSH, Git Fondamentaux, et GitHub & Collaboration. Chaque module débloque le suivant."
+                "text": "Le curriculum comporte 11 modules progressifs : Navigation, Fichiers & Dossiers, Lecture de fichiers, Permissions, Processus, Redirection & Pipes, Variables & Scripts, Réseau & SSH, Git Fondamentaux, GitHub & Collaboration, et L'IA comme outil dev. Chaque module débloque le suivant."
               }
             }
           ]

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -16,7 +16,7 @@ Terminal Learning is a free, open-source, browser-based interactive platform to 
 
 ## Curriculum Structure
 
-10 modules, 52 lessons total. Modules unlock progressively as the learner completes prerequisites.
+11 modules, 64 lessons total. Modules unlock progressively as the learner completes prerequisites.
 
 ---
 
@@ -159,6 +159,27 @@ Terminal Learning is a free, open-source, browser-based interactive platform to 
 | Pull Requests — Code Review & Collaboration | GitHub PR workflow, review, merge strategies | /app/learn/github-collaboration/pull-requests |
 | Conflits de merge — Les résoudre comme un pro | conflict markers, `git mergetool`, resolution strategies | /app/learn/github-collaboration/conflicts |
 | GitHub Actions — CI/CD automatisé | `.github/workflows/`, YAML syntax, triggers, jobs | /app/learn/github-collaboration/github-actions |
+
+---
+
+### Module 11 — L'IA comme outil dev (12 lessons)
+
+**Goal**: Use AI as an amplifier, not a crutch. Write better prompts, validate generated code, avoid hallucinations and technical debt.
+
+| Lesson | Commands | URL |
+|--------|----------|-----|
+| L'IA en 2026 : un outil, pas un oracle | `ai-help` | /app/learn/ia-dev/ia-dev-intro |
+| Ce que l'IA sait vraiment faire | `ai-help capabilities` | /app/learn/ia-dev/ia-dev-capacites |
+| Ce que l'IA ne sait pas faire | `ai-help limits` | /app/learn/ia-dev/ia-dev-limites |
+| Écrire un bon prompt — les bases | `ai-help prompts` | /app/learn/ia-dev/ia-dev-prompts-basics |
+| Prompts avancés — contexte technique | `ai-help context` | /app/learn/ia-dev/ia-dev-prompts-avances |
+| Valider la sortie de l'IA | `ai-help validate` | /app/learn/ia-dev/ia-dev-valider |
+| Debug assisté par IA | `ai-help debug` | /app/learn/ia-dev/ia-dev-debug |
+| Sécurité et code IA | `ai-help security` | /app/learn/ia-dev/ia-dev-securite |
+| Claude CLI dans le terminal | `ai-help claude-cli` | /app/learn/ia-dev/ia-dev-claude-cli |
+| L'IA dans différents métiers | `ai-help professions` | /app/learn/ia-dev/ia-dev-metiers |
+| La posture professionnelle face à l'IA | `ai-help posture` | /app/learn/ia-dev/ia-dev-posture |
+| Workflow complet avec l'IA | `ai-help workflow` | /app/learn/ia-dev/ia-dev-workflow |
 
 ---
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ Terminal Learning is a beginner-friendly educational web app built with React an
 - **License**: Open source (MIT)
 - **Stack**: Vite 6, React 18, TypeScript strict, Tailwind CSS v4, Supabase, Vercel
 
-## Curriculum (10 modules, 52 lessons)
+## Curriculum (11 modules, 64 lessons)
 
 ### Module 1 — Navigation
 `pwd`, `ls`, `ls -la`, `cd` — moving through the file system
@@ -94,6 +94,21 @@ Environment variables, `$PATH`, `.env`, shell config, bash scripts, `cron`
 - https://terminallearning.dev/app/learn/github-collaboration/pull-requests
 - https://terminallearning.dev/app/learn/github-collaboration/conflicts
 - https://terminallearning.dev/app/learn/github-collaboration/github-actions
+
+### Module 11 — L'IA comme outil dev
+`ai-help` and 11 sub-commands: capabilities, limits, prompts, context, validate, debug, security, claude CLI, professions, posture, workflow — how to use AI as an amplifier (not a crutch), write better prompts, validate generated code, avoid common pitfalls
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-intro
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-capacites
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-limites
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-prompts-basics
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-prompts-avances
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-valider
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-debug
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-securite
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-claude-cli
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-metiers
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-posture
+- https://terminallearning.dev/app/learn/ia-dev/ia-dev-workflow
 
 ## Multi-environment support
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -96,7 +96,7 @@ Environment variables, `$PATH`, `.env`, shell config, bash scripts, `cron`
 - https://terminallearning.dev/app/learn/github-collaboration/github-actions
 
 ### Module 11 — L'IA comme outil dev
-`ai-help` and 11 sub-commands: capabilities, limits, prompts, context, validate, debug, security, claude CLI, professions, posture, workflow — how to use AI as an amplifier (not a crutch), write better prompts, validate generated code, avoid common pitfalls
+`ai-help` and 11 sub-commands: capabilities, limits, prompts, context, validate, debug, security, Claude CLI, professions, posture, workflow — how to use AI as an amplifier (not a crutch), write better prompts, validate generated code, avoid common pitfalls
 - https://terminallearning.dev/app/learn/ia-dev/ia-dev-intro
 - https://terminallearning.dev/app/learn/ia-dev/ia-dev-capacites
 - https://terminallearning.dev/app/learn/ia-dev/ia-dev-limites

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -39,7 +39,7 @@ export function Dashboard() {
 
   usePageSEO({
     title: 'Tableau de bord — Terminal Learning',
-    description: 'Suivez votre progression dans l\'apprentissage du terminal. 10 modules progressifs, exercices interactifs, Linux / macOS / Windows.',
+    description: 'Suivez votre progression dans l\'apprentissage du terminal. 11 modules progressifs, exercices interactifs, Linux / macOS / Windows.',
     path: '/app',
   });
 

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -52,7 +52,7 @@ export function Landing() {
 
   const handleShare = async () => {
     const url = 'https://terminallearning.dev';
-    const text = 'Apprends le terminal gratuitement — 10 modules interactifs, Linux / macOS / Windows.';
+    const text = 'Apprends le terminal gratuitement — 11 modules interactifs, Linux / macOS / Windows.';
     if (navigator.share) {
       try {
         await navigator.share({ title: 'Terminal Learning', text, url });
@@ -383,7 +383,7 @@ export function Landing() {
           </div>
 
           <p className="mt-8 text-center text-[#8b949e] text-sm">
-            10 modules inclus — aucun compte requis.
+            11 modules inclus — aucun compte requis.
           </p>
         </FadeIn>
       </section>

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -56,7 +56,7 @@ export const FEATURES = [
 // ── Roadmap ───────────────────────────────────────────────────────────────────
 
 export const ROADMAP_AVAILABLE = [
-  '10 modules progressifs (navigation → GitHub)',
+  '11 modules progressifs (navigation → IA pour dev)',
   'Terminal interactif avec validation',
   'Dashboard de progression',
   'Sauvegarde locale + cloud (optionnel)',

--- a/src/app/hooks/useLessonSEO.ts
+++ b/src/app/hooks/useLessonSEO.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Module, Lesson } from '../data/curriculum';
 
 const DEFAULT_TITLE = 'Terminal Learning — Apprends le terminal pas à pas';
-const DEFAULT_DESCRIPTION = 'Apprends les commandes du terminal gratuitement. 10 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source.';
+const DEFAULT_DESCRIPTION = 'Apprends les commandes du terminal gratuitement. 11 modules progressifs (Linux, macOS, Windows), émulateur interactif, progression sauvegardée. Pour débutants, open source.';
 const DEFAULT_URL = 'https://terminallearning.dev/';
 
 const BASE_URL = 'https://terminallearning.dev';


### PR DESCRIPTION
## Summary
- Stale counts corrected across SEO metas, JSON-LD (SoftwareApplication + Course + FAQPage), Landing UI, Dashboard SEO, and LLM files (`llms.txt` + `llms-full.txt`).
- Module 11 (L'IA comme outil dev — THI-29, merged 13 Apr 2026) is now reflected in the `teaches` JSON-LD array and both `llms*.txt` as a full section with 12 lessons + `ai-help` sub-commands.
- Spotted by Thierry on the live site: "10 modules inclus — aucun compte requis" was hardcoded in Landing.

## Files changed
- `index.html` — meta description (3×), OG, Twitter, SoftwareApplication + Course descriptions, `teaches` array (+1 entry), FAQ Q&A (lesson count + module list).
- `public/llms.txt` — header "10 modules, 52 lessons" → "11 modules, 64 lessons" + full Module 11 section.
- `public/llms-full.txt` — same header fix + Module 11 table (12 lessons with `ai-help` commands + URLs).
- `src/app/components/Landing.tsx` — `navigator.share` text + "11 modules inclus" visible string.
- `src/app/components/Dashboard.tsx` — `usePageSEO` description.
- `src/app/hooks/useLessonSEO.ts` — `DEFAULT_DESCRIPTION`.
- `src/app/data/landingContent.ts` — `ROADMAP_AVAILABLE[0]` → "11 modules progressifs (navigation → IA pour dev)".

## Preserved (intentional)
- `src/app/data/curriculum.ts:2633` and `:2804` — narrative references to "les 10 modules précédents" are semantically correct (spoken from within Module 11 about Modules 1–10).
- `docs/plan.md:13` — historical record (THI-28 PR #72 shipped at 52 lessons), not a live count.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (3.37s)
- [ ] Verify preview shows "11 modules inclus" on Landing
- [ ] Verify JSON-LD in preview DevTools has 11-entry `teaches` array
- [ ] Verify `/llms.txt` and `/llms-full.txt` headers show "11 modules, 64 lessons"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Aligner le nombre de modules et de leçons entre le contenu public et les métadonnées SEO afin de refléter l’ajout d’un 11ᵉ module et la mise à jour du nombre total de leçons.

Corrections de bugs :
- Corriger les références obsolètes à 10 modules et 52 leçons dans le texte de la landing page, le SEO du tableau de bord et les valeurs par défaut du SEO des leçons.

Améliorations :
- Mettre à jour les métadonnées JSON-LD du cours dans `index.html` pour inclure le nouveau 11ᵉ module sur l’utilisation de l’IA comme outil de développement ainsi que sa description.
- Actualiser le texte de la feuille de route sur la landing page pour décrire la progression complète des 11 modules, de la navigation à l’IA pour les développeurs.
- Ajuster le texte de partage sur les réseaux sociaux de la landing page afin de mettre en avant 11 modules interactifs sur Linux, macOS et Windows.

Documentation :
- Réviser les réponses de la FAQ et les fichiers publics de description LLM pour indiquer 11 modules et 64 leçons incluant le nouveau module axé sur l’IA.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align module and lesson counts across public content and SEO metadata to reflect the addition of an 11th module and updated total lessons.

Bug Fixes:
- Correct stale references to 10 modules and 52 lessons in landing copy, dashboard SEO, and lesson SEO defaults.

Enhancements:
- Update index.html JSON-LD Course metadata to include the new 11th module on using AI as a dev tool and its description.
- Refresh landing roadmap text to describe the full 11-module progression from navigation to AI for developers.
- Adjust social sharing text on the landing page to advertise 11 interactive modules across Linux, macOS, and Windows.

Documentation:
- Revise FAQ answers and public LLM descriptor text files to state 11 modules and 64 lessons with the new AI-focused module.

</details>