### PR TITLE
feat(ui): THI-91 Sidebar shadcn migration + fix PWA install scope

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -2,15 +2,13 @@ import { useState } from 'react';
 import { NavLink, useNavigate } from 'react-router';
 import {
   Terminal, LayoutDashboard, BookOpen,
-  ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock, Download,
+  ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock,
 } from 'lucide-react';
 import { UserMenu } from './auth/UserMenu';
 import { curriculum } from '../data/curriculum';
 import { useProgress } from '../context/ProgressContext';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import { iconMap } from '../data/moduleIcons';
-import { PWAInstallModal } from './PWAInstallModal';
-import { usePWAInstall } from '../hooks/usePWAInstall';
 import { Button } from './ui/button';
 
 interface SidebarProps {
@@ -22,8 +20,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const navigate = useNavigate();
   const { isLessonCompleted, getModuleProgress, overallProgress, syncStatus, unlockTree } = useProgress();
   const { selectedEnv, setEnvironment } = useEnvironment();
-  const { isInstalled } = usePWAInstall();
-  const [showPWAModal, setShowPWAModal] = useState(false);
   const [expandedModules, setExpandedModules] = useState<Record<string, boolean>>(() => {
     const init: Record<string, boolean> = {};
     curriculum.forEach((m) => { init[m.id] = true; });
@@ -249,39 +245,23 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <UserMenu
             syncStatus={syncStatus}
             extraActions={
-              <>
-                {!isInstalled && (
-                  <Button
-                    type="button"
-                    variant="tl-sidebar-icon"
-                    size="tl-icon-44-md"
-                    onClick={() => setShowPWAModal(true)}
-                    className="hover:text-emerald-400 hover:bg-[#21262d]"
-                    aria-label="Installer l'application"
-                    title="Installer l'application"
-                  >
-                    <Download size={13} className="size-[13px]" aria-hidden="true" />
-                  </Button>
-                )}
-                <Button
-                  asChild
-                  variant="tl-sidebar-icon"
-                  size="tl-icon-44-md"
-                  className="hover:bg-[#21262d]"
+              <Button
+                asChild
+                variant="tl-sidebar-icon"
+                size="tl-icon-44-md"
+                className="hover:bg-[#21262d]"
+              >
+                <NavLink
+                  to="/"
+                  onClick={onClose}
+                  aria-label="Retour à l'accueil"
+                  title="Retour à l'accueil"
                 >
-                  <NavLink
-                    to="/"
-                    onClick={onClose}
-                    aria-label="Retour à l'accueil"
-                    title="Retour à l'accueil"
-                  >
-                    <Home size={13} className="size-[13px]" aria-hidden="true" />
-                  </NavLink>
-                </Button>
-              </>
+                  <Home size={13} className="size-[13px]" aria-hidden="true" />
+                </NavLink>
+              </Button>
             }
           />
-          {showPWAModal && <PWAInstallModal onClose={() => setShowPWAModal(false)} />}
         </div>
       </aside>
     </>

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/E
 import { iconMap } from '../data/moduleIcons';
 import { PWAInstallModal } from './PWAInstallModal';
 import { usePWAInstall } from '../hooks/usePWAInstall';
+import { Button } from './ui/button';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -65,14 +66,16 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               <div className="text-xs text-emerald-400 font-mono">Master</div>
             </div>
           </NavLink>
-          <button
+          <Button
             type="button"
+            variant="tl-sidebar-icon"
+            size="tl-icon-44"
             onClick={onClose}
-            className="lg:hidden flex items-center justify-center w-11 h-11 -mr-2 rounded-lg text-[#8b949e] hover:text-[#e6edf3] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors"
+            className="lg:hidden -mr-2"
             aria-label="Fermer le menu"
           >
             <X size={18} aria-hidden="true" />
-          </button>
+          </Button>
         </div>
 
         {/* Progress bar */}
@@ -135,24 +138,22 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             return (
               <div key={mod.id}>
                 {/* Module header */}
-                <button
+                <Button
                   type="button"
+                  variant={locked ? 'tl-sidebar-row-locked' : 'tl-sidebar-row'}
+                  size="tl-sidebar-row"
                   onClick={() => !locked && toggleModule(mod.id)}
                   aria-disabled={locked ? true : undefined}
                   aria-label={locked
                     ? `${mod.title} — verrouillé, Niv. ${unlockStatus?.level}`
                     : `${mod.title} — ${completed}/${total} leçons`}
-                  className={`w-full flex items-center gap-2.5 min-h-11 px-3 py-2 rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 group ${
-                    locked
-                      ? 'cursor-not-allowed text-[#8b949e]'
-                      : 'hover:bg-[#161b22] text-[#c9d1d9]'
-                  }`}
+                  className="group"
                   title={locked ? `Prérequis : ${unlockStatus?.missingPrerequisiteLabels.join(', ')}` : undefined}
                 >
                   {locked ? (
-                    <Lock size={15} className="text-[#8b949e] shrink-0" />
+                    <Lock size={15} className="size-[15px] text-[#8b949e] shrink-0" />
                   ) : (
-                    <span style={{ color: mod.color }}><Icon size={15} /></span>
+                    <span style={{ color: mod.color }}><Icon size={15} className="size-[15px]" /></span>
                   )}
                   <span className="flex-1 text-left truncate">{mod.title}</span>
                   {locked ? (
@@ -161,13 +162,13 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     <>
                       <span className="text-xs text-[#8b949e] font-mono shrink-0">{completed}/{total}</span>
                       {isExpanded ? (
-                        <ChevronDown size={14} className="text-[#8b949e] shrink-0" />
+                        <ChevronDown size={14} className="size-[14px] text-[#8b949e] shrink-0" />
                       ) : (
-                        <ChevronRight size={14} className="text-[#8b949e] shrink-0" />
+                        <ChevronRight size={14} className="size-[14px] text-[#8b949e] shrink-0" />
                       )}
                     </>
                   )}
-                </button>
+                </Button>
 
                 {/* Locked hint */}
                 {locked && (
@@ -182,19 +183,20 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     {mod.lessons.map((lesson) => {
                       const done = isLessonCompleted(mod.id, lesson.id);
                       return (
-                        <button
+                        <Button
                           key={lesson.id}
                           type="button"
+                          variant="tl-sidebar-lesson"
+                          size="tl-sidebar-lesson"
                           onClick={() => handleLessonClick(mod.id, lesson.id)}
-                          className="w-full flex items-center gap-2 min-h-10 px-2 py-1.5 rounded-md text-xs transition-colors hover:bg-[#161b22] text-[#8b949e] hover:text-[#e6edf3] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 group text-left"
                         >
                           {done ? (
-                            <CheckCircle2 size={12} className="text-emerald-400 shrink-0" />
+                            <CheckCircle2 size={12} className="size-[12px] text-emerald-400 shrink-0" />
                           ) : (
-                            <Circle size={12} className="text-[#30363d] shrink-0 group-hover:text-[#8b949e]" />
+                            <Circle size={12} className="size-[12px] text-[#30363d] shrink-0 group-hover:text-[#8b949e]" />
                           )}
                           <span className="truncate">{lesson.title}</span>
-                        </button>
+                        </Button>
                       );
                     })}
                   </div>
@@ -216,27 +218,25 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 const meta = ENV_META[envId];
                 const active = selectedEnv === envId;
                 return (
-                  <button
+                  <Button
                     key={envId}
                     type="button"
+                    variant="tl-env-pill"
+                    size="tl-env-pill"
                     onClick={() => setEnvironment(envId)}
-                    className={`flex-1 flex items-center justify-center gap-1 min-h-9 py-1.5 rounded-md text-[10px] font-mono transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 ${
-                      active
-                        ? `${meta.bgColor} ${meta.color} border ${meta.borderColor}`
-                        : 'text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22] border border-transparent'
-                    }`}
+                    className={active ? `${meta.bgColor} ${meta.color} border ${meta.borderColor}` : undefined}
                     title={`${meta.label} — ${meta.shell}`}
                     aria-pressed={active}
                   >
                     {envId === 'linux' ? (
-                      <Terminal size={10} aria-hidden="true" />
+                      <Terminal size={10} className="size-[10px]" aria-hidden="true" />
                     ) : envId === 'macos' ? (
                       <span className="text-[10px] leading-none select-none" aria-hidden="true"></span>
                     ) : (
                       <span className="text-[9px] leading-none select-none" aria-hidden="true">⊞</span>
                     )}
                     {meta.label}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -251,25 +251,33 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             extraActions={
               <>
                 {!isInstalled && (
-                  <button
+                  <Button
                     type="button"
+                    variant="tl-sidebar-icon"
+                    size="tl-icon-44-md"
                     onClick={() => setShowPWAModal(true)}
-                    className="flex items-center justify-center w-11 h-11 rounded-md text-[#8b949e] hover:text-emerald-400 hover:bg-[#21262d] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-all"
+                    className="hover:text-emerald-400 hover:bg-[#21262d]"
                     aria-label="Installer l'application"
                     title="Installer l'application"
                   >
-                    <Download size={13} aria-hidden="true" />
-                  </button>
+                    <Download size={13} className="size-[13px]" aria-hidden="true" />
+                  </Button>
                 )}
-                <NavLink
-                  to="/"
-                  onClick={onClose}
-                  className="flex items-center justify-center w-11 h-11 rounded-md text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#21262d] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-all"
-                  aria-label="Retour à l'accueil"
-                  title="Retour à l'accueil"
+                <Button
+                  asChild
+                  variant="tl-sidebar-icon"
+                  size="tl-icon-44-md"
+                  className="hover:bg-[#21262d]"
                 >
-                  <Home size={13} aria-hidden="true" />
-                </NavLink>
+                  <NavLink
+                    to="/"
+                    onClick={onClose}
+                    aria-label="Retour à l'accueil"
+                    title="Retour à l'accueil"
+                  >
+                    <Home size={13} className="size-[13px]" aria-hidden="true" />
+                  </NavLink>
+                </Button>
               </>
             }
           />
@@ -282,13 +290,15 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
 export function MenuButton({ onClick }: { onClick: () => void }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="tl-menu-fab"
+      size="tl-icon-44"
       onClick={onClick}
-      className="lg:hidden shrink-0 flex items-center justify-center w-11 h-11 rounded-lg bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-[#e6edf3] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors"
+      className="lg:hidden shrink-0"
       aria-label="Ouvrir le menu de navigation"
     >
-      <Menu size={18} aria-hidden="true" />
-    </button>
+      <Menu size={18} className="size-[18px]" aria-hidden="true" />
+    </Button>
   );
 }

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -52,6 +52,24 @@ const buttonVariants = cva(
           "border transition-colors text-[#8b949e] border-[#30363d] hover:border-[#8b949e] hover:text-[#e6edf3]",
         "tl-filter-pill-active":
           "border transition-colors bg-[#e6edf3] text-[#0d1117] border-[#e6edf3] hover:bg-[#e6edf3]",
+        // Terminal Learning — Sidebar icon 44px with emerald ring (close, install, NavLink icons)
+        "tl-sidebar-icon":
+          "text-[#8b949e] hover:text-[#e6edf3] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 transition-colors",
+        // Terminal Learning — Sidebar module row (w-full, left-align)
+        "tl-sidebar-row":
+          "w-full justify-start text-left gap-2.5 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#c9d1d9] hover:bg-[#161b22]",
+        // Terminal Learning — Locked sidebar row (no hover bg, greyed)
+        "tl-sidebar-row-locked":
+          "w-full justify-start text-left gap-2.5 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#8b949e] cursor-not-allowed",
+        // Terminal Learning — Sidebar lesson subitem
+        "tl-sidebar-lesson":
+          "w-full justify-start text-left gap-2 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22] group",
+        // Terminal Learning — Env switcher pill base (active state via className override)
+        "tl-env-pill":
+          "transition-all focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 font-mono text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22] border border-transparent",
+        // Terminal Learning — Menu FAB (mobile nav trigger)
+        "tl-menu-fab":
+          "bg-[#161b22] border border-[#30363d] text-[#8b949e] hover:text-[#e6edf3] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 transition-colors",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -78,6 +96,16 @@ const buttonVariants = cva(
         "tl-tab-size": "h-auto flex-1 py-2.5 text-xs",
         // Terminal Learning — CommandReference filter pill
         "tl-filter-pill-size": "h-auto min-h-11 px-3 py-1.5 text-xs rounded-full",
+        // Terminal Learning — 44x44 icon button (sidebar close, install, menu FAB)
+        "tl-icon-44": "size-11 rounded-lg",
+        // Terminal Learning — 44x44 icon button (rounded-md variant for install button in UserMenu)
+        "tl-icon-44-md": "size-11 rounded-md",
+        // Terminal Learning — Sidebar module row
+        "tl-sidebar-row": "h-auto min-h-11 px-3 py-2 text-sm rounded-lg",
+        // Terminal Learning — Sidebar lesson subitem
+        "tl-sidebar-lesson": "h-auto min-h-10 px-2 py-1.5 text-xs rounded-md",
+        // Terminal Learning — Env switcher pill
+        "tl-env-pill": "h-auto flex-1 min-h-9 py-1.5 px-1 text-[10px] gap-1 rounded-md",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- Migrates **Sidebar.tsx** + **MenuButton** to shadcn Button across 6 buttons
- Adds variants + sizes to `button.tsx` for sidebar-specific patterns (row, lesson, env pill, menu FAB, icon-44 variants)
- **Fix scope-drift** : retire le bouton d'install PWA (doublon Landing) — signalé visuellement par Thierry

## Buttons migrated
| # | Button | Variant | Size |
|---|--------|---------|------|
| 1 | Close X (mobile) | `tl-sidebar-icon` | `tl-icon-44` |
| 2 | Module header (locked/unlocked) | `tl-sidebar-row` / `tl-sidebar-row-locked` | `tl-sidebar-row` |
| 3 | Lesson subitem | `tl-sidebar-lesson` | `tl-sidebar-lesson` |
| 4 | Env switcher (Linux/macOS/Windows) | `tl-env-pill` | `tl-env-pill` |
| 5 | Home NavLink (asChild) | `tl-sidebar-icon` | `tl-icon-44-md` |
| 6 | MenuButton FAB (exported) | `tl-menu-fab` | `tl-icon-44` |

## Fix — PWA install button removed
Le bouton Download qui ouvrait la `PWAInstallModal` depuis la sidebar est retiré :
- La modale PWA est un CTA **d'acquisition public** (Landing uniquement)
- Sa présence dans `/app/*` dupliquait l'action et n'avait pas de raison d'être dans le flux utilisateur authentifié
- `Landing.tsx` expose toujours le flow d'install normalement

## Notes
- Replaces closed PR #136 (auto-fermée après merge de #135 ayant supprimé la base branch stacked)
- All Lucide icons kept their custom size via `className="size-[Npx]"` to bypass the shadcn base regex that forces svg children to 16px.
- WCAG AAA preserved : `min-h-11` / `size-11` touch targets, `focus-visible:ring-emerald-500/60` on every button, `aria-pressed` on env switcher, `aria-label`/`title` retained.
- Active env pill uses `className` override (`${meta.bgColor} ${meta.color} border ${meta.borderColor}`) — the inactive state lives in the variant.
- `Home` NavLink wrapped via `Button asChild + NavLink` so routing stays intact with shadcn styling.

## Validation visuelle
Testée par Claude Code via Chrome DevTools MCP :
- Desktop 1440×900 : sidebar complète, modules locked/unlocked, env switcher Linux actif yellow
- Mobile 390×844 (iPhone 14) : menu FAB 44×44, overlay sidebar, close X, touch targets 44px, env pills
- **Fix PWA confirmé** : 0 bouton Download/Installer dans le DOM (`installButtonFound: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrer les contrôles de navigation de la barre latérale vers les variantes partagées de `Button` shadcn et supprimer le point d’entrée d’installation PWA de la zone authentifiée.

Nouvelles fonctionnalités :
- Ajouter des variantes et des tailles de boutons spécifiques à la barre latérale au composant partagé `Button` shadcn pour les lignes de modules, les leçons, les « environment pills », les icônes de barre latérale et le FAB du menu mobile.

Corrections de bugs :
- Supprimer le bouton et la modale d’installation PWA de la barre latérale intégrée à l’application afin d’éviter de dupliquer le flux d’installation de la page d’accueil publique.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate sidebar navigation controls to shared shadcn Button variants and remove the authenticated-area PWA install entrypoint.

New Features:
- Add sidebar-specific button variants and sizes to the shared shadcn Button component for module rows, lessons, environment pills, sidebar icons, and the mobile menu FAB.

Bug Fixes:
- Remove the PWA install button and modal from the in-app sidebar to avoid duplicating the public landing install flow.

</details>