### PR TITLE
refactor(ui): Landing chunk B — shadcn Badge migration (THI-93)

### DIFF
--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -14,6 +14,7 @@ import { useProgress } from '../context/ProgressContext';
 import { UserMenu } from './auth/UserMenu';
 import { LoginModal } from './auth/LoginModal';
 import { Button } from './ui/button';
+import { Badge } from './ui/badge';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import {
   TOTAL_LESSONS, TOTAL_COMMANDS,
@@ -283,13 +284,11 @@ export function Landing() {
           {TRUST_BADGES.map((badge, i) => {
             const Icon = badge.icon;
             const pill = (
-              <FadeIn
-                as="span"
-                delay={i * 70}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-[#30363d] text-[#8b949e] text-xs font-medium"
-              >
-                <Icon size={13} aria-hidden="true" />
-                {badge.label}
+              <FadeIn as="span" delay={i * 70} className="inline-flex">
+                <Badge variant="pill-muted" className="text-xs [&>svg]:size-[13px]">
+                  <Icon aria-hidden="true" />
+                  {badge.label}
+                </Badge>
               </FadeIn>
             );
 
@@ -301,7 +300,7 @@ export function Landing() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={badge.label}
-                  className="hover:opacity-80 transition-opacity"
+                  className="hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 rounded-full"
                 >
                   {pill}
                 </a>

--- a/src/app/components/ui/badge.tsx
+++ b/src/app/components/ui/badge.tsx
@@ -26,6 +26,8 @@ const badgeVariants = cva(
           "rounded-full border-amber-500/30 bg-amber-500/10 text-amber-400 gap-1.5 px-3 py-1.5",
         "pill-purple":
           "rounded-full border-purple-500/30 bg-purple-500/10 text-purple-400 gap-1.5 px-3 py-1.5",
+        "pill-muted":
+          "rounded-full border-[#30363d] text-[#8b949e] gap-1.5 px-3 py-1.5 font-medium",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Chunk B de la migration Landing vers shadcn (THI-91 umbrella).

### Scope migré

- **Trust badges** (5 pills GitHub-style) : `<span>` custom → `<Badge variant=\"pill-muted\">`
  - Nouvelle variante `pill-muted` ajoutée à `badge.tsx` : `rounded-full border-[#30363d] text-[#8b949e] gap-1.5 px-3 py-1.5`
  - Icônes Lucide passées en `[&>svg]:size-[13px]` (CVA par défaut met 12px via `[&>svg]:size-3`)
  - Wrappers `<a>` : focus-visible ring emerald-500/60 pour a11y keyboard
  - `FadeIn` préservé + `delay={i * 70}` séquentiel préservé

### Scope NON migré (décision documentée)

- **Stats bar** (4 cards) : `border-[#30363d] bg-[#161b22]` — structure simple
- **Features** (4 cards) : `f.border` + `f.bg` colorés dynamiques (emerald/blue/amber/purple venant de `landingContent.ts`)
- **Roadmap** (3 cards) : palettes hardcoded (emerald/blue/neutral)
- **Support cards** (Ko-fi + GitHub Sponsors) : `opacity-60 cursor-not-allowed` disabled state

**Rationale** : `<Card>` shadcn utilise les tokens `bg-card` / `text-card-foreground` incompatibles avec `#161b22`. Créer une variante custom `<Card variant=\"terminal\">` par card unique ajouterait du boilerplate sans bénéfice a11y (aucune de ces cards n'est interactive). Même pattern que le 404 hero (PR #117) — documenté.

## Files changed

- `src/app/components/ui/badge.tsx` (+2) — variante `pill-muted`
- `src/app/components/Landing.tsx` (+7/-9) — trust badges

## Bundle

- Landing chunk : **25.02 → 24.93 kB gzip** (−0.09 kB)

## Test plan

- [x] type-check ✅
- [x] lint ✅
- [x] build ✅
- [x] vitest 900 tests ✅
- [ ] Screenshot prod vs preview (desktop + mobile) — visuel strictement identique attendu

Sub-issue de THI-91 (Landing shadcn umbrella). Prochain : THI-94 chunk C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Migrer les badges de confiance de la page d'accueil pour utiliser le composant partagé shadcn Badge tout en préservant l’apparence et l’animation existantes, et améliorer leurs styles de focus pour une meilleure accessibilité au clavier.

Nouvelles fonctionnalités :
- Ajouter une nouvelle variante visuelle `pill-muted` au composant partagé Badge pour des « pills » neutres de style GitHub.

Améliorations :
- Refactoriser les badges de confiance de la page d'accueil pour utiliser le composant partagé Badge au lieu d’un style personnalisé sur des balises `span`.
- Améliorer l’accessibilité clavier des liens des badges de confiance grâce à un style d’anneau `focus-visible`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate Landing page trust badges to use the shared shadcn Badge component while preserving existing appearance and animation, and enhance their focus styles for better keyboard accessibility.

New Features:
- Add a new `pill-muted` visual variant to the shared Badge component for neutral GitHub-style pills.

Enhancements:
- Refactor Landing trust badges to use the shared Badge component instead of custom span styling.
- Improve keyboard accessibility of trust badge links with focus-visible ring styling.

</details>