### PR TITLE
refactor(ui): THI-91 LessonPage shadcn consolidation (PR D)

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -173,10 +173,10 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
         <Button
           type="button"
           variant="nav-link"
-          size="link-inline"
+          size="tl-nav-inline"
           onClick={() => navigate('/app')}
           aria-label="Retour au tableau de bord"
-          className="gap-1.5 min-h-11 px-2 -ml-2 rounded text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent"
+          className="-ml-2"
         >
           <ChevronLeft className="size-4" aria-hidden="true" />
           <span className="hidden sm:inline">Tableau de bord</span>
@@ -197,11 +197,11 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
         <Button
           type="button"
           variant="ghost-gh"
-          size="link-inline"
+          size="tl-nav-inline"
           onClick={() => setShowTerminal((v) => !v)}
           aria-pressed={showTerminal}
           aria-label={showTerminal ? 'Afficher le contenu de la leçon' : 'Afficher le terminal interactif'}
-          className="lg:hidden gap-1.5 min-h-11 px-3 rounded text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-[#30363d]"
+          className="lg:hidden px-3"
         >
           <Terminal className="size-3.5" aria-hidden="true" />
           <span className="text-xs">{showTerminal ? 'Contenu' : 'Terminal'}</span>
@@ -263,11 +263,11 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
                     <Button
                       type="button"
                       variant="nav-link"
-                      size="link-inline"
+                      size="tl-nav-inline-xs"
                       onClick={() => setShowHint((v) => !v)}
                       aria-expanded={showHint}
                       aria-controls={`lesson-hint-panel-${moduleId}-${lessonId}`}
-                      className="gap-1 min-h-11 px-2 -ml-2 rounded text-xs font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent"
+                      className="-ml-2"
                     >
                       <Lightbulb className="size-3" aria-hidden="true" />
                       {showHint ? "Masquer l'indice" : "Afficher un indice"}
@@ -293,11 +293,11 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
             <Button
               type="button"
               variant="nav-link"
-              size="link-inline"
+              size="tl-nav-inline"
               onClick={() => handleNavigate(prevLesson)}
               disabled={!prevLesson}
               aria-disabled={!prevLesson}
-              className="gap-2 min-h-11 px-2 -ml-2 rounded text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent disabled:opacity-30"
+              className="gap-2 -ml-2 disabled:opacity-30"
             >
               <ChevronLeft className="size-4" aria-hidden="true" />
               <span>Précédent</span>
@@ -307,10 +307,9 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
               <Button
                 type="button"
                 variant="emerald-soft"
-                size="link-inline"
+                size="tl-nav-cta"
                 onClick={() => handleNavigate(nextLesson)}
                 aria-label="Passer à la leçon suivante"
-                className="gap-2 min-h-11 rounded-lg px-3 py-2 text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-emerald-500/20"
               >
                 <span>Suivant</span>
                 <ChevronRight className="size-4" aria-hidden="true" />
@@ -319,10 +318,9 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
               <Button
                 type="button"
                 variant="emerald-soft"
-                size="link-inline"
+                size="tl-nav-cta"
                 onClick={() => navigate('/app')}
                 aria-label="Retour au tableau de bord"
-                className="gap-2 min-h-11 rounded-lg px-3 py-2 text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-emerald-500/20"
               >
                 <span>Tableau de bord</span>
                 <ChevronRight className="size-4" aria-hidden="true" />
@@ -341,13 +339,13 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
             <Button
               type="button"
               variant="nav-link"
-              size="link-inline"
+              size="tl-nav-inline-xs"
               onClick={() => {
                 setTerminalKey(`${moduleId}-${lessonId}-${Date.now()}`);
                 setExerciseMessage('');
               }}
               aria-label="Réinitialiser le terminal"
-              className="gap-1.5 min-h-11 px-2 -mr-2 rounded text-xs font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent"
+              className="gap-1.5 -mr-2"
             >
               <RotateCcw className="size-3" aria-hidden="true" />
               <span>Réinitialiser</span>
