### PR TITLE
feat(ui): THI-85 MarkdownPage migration to shadcn/ui

### DIFF
--- a/src/app/components/MarkdownPage.tsx
+++ b/src/app/components/MarkdownPage.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Terminal, ArrowLeft, ArrowUp } from 'lucide-react';
 import type { Components } from 'react-markdown';
+import { Button } from './ui/button';
 
 const mdComponents: Components = {
   h1: ({ children }) => (
@@ -149,13 +150,14 @@ export function MarkdownPage({ content, title, subtitle, seo }: MarkdownPageProp
           <Terminal size={18} className="text-emerald-400" />
           <span className="font-mono text-sm text-[#e6edf3]">Terminal Learning</span>
         </div>
-        <button
+        <Button
+          variant="nav-link"
+          size="link-inline"
           onClick={() => navigate('/')}
-          className="flex items-center gap-2 text-[#8b949e] hover:text-[#e6edf3] text-sm transition-colors"
         >
-          <ArrowLeft size={14} />
+          <ArrowLeft size={14} className="size-[14px]" aria-hidden="true" />
           Retour
-        </button>
+        </Button>
       </nav>
 
       <main className="max-w-4xl mx-auto px-6 py-12">
@@ -175,17 +177,19 @@ export function MarkdownPage({ content, title, subtitle, seo }: MarkdownPageProp
 
       {/* Scroll to top */}
       {showScrollTop && (
-        <button
+        <Button
           type="button"
+          variant="floating"
+          size="icon-round"
           onClick={() => {
             const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
             window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
           }}
           aria-label="Retour en haut"
-          className="fixed right-6 bottom-[max(1.5rem,env(safe-area-inset-bottom))] w-11 h-11 flex items-center justify-center rounded-full bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors shadow-lg"
+          className="fixed right-6 bottom-[max(1.5rem,env(safe-area-inset-bottom))] w-11 h-11 focus-visible:ring-emerald-500/60"
         >
           <ArrowUp size={18} aria-hidden="true" />
-        </button>
+        </Button>
       )}
 
       {/* Footer */}
@@ -195,9 +199,14 @@ export function MarkdownPage({ content, title, subtitle, seo }: MarkdownPageProp
             <Terminal size={12} className="text-emerald-400" />
             Terminal Learning · MIT License
           </span>
-          <button onClick={() => navigate('/')} className="hover:text-[#e6edf3] transition-colors">
+          <Button
+            variant="nav-link"
+            size="link-inline"
+            onClick={() => navigate('/')}
+            className="text-xs"
+          >
             ← Accueil
-          </button>
+          </Button>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- Migre les **3 `<button>` custom** de `MarkdownPage.tsx` vers `<Button>` shadcn — **aucune nouvelle variante nécessaire** (toutes déjà définies par PRs précédentes)
- Clôture le CRITICAL out-of-scope `MarkdownPage.tsx — back navigation custom` détecté par `ui-auditor` après PR #131
- Impacte indirectement `/changelog` et `/story` (thin wrappers autour de `MarkdownPage`)

## Buttons migrés
| Button | Variant + Size | Notes |
|---|---|---|
| Nav "← Retour" (top) | `variant="nav-link" size="link-inline"` | `ArrowLeft size={14} className="size-[14px]"` pour bypass regex shadcn |
| FAB scroll-top | `variant="floating" size="icon-round"` | `w-11 h-11` override preserve 44px touch target + `focus-visible:ring-emerald-500/60` |
| Footer "← Accueil" | `variant="nav-link" size="link-inline"` | `text-xs` override (parent donne text-xs) |

Comportements préservés :
- `bottom-[max(1.5rem,env(safe-area-inset-bottom))]` (THI-101 safe-area)
- `prefers-reduced-motion` sur scrollTo
- Tous les `aria-label` et `aria-hidden`

## Quality gates
- [x] 901/901 tests ✅
- [x] Lint ✅ · Type-check ✅
- [x] Build ✅ (MarkdownPage chunk 44.83 kB raw / 13.64 kB gzip)
- [x] `ui-auditor` VERDICT: **CLEAN** — merge-safe

## Scope THI-91 umbrella
PR A/3 — reste :
- PR B : CommandReference + Sidebar + PWAInstallModal (groupées)
- PR C : LessonPage (solo, complexité terminal)

## Test plan
- [ ] Preview Vercel : ouvrir `/changelog` et `/story`
  - [ ] Nav "Retour" fonctionne (clic → /)
  - [ ] Footer "← Accueil" fonctionne (clic → /)
  - [ ] Scroll > 400px → FAB apparaît → clic → retour en haut smooth
  - [ ] Vérifier visuel identique prod vs preview (desktop + mobile iPhone 14)
- [ ] Sourcery ✅ ou SKIPPED (rate limit hebdomadaire acceptable)

Refs: THI-85, THI-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorations :
- Remplacer l’en-tête, le pied de page et les boutons de retour en haut personnalisés de `MarkdownPage` par les variantes standardisées de `Button` de shadcn/ui afin de les aligner sur le système d’interface utilisateur partagé.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace custom MarkdownPage header, footer, and scroll-to-top buttons with the standardized shadcn/ui Button variants to align with the shared UI system.

</details>