### PR TITLE
feat(ui): THI-95 Dashboard migration to shadcn/ui

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
 >
   <url>
     <loc>https://terminallearning.dev/</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -17,287 +17,287 @@
 
   <url>
     <loc>https://terminallearning.dev/app</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/reference</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/privacy</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/pwd</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls-la</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/cd</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mkdir</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/touch</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/cp</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mv</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/rm</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/cat</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/head-tail</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/grep</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/wc</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/comprendre-permissions</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chmod</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chown</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/sudo</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/security-permissions</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/ps</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/kill</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/top</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/background</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/redirection-sortie</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/pipes</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/stderr</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/tee</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/env-vars</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/path-variable</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/shell-config</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/dotenv</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/scripts</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/cron</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ping</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/curl</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/wget</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/dns</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ssh</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/scp</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -7,6 +7,8 @@ import { useProgress } from '../context/ProgressContext';
 import { iconMap } from '../data/moduleIcons';
 import { usePageSEO } from '../hooks/useLessonSEO';
 import { Button } from './ui/button';
+import { Card, CardContent, CardHeader } from './ui/card';
+import { Progress } from './ui/progress';
 
 const MODULE_GRADIENTS: Record<string, string> = {
   navigation: 'from-emerald-500/20 to-emerald-500/5',
@@ -32,6 +34,10 @@ const MODULE_BORDER: Record<string, string> = {
   reseau: 'border-cyan-400/30 hover:border-cyan-400/60',
   git: 'border-orange-500/30 hover:border-orange-500/60',
   'github-collaboration': 'border-violet-500/30 hover:border-violet-500/60',
+};
+
+type ModuleProgressStyle = React.CSSProperties & {
+  '--tl-progress-color'?: string;
 };
 
 export function Dashboard() {
@@ -80,44 +86,47 @@ export function Dashboard() {
         </div>
 
         {/* Overall progress */}
-        <div className="bg-[#161b22] border border-[#30363d] rounded-xl p-5">
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center gap-2">
-              <Award size={18} className="text-amber-400" />
-              <span className="text-sm text-[#8b949e]">Progression globale</span>
+        <Card variant="tl-surface" className="p-5">
+          <CardHeader className="p-0 mb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Award size={18} className="text-amber-400" />
+                <span className="text-sm text-[#8b949e]">Progression globale</span>
+              </div>
+              <span className="text-emerald-400 font-mono text-sm">{overallProgress}%</span>
             </div>
-            <span className="text-emerald-400 font-mono text-sm">{overallProgress}%</span>
-          </div>
-          <div className="h-2 bg-[#21262d] rounded-full overflow-hidden">
-            <div
-              className="h-full bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full transition-all duration-700"
-              style={{ width: `${overallProgress}%` }}
+          </CardHeader>
+          <CardContent className="p-0">
+            <Progress
+              variant="tl"
+              value={overallProgress}
+              aria-label={`Progression globale : ${overallProgress}%`}
             />
-          </div>
-          <div className="mt-3 flex items-center justify-between text-xs text-[#8b949e]">
-            <span>{totalCompleted} leçons complétées</span>
-            <span>{totalLessons - totalCompleted} restantes</span>
-          </div>
-        </div>
+            <div className="mt-3 flex items-center justify-between text-xs text-[#8b949e]">
+              <span>{totalCompleted} leçons complétées</span>
+              <span>{totalLessons - totalCompleted} restantes</span>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Stats row */}
       <div className="grid grid-cols-3 gap-4 mb-8">
-        <div className="bg-[#161b22] border border-[#30363d] rounded-xl p-4 flex flex-col items-center">
+        <Card variant="tl-stat">
           <BookOpen size={20} className="text-blue-400 mb-2" />
           <div className="text-xl text-[#e6edf3] font-mono">{totalLessons}</div>
           <div className="text-xs text-[#8b949e] text-center">Leçons au total</div>
-        </div>
-        <div className="bg-[#161b22] border border-[#30363d] rounded-xl p-4 flex flex-col items-center">
+        </Card>
+        <Card variant="tl-stat">
           <CheckCircle2 size={20} className="text-emerald-400 mb-2" />
           <div className="text-xl text-[#e6edf3] font-mono">{totalCompleted}</div>
           <div className="text-xs text-[#8b949e] text-center">Complétées</div>
-        </div>
-        <div className="bg-[#161b22] border border-[#30363d] rounded-xl p-4 flex flex-col items-center">
+        </Card>
+        <Card variant="tl-stat">
           <Zap size={20} className="text-amber-400 mb-2" />
           <div className="text-xl text-[#e6edf3] font-mono">{curriculum.length}</div>
           <div className="text-xs text-[#8b949e] text-center">Modules</div>
-        </div>
+        </Card>
       </div>
 
       {/* CTA */}
@@ -154,13 +163,14 @@ export function Dashboard() {
               : `${mod.title} — ${completed}/${total} leçons`;
 
             return (
-              <div
+              <Card
                 key={mod.id}
+                variant="tl-module"
                 role={locked ? undefined : 'button'}
                 tabIndex={locked ? undefined : 0}
                 aria-label={ariaLabel}
                 aria-disabled={locked ? true : undefined}
-                className={`relative min-h-11 bg-gradient-to-br ${gradient} border ${border} rounded-xl p-4 transition-all duration-200 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 ${
+                className={`relative min-h-11 border group ${gradient} ${border} ${
                   locked ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
                 }`}
                 onClick={() => !locked && navigate(`/app/learn/${mod.id}/${mod.lessons[0].id}`)}
@@ -208,16 +218,17 @@ export function Dashboard() {
                 {!locked && (
                   <>
                     <div className="flex items-center gap-2">
-                      <div className="flex-1 h-1 bg-black/30 rounded-full overflow-hidden">
-                        <div
-                          className="h-full rounded-full transition-all duration-500"
-                          style={{ width: `${pct}%`, backgroundColor: mod.color }}
-                        />
-                      </div>
+                      <Progress
+                        variant="tl-thin"
+                        value={pct}
+                        className="flex-1"
+                        style={{ '--tl-progress-color': mod.color } as ModuleProgressStyle}
+                        aria-label={`${mod.title} : ${completed} sur ${total} leçons`}
+                      />
                       <span className="text-xs text-[#8b949e] font-mono shrink-0">{completed}/{total}</span>
                     </div>
 
-                    {/* Lessons dots */}
+                    {/* Lessons dots — micro decoration, no shadcn equivalent */}
                     <div className="flex gap-1 mt-2.5">
                       {mod.lessons.map((lesson) => (
                         <div
@@ -232,7 +243,7 @@ export function Dashboard() {
                     </div>
                   </>
                 )}
-              </div>
+              </Card>
             );
           })}
         </div>
@@ -242,7 +253,7 @@ export function Dashboard() {
       {totalCompleted > 0 && (
         <div className="mt-8">
           <h2 className="text-[#e6edf3] mb-4">Leçons récentes</h2>
-          <div className="bg-[#161b22] border border-[#30363d] rounded-xl divide-y divide-[#21262d]">
+          <Card variant="tl-surface" className="divide-y divide-[#21262d] overflow-hidden">
             {curriculum
               .flatMap((mod) =>
                 mod.lessons
@@ -254,11 +265,12 @@ export function Dashboard() {
               .map(({ mod, lesson }) => {
                 const Icon = iconMap[mod.iconName] ?? BookOpen;
                 return (
-                  <button
+                  <Button
                     key={`${mod.id}/${lesson.id}`}
                     type="button"
+                    variant="tl-ghost"
+                    size="tl-list-row"
                     onClick={() => navigate(`/app/learn/${mod.id}/${lesson.id}`)}
-                    className="w-full min-h-11 flex items-center gap-3 px-4 py-3 hover:bg-[#21262d] transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500/60"
                   >
                     <CheckCircle2 size={14} className="text-emerald-400 shrink-0" />
                     <div className="flex-1 min-w-0">
@@ -269,10 +281,10 @@ export function Dashboard() {
                       </div>
                     </div>
                     <ChevronRight size={14} className="text-[#8b949e] shrink-0" />
-                  </button>
+                  </Button>
                 );
               })}
-          </div>
+          </Card>
         </div>
       )}
     </div>

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -36,6 +36,9 @@ const buttonVariants = cva(
         // Terminal Learning — translucent emerald CTA (LessonPage nav, THI-99)
         "emerald-soft":
           "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 transition-colors",
+        // Terminal Learning — list row (Dashboard recent lessons, THI-95)
+        "tl-ghost":
+          "w-full justify-start text-left whitespace-normal text-[#e6edf3] hover:bg-[#21262d] transition-colors focus-visible:ring-inset",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -50,6 +53,8 @@ const buttonVariants = cva(
         "icon-round": "size-auto rounded-full p-3",
         "link-inline": "h-auto p-0",
         "footer-link": "h-auto min-h-11 px-2",
+        // Terminal Learning — Dashboard list row (THI-95)
+        "tl-list-row": "h-auto min-h-11 px-4 py-3 rounded-none",
       },
     },
     defaultVariants: {

--- a/src/app/components/ui/card.tsx
+++ b/src/app/components/ui/card.tsx
@@ -1,15 +1,41 @@
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+const cardVariants = cva(
+  "flex flex-col rounded-xl border",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground gap-6",
+        // Terminal Learning — GitHub-dark surface (THI-95)
+        "tl-surface":
+          "bg-[#161b22] border-[#30363d] text-[#e6edf3] gap-0",
+        // Terminal Learning — compact stat tile (THI-95)
+        "tl-stat":
+          "bg-[#161b22] border-[#30363d] text-[#e6edf3] items-center justify-center p-4 gap-0",
+        // Terminal Learning — module card with dynamic gradient (THI-95)
+        // The gradient + border colour are injected via className at usage site.
+        "tl-module":
+          "bg-gradient-to-br text-[#e6edf3] transition-all duration-200 p-4 gap-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Card({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof cardVariants>) {
   return (
     <div
       data-slot="card"
-      className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border",
-        className,
-      )}
+      className={cn(cardVariants({ variant, className }))}
       {...props}
     />
   );
@@ -89,4 +115,5 @@ export {
   CardAction,
   CardDescription,
   CardContent,
+  cardVariants,
 };

--- a/src/app/components/ui/progress.tsx
+++ b/src/app/components/ui/progress.tsx
@@ -2,30 +2,63 @@
 
 import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
+
+const progressRootVariants = cva(
+  "relative w-full overflow-hidden rounded-full",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary/20 h-2",
+        // Terminal Learning — GitHub-dark track (THI-95)
+        tl: "bg-[#21262d] h-2",
+        // Terminal Learning — micro progress bar per module card (THI-95)
+        "tl-thin": "bg-black/30 h-1",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+const progressIndicatorVariants = cva(
+  "h-full w-full flex-1 transition-all duration-500",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary",
+        // Terminal Learning — gradient emerald indicator (THI-95)
+        tl: "bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full",
+        // Terminal Learning — colour injected via --tl-progress-color CSS var (THI-95)
+        "tl-thin":
+          "rounded-full bg-[var(--tl-progress-color,theme(colors.emerald.500))]",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
 
 function Progress({
   className,
   value,
+  variant,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> &
+  VariantProps<typeof progressRootVariants>) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
-      className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
-        className,
-      )}
+      className={cn(progressRootVariants({ variant, className }))}
       {...props}
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn(progressIndicatorVariants({ variant }))}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>
   );
 }
 
-export { Progress };
+export { Progress, progressRootVariants };


### PR DESCRIPTION
## Summary
Migrates `Dashboard.tsx` to 100% shadcn/ui primitives (Card / Progress / Button). Adds 3 new Terminal Learning variants so the GitHub-dark visual stays 1:1 identical to prod.

### Variants added
- `card.tsx` — `tl-surface`, `tl-stat`, `tl-module`
- `progress.tsx` — `tl` (h-2 emerald gradient), `tl-thin` (h-1, colour via `--tl-progress-color` CSS var)
- `button.tsx` — `tl-ghost` variant + `tl-list-row` size

### Mapping (before → after)
| Avant | Après |
|---|---|
| `<div bg-[#161b22] border rounded-xl>` overall | `<Card variant="tl-surface">` + `<Progress variant="tl">` |
| `<div bg-[#161b22] border rounded-xl p-4 flex-col items-center>` ×3 | `<Card variant="tl-stat">` |
| `<div role="button" bg-gradient-to-br>` module cards | `<Card variant="tl-module" className={gradient+border}>` |
| Inline `<div h-1 bg-black/30>` + inline bar | `<Progress variant="tl-thin" style={'--tl-progress-color': mod.color}>` |
| `<button>` recent lessons | `<Button variant="tl-ghost" size="tl-list-row">` |

### Exception volontaire
Les lesson dots (`<div className="flex-1 h-1 rounded-full">` sous chaque module card) restent en Tailwind : aucun équivalent shadcn, purement décoratif, ≤10 lignes. Logique similaire à la règle documentée pour NotFound.tsx.

### Préservé
- `usePageSEO` inchangé — SEO stable (`/app`, title, description)
- Tous les `aria-label`, `role="button"`, `tabIndex`, `aria-disabled` des modules verrouillés
- `focus-visible:ring-emerald-500/60` — via les variantes `tl-module` et `tl-ghost`
- Touch targets `min-h-11` (WCAG 2.2 AAA, conformité Web 2026)
- Système de couleurs par module (gradients + borders `MODULE_GRADIENTS` / `MODULE_BORDER`)

## Why
THI-85 umbrella : sortir la dette shadcn une page à la fois. Dashboard était la prochaine page listée après les chunks Landing (THI-92/93/94 Done).

Règle "100% shadcn" explicitement validée par Thierry (17 avril 2026) — zéro HTML+Tailwind custom là où un composant shadcn existe.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 901/901 pass (20 skipped, inchangés)
- [x] `npm run build` — Dashboard chunk 12.66 kB raw / 4.42 kB gzip
- [ ] Screenshot comparatif prod vs preview Vercel — **desktop (1440×900)**
- [ ] Screenshot comparatif prod vs preview Vercel — **mobile (iPhone 14, 390×844)**
- [ ] Module card hover / focus-visible (emerald ring) visuellement correct
- [ ] Cards verrouillées avec `cursor-not-allowed` + `opacity-60`
- [ ] Recent lessons : hover `bg-[#21262d]` + focus-visible inset ring
- [ ] Sourcery review (si non-SKIPPED)

## Suite
Après merge, prochains chantiers THI-85 : LessonPage → ChangelogPage → StoryPage → CommandReference.