@@ -386,9 +384,9 @@ export function LessonPage() {
           <Button
             type="button"
             variant="nav-link"
-            size="link-inline"
+            size="tl-nav-inline"
             onClick={() => navigate('/app')}
-            className="mt-4 min-h-11 px-4 rounded text-emerald-400 hover:text-emerald-300 text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent"
+            className="mt-4 px-4 text-emerald-400 hover:text-emerald-300"
           >
             Retour au tableau de bord
           </Button>
@@ -407,9 +405,9 @@ export function LessonPage() {
           <Button
             type="button"
             variant="nav-link"
-            size="link-inline"
+            size="tl-nav-inline"
             onClick={() => navigate('/app')}
-            className="mt-4 min-h-11 px-4 rounded text-emerald-400 hover:text-emerald-300 text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 focus-visible:border-transparent"
+            className="mt-4 px-4 text-emerald-400 hover:text-emerald-300"
           >
             Retour au tableau de bord
           </Button>

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -23,19 +23,19 @@ const buttonVariants = cva(
         emerald:
           "bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-semibold hover:scale-[1.02] active:scale-[0.98]",
         "ghost-gh":
-          "border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium",
+          "border border-[#30363d] hover:border-emerald-500/40 text-[#8b949e] hover:text-emerald-400 font-medium focus-visible:border-[#30363d] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         // Terminal Learning — Landing nav + footer variants (THI-92)
         "emerald-nav":
           "bg-emerald-500 hover:bg-emerald-400 text-[#0d1117] font-medium transition-colors",
         "ghost-gh-neutral":
           "border border-[#30363d] hover:border-[#8b949e]/40 text-[#8b949e] hover:text-[#e6edf3] font-medium",
         "nav-link":
-          "text-[#8b949e] hover:text-[#e6edf3] transition-colors",
+          "text-[#8b949e] hover:text-[#e6edf3] transition-colors focus-visible:border-transparent focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         floating:
           "bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-emerald-400 hover:border-emerald-500/40 transition-colors shadow-lg",
         // Terminal Learning — translucent emerald CTA (LessonPage nav, THI-99)
         "emerald-soft":
-          "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 transition-colors",
+          "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 transition-colors focus-visible:border-emerald-500/20 focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         // Terminal Learning — list row (Dashboard recent lessons, THI-95)
         "tl-ghost":
           "w-full justify-start text-left whitespace-normal text-[#e6edf3] hover:bg-[#21262d] transition-colors focus-visible:ring-inset",
@@ -106,6 +106,12 @@ const buttonVariants = cva(
         "tl-sidebar-lesson": "h-auto min-h-10 px-2 py-1.5 text-xs rounded-md",
         // Terminal Learning — Env switcher pill
         "tl-env-pill": "h-auto flex-1 min-h-9 py-1.5 px-1 text-[10px] gap-1 rounded-md",
+        // Terminal Learning — LessonPage inline nav (back, reset, mobile toggle, hint, prev)
+        "tl-nav-inline": "h-auto min-h-11 rounded px-2 text-sm font-normal gap-1.5",
+        // Terminal Learning — LessonPage hint toggle (xs, tighter gap)
+        "tl-nav-inline-xs": "h-auto min-h-11 rounded px-2 text-xs font-normal gap-1",
+        // Terminal Learning — LessonPage next/finish CTA (emerald-soft)
+        "tl-nav-cta": "h-auto min-h-11 rounded-lg px-3 py-2 text-sm font-normal gap-2",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- Cleans up **LessonPage.tsx** — 8 Button sites already used shadcn but carried verbose className chains
- Enhances 3 variants + adds 3 sizes in \`button.tsx\` so each Button now expresses its intent via \`variant\` + \`size\`, with \`className\` reserved for alignment tweaks
- Knock-on: Landing + NotFound also gain the TL emerald focus ring (consistency)

## Variant enhancements (existing variants — adds emerald focus ring)
| Variant | Before | After |
|---|---|---|
| \`nav-link\` | text only | + emerald-500/60 ring-2 offset-0 border-transparent |
| \`ghost-gh\` | border + hover | + emerald ring (border stays #30363d on focus) |
| \`emerald-soft\` | bg + hover | + emerald ring (border stays emerald-500/20 on focus) |

## New sizes
| Size | Used for | Shape |
|---|---|---|
| \`tl-nav-inline\` | Dashboard back, mobile toggle, prev, not-found links | min-h-11 rounded px-2 text-sm gap-1.5 |
| \`tl-nav-inline-xs\` | hint toggle, terminal reset | min-h-11 rounded px-2 text-xs gap-1 |
| \`tl-nav-cta\` | Suivant / Tableau de bord (emerald-soft) | min-h-11 rounded-lg px-3 py-2 text-sm gap-2 |

## LessonPage sites refactored (8)
1. Top-bar : Dashboard back
2. Top-bar : mobile Contenu/Terminal toggle
3. Exercise : hint toggle (Afficher/Masquer l'indice)
4. Terminal pane : Réinitialiser
5. Bottom nav : Précédent
6. Bottom nav : Suivant (emerald-soft)
7. Bottom nav : Tableau de bord (emerald-soft, final lesson)
8. Not-found + Locked module : Retour au tableau de bord (×2)

Each Button dropped ≈ 4-5 utility classes that were duplicating variant responsibilities. \`className\` now only contains true one-offs (-ml-2, -mr-2, text-emerald-400 override, disabled:opacity-30).

## Side-effects on Landing + NotFound
\`Landing.tsx\` (nav + footer links) and \`NotFound.tsx\` (secondary CTA) share these variants. They now render the TL emerald focus ring instead of the default \`ring-ring/50\`. Visually unchanged except under keyboard focus, where focus now matches Sidebar / Dashboard — consistent across the whole app.

## No behavior change
- click / disabled / aria / keyboard / \`-ml-*\` alignment all preserved
- bundle : LessonPage chunk **94.75 → 93.04 kB** (−1.7 kB, dedup'd classnames)

## Quality gates
- Type-check : green
- Lint : green
- Vitest : 901 passed / 20 skipped
- Build : OK

## Test plan
- [ ] Desktop (Chrome) : navigate through a lesson, verify all 5 buttons + hint panel + reset
- [ ] Mobile (iPhone 14 emulate) : mobile toggle switches content/terminal, touch targets 44×44
- [ ] Keyboard : Tab focus ring is emerald (not muted purple/blue) on every LessonPage + Landing + NotFound button
- [ ] Exercise flow : complete an exercise, verify auto-navigate to next lesson (Suivant → Tableau de bord on final)
- [ ] Locked module : navigate to a locked lesson URL, verify \`/app\` back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)