### PR TITLE
feat(a11y): MarkdownPage FAB scroll-top — touch + safe-area (THI-101)

### DIFF
--- a/src/app/components/MarkdownPage.tsx
+++ b/src/app/components/MarkdownPage.tsx
@@ -176,11 +176,12 @@ export function MarkdownPage({ content, title, subtitle, seo }: MarkdownPageProp
       {/* Scroll to top */}
       {showScrollTop && (
         <button
+          type="button"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           aria-label="Retour en haut"
-          className="fixed bottom-6 right-6 p-3 rounded-full bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 transition-colors shadow-lg"
+          className="fixed right-6 bottom-[max(1.5rem,env(safe-area-inset-bottom))] w-11 h-11 flex items-center justify-center rounded-full bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors shadow-lg"
         >
-          <ArrowUp size={18} />
+          <ArrowUp size={18} aria-hidden="true" />
         </button>
       )}
 

--- a/src/app/components/MarkdownPage.tsx
+++ b/src/app/components/MarkdownPage.tsx
@@ -177,7 +177,10 @@ export function MarkdownPage({ content, title, subtitle, seo }: MarkdownPageProp
       {showScrollTop && (
         <button
           type="button"
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          onClick={() => {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+          }}
           aria-label="Retour en haut"
           className="fixed right-6 bottom-[max(1.5rem,env(safe-area-inset-bottom))] w-11 h-11 flex items-center justify-center rounded-full bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors shadow-lg"
         >


### PR DESCRIPTION
## Summary
- FAB scroll-top passe de 42px à 44×44 (WCAG 2.2 AAA) via `w-11 h-11` explicite
- `bottom-6` → `bottom-[max(1.5rem,env(safe-area-inset-bottom))]` — FAB plus sous home indicator iOS
- Ajoute `focus-visible:ring-emerald` + `type="button"` + `aria-hidden` sur icône (cohérent THI-99/100)
- `min-h-dvh` déjà en place (l.125) — pas de changement

Scope : uniquement le FAB. Les 2 autres boutons (nav + footer) restent hors scope THI-101.

## Impact
- Pages affectées : `/changelog`, `/story` (partagent `MarkdownPage`)
- Bundle : stable (2 className tweaks)
- Tests : 901/901 pass, 20 skip, 0 fail
- Type-check : OK
- Build prod : OK

## Test plan
- [ ] Preview Vercel : /changelog — scroll > 400px, FAB apparaît à 44×44, focus-visible cyan, clic retour top smooth
- [ ] Preview Vercel mobile (iPhone 14/SE) : FAB au-dessus du home indicator, pas de recouvrement
- [ ] Preview /story — idem
- [ ] CI : type-check + lint + test + build
- [ ] Sourcery review

Refs: THI-101 (epic THI-96 Web 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorer l’accessibilité et la disposition du bouton d’action flottant « remonter en haut » sur la page MarkdownPage.

Améliorations :
- Ajuster le bouton « remonter en haut » à une taille fixe de 44×44 et le repositionner pour tenir compte des marges de sécurité inférieures (safe-area insets) sur les appareils mobiles.
- Améliorer l’accessibilité du bouton « remonter en haut » avec un type de bouton explicite, des styles focus-visible améliorés, et en masquant l’icône décorative des technologies d’assistance.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and layout of the MarkdownPage scroll-to-top floating action button.

Enhancements:
- Adjust the scroll-to-top button to a fixed 44×44 size and reposition it to account for bottom safe-area insets on mobile devices.
- Enhance the scroll-to-top button’s accessibility with an explicit button type, improved focus-visible styles, and hiding the decorative icon from assistive technologies.

</details>