### PR TITLE
fix(a11y): focus-visible rings + disabled prop sur Button (THI-106)

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -296,7 +296,6 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
               size="tl-nav-inline"
               onClick={() => handleNavigate(prevLesson)}
               disabled={!prevLesson}
-              aria-disabled={!prevLesson}
               className="gap-2 -ml-2 disabled:opacity-30"
             >
               <ChevronLeft className="size-4" aria-hidden="true" />

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -138,8 +138,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   type="button"
                   variant={locked ? 'tl-sidebar-row-locked' : 'tl-sidebar-row'}
                   size="tl-sidebar-row"
-                  onClick={() => !locked && toggleModule(mod.id)}
-                  aria-disabled={locked ? true : undefined}
+                  onClick={locked ? undefined : () => toggleModule(mod.id)}
+                  disabled={locked}
                   aria-label={locked
                     ? `${mod.title} — verrouillé, Niv. ${unlockStatus?.level}`
                     : `${mod.title} — ${completed}/${total} leçons`}

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -41,17 +41,17 @@ const buttonVariants = cva(
           "w-full justify-start text-left whitespace-normal text-[#e6edf3] hover:bg-[#21262d] transition-colors focus-visible:ring-inset",
         // Terminal Learning — icon-only ghost action (close X, modal dismiss)
         "tl-icon-ghost":
-          "rounded text-[#8b949e] hover:text-[#e6edf3] transition-colors",
+          "rounded text-[#8b949e] hover:text-[#e6edf3] transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         // Terminal Learning — tab segmented control (PWAInstallModal tabs)
         "tl-tab":
-          "font-mono transition-colors text-[#8b949e] hover:text-[#e6edf3] rounded-none",
+          "font-mono transition-colors text-[#8b949e] hover:text-[#e6edf3] rounded-none focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         "tl-tab-active":
-          "font-mono transition-colors text-emerald-400 border-b-2 border-emerald-400 -mb-px rounded-none",
+          "font-mono transition-colors text-emerald-400 border-b-2 border-emerald-400 -mb-px rounded-none focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         // Terminal Learning — CommandReference filter pill
         "tl-filter-pill":
-          "border transition-colors text-[#8b949e] border-[#30363d] hover:border-[#8b949e] hover:text-[#e6edf3]",
+          "border transition-colors text-[#8b949e] border-[#30363d] hover:border-[#8b949e] hover:text-[#e6edf3] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         "tl-filter-pill-active":
-          "border transition-colors bg-[#e6edf3] text-[#0d1117] border-[#e6edf3] hover:bg-[#e6edf3]",
+          "border transition-colors bg-[#e6edf3] text-[#0d1117] border-[#e6edf3] hover:bg-[#e6edf3] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0",
         // Terminal Learning — Sidebar icon 44px with emerald ring (close, install, NavLink icons)
         "tl-sidebar-icon":
           "text-[#8b949e] hover:text-[#e6edf3] focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 transition-colors",
@@ -59,8 +59,9 @@ const buttonVariants = cva(
         "tl-sidebar-row":
           "w-full justify-start text-left gap-2.5 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#c9d1d9] hover:bg-[#161b22]",
         // Terminal Learning — Locked sidebar row (no hover bg, greyed)
+        // disabled:opacity-100 overrides the base disabled:opacity-50 — the grey color + lock icon already signal the disabled state, and halving opacity would drop contrast below WCAG AA on #0d1117.
         "tl-sidebar-row-locked":
-          "w-full justify-start text-left gap-2.5 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#8b949e] cursor-not-allowed",
+          "w-full justify-start text-left gap-2.5 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#8b949e] cursor-not-allowed disabled:opacity-100",
         // Terminal Learning — Sidebar lesson subitem
         "tl-sidebar-lesson":
           "w-full justify-start text-left gap-2 transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0 text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22] group",


### PR DESCRIPTION
## Summary

Fix rapide suite au rapport **`ui-auditor`** post-merge **THI-91** (2026-04-18) : deux blockers A11y confirmés + trois inconsistencies mineures traitées en une PR courte.

- **Blocker W6** — `tl-icon-ghost` (close X modal) sans `focus-visible` ring
- **Blocker W7** — `tl-tab` + `tl-tab-active` (PWAInstallModal) sans `focus-visible` ring
- **Sourcery Issue 1** — Sidebar module verrouillé utilisait seulement `aria-disabled`, donc focusable via Tab et onClick "mou" — passage à `disabled` natif
- **W3 bonus** — `tl-filter-pill` + `tl-filter-pill-active` utilisaient le ring par défaut au lieu du emerald standard
- **C2 bonus** — LessonPage bouton "Précédent" avait `disabled` + `aria-disabled` redondants

## Changements

### `src/app/components/ui/button.tsx`
- `tl-icon-ghost`, `tl-tab`, `tl-tab-active` : ajout `focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0`
- `tl-filter-pill`, `tl-filter-pill-active` : idem (cohérence design system)
- `tl-sidebar-row-locked` : ajout `disabled:opacity-100` pour neutraliser la base `disabled:opacity-50` — sinon le texte `#8b949e` passerait sous le contraste AA sur `#0d1117` une fois `disabled` appliqué

### `src/app/components/Sidebar.tsx`
- Module verrouillé : `aria-disabled={locked}` seul → `disabled={locked}` (sorti du tab order, vraiment non-interactif)
- `onClick={() => !locked && toggleModule(...)}` → `onClick={locked ? undefined : () => toggleModule(...)}`

### `src/app/components/LessonPage.tsx`
- Bouton "Précédent" : retrait de `aria-disabled={!prevLesson}` redondant avec `disabled={!prevLesson}`

## Test plan

- [x] `ui-auditor` post-fix → VERDICT **RESOLVED**, 0 régression
- [x] vitest → 901 pass / 0 fail / 20 skip
- [x] `tsc --noEmit` → ✅
- [x] ESLint → ✅
- [ ] **Validation visuelle Thierry (Chrome + mobile)** — focus-visible sur tab PWAInstallModal, close X, filter pills, module verrouillé dans la sidebar

## Hors scope

- **THI-105** — refactor complexité CVA (wrappers `SidebarRowButton` / `EnvPill`, séparation variant/size, `icon-lg` générique)
- **Nouvelle issue à créer** — migration des 13 `<button>` natifs restants (UserMenu, LoginModal, PrivacyPolicy, Landing env pills)

Refs: THI-106 · suite audit THI-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Amélioration de l’accessibilité et du comportement `focus-visible` pour différentes variantes de boutons et les éléments de navigation de la barre latérale.

Corrections de bugs :
- Ajout d’anneaux `focus-visible` cohérents aux variantes de boutons icône fantôme, onglet et pilule de filtre afin de répondre aux exigences d’accessibilité.
- Rendre les boutons de modules verrouillés dans la barre latérale réellement désactivés et non focalisables au lieu d’être uniquement `aria-disabled`.
- Suppression de l’attribut redondant `aria-disabled` sur le bouton de navigation « Précédent » de la page LessonPage lorsqu’il est désactivé.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus-visible behavior for various button variants and sidebar navigation elements.

Bug Fixes:
- Add consistent focus-visible rings to icon ghost, tab, and filter pill button variants to meet accessibility requirements.
- Make locked sidebar module buttons truly disabled and non-focusable instead of only aria-disabled.
- Remove redundant aria-disabled attribute on the LessonPage "Previous" navigation button when disabled.

</details>