### PR TITLE
feat(ui): THI-85 PWAInstallModal + CommandReference shadcn migration

### DIFF
--- a/src/app/components/CommandReference.tsx
+++ b/src/app/components/CommandReference.tsx
@@ -3,6 +3,7 @@ import { Search, Terminal, ChevronDown, ChevronRight } from 'lucide-react';
 import { useEnvironment } from '../context/EnvironmentContext';
 import type { EnvId } from '../data/curriculum';
 import { usePageSEO } from '../hooks/useLessonSEO';
+import { Button } from './ui/button';
 
 interface CommandEntry {
   /** Command name shown — can be overridden per env */
@@ -717,18 +718,16 @@ export function CommandReference() {
       {/* Category filters */}
       <div className="flex gap-2 flex-wrap mb-6">
         {categories.map((cat) => (
-          <button
+          <Button
             key={cat}
             type="button"
+            variant={activeCategory === cat ? 'tl-filter-pill-active' : 'tl-filter-pill'}
+            size="tl-filter-pill-size"
             onClick={() => setActiveCategory(cat)}
-            className={`min-h-11 text-xs px-3 py-1.5 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 ${
-              activeCategory === cat
-                ? 'bg-[#e6edf3] text-[#0d1117] border-[#e6edf3]'
-                : 'text-[#8b949e] border-[#30363d] hover:border-[#8b949e] hover:text-[#e6edf3]'
-            }`}
+            aria-pressed={activeCategory === cat}
           >
             {cat}
-          </button>
+          </Button>
         ))}
       </div>
 

--- a/src/app/components/PWAInstallModal.tsx
+++ b/src/app/components/PWAInstallModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { X, Smartphone, Monitor, Share, MoreVertical, Plus, Download, CheckCircle2 } from 'lucide-react';
 import { usePWAInstall } from '../hooks/usePWAInstall';
+import { Button } from './ui/button';
 
 interface PWAInstallModalProps {
   onClose: () => void;
@@ -56,12 +57,13 @@ export function PWAInstallModal({ onClose }: PWAInstallModalProps) {
           <CheckCircle2 size={48} className="text-emerald-400 mx-auto mb-4" />
           <h2 className="text-lg font-semibold text-[#e6edf3] mb-2">Déjà installée !</h2>
           <p className="text-sm text-[#8b949e] mb-6">Terminal Learning est déjà installée sur cet appareil.</p>
-          <button
+          <Button
+            variant="emerald-soft"
+            size="cta-pill-sm"
             onClick={onClose}
-            className="px-6 py-2 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-emerald-400 text-sm hover:bg-emerald-500/20 transition-colors"
           >
             Fermer
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -81,29 +83,28 @@ export function PWAInstallModal({ onClose }: PWAInstallModalProps) {
             </div>
             <h2 className="text-sm font-semibold text-[#e6edf3]">Installer l'application</h2>
           </div>
-          <button
+          <Button
+            variant="tl-icon-ghost"
+            size="tl-icon-sm"
             onClick={onClose}
-            className="text-[#8b949e] hover:text-[#e6edf3] transition-colors p-1 rounded"
             aria-label="Fermer"
           >
-            <X size={16} />
-          </button>
+            <X size={16} aria-hidden="true" />
+          </Button>
         </div>
 
         {/* Tabs */}
         <div className="flex border-b border-[#30363d]">
           {(Object.keys(TAB_LABELS) as Tab[]).map((tab) => (
-            <button
+            <Button
               key={tab}
+              variant={activeTab === tab ? 'tl-tab-active' : 'tl-tab'}
+              size="tl-tab-size"
               onClick={() => setActiveTab(tab)}
-              className={`flex-1 py-2.5 text-xs font-mono transition-colors ${
-                activeTab === tab
-                  ? 'text-emerald-400 border-b-2 border-emerald-400 -mb-px'
-                  : 'text-[#8b949e] hover:text-[#e6edf3]'
-              }`}
+              aria-pressed={activeTab === tab}
             >
               {TAB_LABELS[tab]}
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -123,14 +124,15 @@ export function PWAInstallModal({ onClose }: PWAInstallModalProps) {
               {canPrompt ? (
                 <div className="text-center space-y-3 py-2">
                   <p className="text-sm text-[#8b949e]">Ton navigateur supporte l'installation directe.</p>
-                  <button
+                  <Button
+                    variant="emerald"
+                    size="tl-install-cta"
                     onClick={handleNativePrompt}
                     disabled={installing}
-                    className="w-full py-2.5 bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-black font-semibold text-sm rounded-lg transition-colors flex items-center justify-center gap-2"
                   >
-                    <Download size={16} />
+                    <Download size={16} aria-hidden="true" />
                     {installing ? 'Installation...' : 'Installer Terminal Learning'}
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <Steps steps={ANDROID_MANUAL_STEPS} />
@@ -143,14 +145,15 @@ export function PWAInstallModal({ onClose }: PWAInstallModalProps) {
               {canPrompt ? (
                 <div className="text-center space-y-3 py-2">
                   <p className="text-sm text-[#8b949e]">Installation disponible pour Chrome et Edge.</p>
-                  <button
+                  <Button
+                    variant="emerald"
+                    size="tl-install-cta"
                     onClick={handleNativePrompt}
                     disabled={installing}
-                    className="w-full py-2.5 bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-black font-semibold text-sm rounded-lg transition-colors flex items-center justify-center gap-2"
                   >
-                    <Monitor size={16} />
+                    <Monitor size={16} aria-hidden="true" />
                     {installing ? 'Installation...' : 'Installer comme application desktop'}
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <Steps steps={DESKTOP_MANUAL_STEPS} />

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -39,6 +39,19 @@ const buttonVariants = cva(
         // Terminal Learning — list row (Dashboard recent lessons, THI-95)
         "tl-ghost":
           "w-full justify-start text-left whitespace-normal text-[#e6edf3] hover:bg-[#21262d] transition-colors focus-visible:ring-inset",
+        // Terminal Learning — icon-only ghost action (close X, modal dismiss)
+        "tl-icon-ghost":
+          "rounded text-[#8b949e] hover:text-[#e6edf3] transition-colors",
+        // Terminal Learning — tab segmented control (PWAInstallModal tabs)
+        "tl-tab":
+          "font-mono transition-colors text-[#8b949e] hover:text-[#e6edf3] rounded-none",
+        "tl-tab-active":
+          "font-mono transition-colors text-emerald-400 border-b-2 border-emerald-400 -mb-px rounded-none",
+        // Terminal Learning — CommandReference filter pill
+        "tl-filter-pill":
+          "border transition-colors text-[#8b949e] border-[#30363d] hover:border-[#8b949e] hover:text-[#e6edf3]",
+        "tl-filter-pill-active":
+          "border transition-colors bg-[#e6edf3] text-[#0d1117] border-[#e6edf3] hover:bg-[#e6edf3]",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -55,6 +68,16 @@ const buttonVariants = cva(
         "footer-link": "h-auto min-h-11 px-2",
         // Terminal Learning — Dashboard list row (THI-95)
         "tl-list-row": "h-auto min-h-11 px-4 py-3 rounded-none",
+        // Terminal Learning — Small icon button (modal close X, p-1)
+        "tl-icon-sm": "size-auto p-1",
+        // Terminal Learning — CTA pill small (rounded-lg, py-2) — "Fermer" in installed modal
+        "cta-pill-sm": "h-auto rounded-lg px-6 py-2 text-sm",
+        // Terminal Learning — Install CTA (full-width, rounded-lg, py-2.5)
+        "tl-install-cta": "h-auto w-full py-2.5 text-sm rounded-lg gap-2",
+        // Terminal Learning — Tab in modal (flex-1, py-2.5, no rounded)
+        "tl-tab-size": "h-auto flex-1 py-2.5 text-xs",
+        // Terminal Learning — CommandReference filter pill
+        "tl-filter-pill-size": "h-auto min-h-11 px-3 py-1.5 text-xs rounded-full",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
PR B de la clôture **THI-91 umbrella**. Migre 7 `<button>` custom (4 dans PWAInstallModal, N filter pills dans CommandReference) vers `<Button>` shadcn avec 5 nouvelles variantes + 5 nouvelles sizes.

## Variantes ajoutées (intention-based)
| Variant | Usage |
|---|---|
| `tl-icon-ghost` | Icon-only dismiss (modal close X) |
| `tl-tab` / `tl-tab-active` | Tab segmented control (PWA install flow) |
| `tl-filter-pill` / `tl-filter-pill-active` | Filter pill (light inverse active) |

| Size | Usage |
|---|---|
| `tl-icon-sm` | Icon button p-1 |
| `cta-pill-sm` | CTA pill `rounded-lg py-2` (plus petit que `cta-pill`) |
| `tl-install-cta` | Full-width install CTA `py-2.5 rounded-lg` |
| `tl-tab-size` | Tab `flex-1 py-2.5 text-xs` |
| `tl-filter-pill-size` | Filter pill `min-h-11 rounded-full` |

## Fichiers migrés
**PWAInstallModal.tsx** (4 buttons)
- Close X → `tl-icon-ghost` + `tl-icon-sm` (préserve `p-1 rounded`)
- "Fermer" installed → `emerald-soft` + `cta-pill-sm`
- Tab buttons x3 → `tl-tab`/`tl-tab-active` + `tl-tab-size` avec `aria-pressed`
- Install CTAs x2 → `emerald` + `tl-install-cta`

**CommandReference.tsx** (1 pattern)
- Category filter pills → `tl-filter-pill`/`tl-filter-pill-active` + `tl-filter-pill-size` avec `aria-pressed`
- Note : les cmd detail cards (L754+) utilisent `<div onClick>` — out of scope pour PR B, a11y préservée via aria-labels + structure sémantique

## Clôture CRITICALs #131
- ✅ `CommandReference.tsx:720` — category buttons custom
- ✅ `PWAInstallModal.tsx` — close + CTA buttons custom

## Quality gates
- [x] 901/901 tests ✅
- [x] Lint ✅ · Type-check ✅
- [x] Build ✅ (Button chunk 30.00 → 30.78 kB, +0.16 kB gzip pour 10 variantes/sizes)
- [x] `ui-auditor` VERDICT: **CLEAN** — merge-safe

## Scope THI-91 umbrella (restant)
- ✅ MarkdownPage (PR #134)
- ✅ PWAInstallModal + CommandReference (**cette PR**)
- 🔄 PR C : Sidebar (solo, complexe — 6 buttons + env switcher + modules dynamiques)
- 🔄 PR D : LessonPage (solo, terminal + exercice)

## Test plan
- [ ] Preview Vercel : ouvrir `/app/reference` — vérifier filter pills (hover, active, focus)
- [ ] Preview Vercel : dans Sidebar, cliquer sur l'icône PWA install → modal apparaît
  - [ ] Tabs iOS/Android/Desktop switchent correctement (active indicator emerald)
  - [ ] Close X ferme le modal (clic + Escape)
  - [ ] Install CTA (si canPrompt) déclenche bien le prompt natif
- [ ] Vérifier visuel identique prod vs preview (desktop + mobile iPhone 14)
- [ ] Sourcery ✅ ou SKIPPED

Refs: THI-85, THI-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)