### PR TITLE
feat(ui): scroll-to-top button on Privacy page

### DIFF
--- a/src/app/components/PrivacyPolicy.tsx
+++ b/src/app/components/PrivacyPolicy.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { Terminal, ArrowLeft, Shield } from 'lucide-react';
+import { Terminal, ArrowLeft, Shield, ArrowUp } from 'lucide-react';
+import { Button } from './ui/button';
 
 /**
  * @component PrivacyPolicy
@@ -9,6 +11,13 @@ import { Terminal, ArrowLeft, Shield } from 'lucide-react';
  */
 export function PrivacyPolicy() {
   const navigate = useNavigate();
+  const [showScrollTop, setShowScrollTop] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShowScrollTop(window.scrollY > 600);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]" style={{ fontFamily: 'Inter, sans-serif' }}>
@@ -159,6 +168,19 @@ export function PrivacyPolicy() {
       <footer className="border-t border-[#30363d]/50 px-6 py-6 text-center text-[#8b949e] text-sm">
         <span className="font-mono">Terminal Learning</span> · Projet open source · MIT License
       </footer>
+
+      {/* ── SCROLL TO TOP ───────────────────────────────────────── */}
+      {showScrollTop && (
+        <Button
+          variant="floating"
+          size="icon-round"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          aria-label="Retour en haut"
+          className="fixed bottom-6 right-6 z-50"
+        >
+          <ArrowUp size={18} />
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add floating scroll-to-top button on `/privacy` — same pattern as Landing.tsx (PR #118).
- Privacy page has 7 long sections; on mobile, users at the bottom had no quick way to return up.
- Uses existing shadcn `Button` variants: `variant="floating"` + `size="icon-round"`.

## Files changed
- `src/app/components/PrivacyPolicy.tsx` — added `useEffect`/`useState` hook + floating button (fixed bottom-right, appears after 600px scroll, smooth scroll-to-top).

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [ ] Scroll down `/privacy` on desktop — button fades in
- [ ] Scroll down `/privacy` on mobile (iPhone) — button visible, tap returns to top smoothly
- [ ] a11y — `aria-label="Retour en haut"` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter un contrôle flottant de remontée en haut de page sur la page de Politique de confidentialité afin d’améliorer la navigation sur les contenus longs.

Nouvelles fonctionnalités :
- Introduire un bouton de remontée en haut de page sur la page de Politique de confidentialité qui apparaît après que l’utilisateur a fait défiler la page vers le bas.
- Activer un défilement fluide vers le haut de la page de Politique de confidentialité grâce au nouveau bouton flottant.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a floating scroll-to-top control to the Privacy policy page to improve navigation on long content.

New Features:
- Introduce a scroll-to-top button on the Privacy page that appears after the user scrolls down.
- Enable smooth scrolling back to the top of the Privacy page via the new floating button.

</details>