### PR TITLE
feat(a11y): migrate 11 native buttons to shadcn Button (THI-107)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,18 +9,20 @@ import { AuthProvider } from './context/AuthContext';
 import { ProgressProvider } from './context/ProgressContext';
 import { EnvironmentProvider } from './context/EnvironmentContext';
 import { PageLoader } from './components/PageLoader';
+import { Button } from './components/ui/button';
 
 function FallbackUI() {
   return (
     <div className="min-h-dvh bg-[#0d1117] flex items-center justify-center text-[#e6edf3] font-mono">
       <div className="text-center space-y-4">
         <p className="text-[#f85149] text-lg">Une erreur inattendue s'est produite.</p>
-        <button
+        <Button
+          variant="outline"
           onClick={() => window.location.reload()}
-          className="text-sm text-emerald-400 hover:text-emerald-300 border border-emerald-500/30 rounded px-4 py-2 transition-colors"
+          className="text-sm text-emerald-400 hover:text-emerald-300 hover:bg-transparent bg-transparent border-emerald-500/30"
         >
           Recharger la page
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/app/components/PrivacyPolicy.tsx
+++ b/src/app/components/PrivacyPolicy.tsx
@@ -27,13 +27,15 @@ export function PrivacyPolicy() {
           <Terminal size={18} className="text-emerald-400" />
           <span className="font-mono text-sm text-[#e6edf3]">Terminal Learning</span>
         </div>
-        <button
+        <Button
+          variant="nav-link"
+          size="link-inline"
           onClick={() => navigate('/')}
-          className="flex items-center gap-2 text-[#8b949e] hover:text-[#e6edf3] text-sm transition-colors"
+          className="text-sm gap-2"
         >
-          <ArrowLeft size={14} />
+          <ArrowLeft size={14} aria-hidden="true" />
           Retour
-        </button>
+        </Button>
       </nav>
 
       <main className="max-w-4xl mx-auto px-6 py-12">

--- a/src/app/components/auth/LoginModal.tsx
+++ b/src/app/components/auth/LoginModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { z } from 'zod';
 import { supabase } from '../../../lib/supabase';
+import { Button } from '../ui/button';
 
 const emailSchema = z.string().email('Email invalide');
 const passwordSchema = z.string().min(8, 'Minimum 8 caractères');
@@ -95,14 +96,16 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
           <h2 className="text-lg font-semibold text-[#e6edf3] font-mono">
             {mode === 'login' ? 'Connexion' : 'Créer un compte'}
           </h2>
-          <button
+          <Button
             type="button"
+            variant="tl-icon-ghost"
+            size="tl-icon-44"
             onClick={handleClose}
             aria-label="Fermer"
-            className="flex items-center justify-center w-11 h-11 -mr-2 rounded-lg text-[#8b949e] hover:text-[#e6edf3] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors text-xl leading-none"
+            className="-mr-2 text-xl leading-none"
           >
             ×
-          </button>
+          </Button>
         </div>
 
         {success ? (
@@ -115,11 +118,13 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
           <>
             {/* OAuth buttons */}
             <div className="space-y-2 mb-4">
-              <button
+              <Button
                 type="button"
+                variant="ghost-gh"
+                size="tl-install-cta"
                 onClick={() => handleOAuth('github')}
                 disabled={loadingOAuth !== null}
-                className="w-full min-h-11 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg border border-[#30363d] bg-[#0d1117] text-[#e6edf3] text-sm font-mono hover:border-emerald-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                className="bg-[#0d1117] text-[#e6edf3] hover:text-[#e6edf3] hover:border-emerald-500/50 focus-visible:border-[#30363d] font-mono disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {loadingOAuth === 'github' ? (
                   <span className="w-4 h-4 border-2 border-[#e6edf3]/30 border-t-[#e6edf3] rounded-full animate-spin" />
@@ -127,12 +132,14 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
                   <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
                 )}
                 {loadingOAuth === 'github' ? 'Redirection…' : 'Continuer avec GitHub'}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost-gh"
+                size="tl-install-cta"
                 onClick={() => handleOAuth('google')}
                 disabled={loadingOAuth !== null}
-                className="w-full min-h-11 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg border border-[#30363d] bg-[#0d1117] text-[#e6edf3] text-sm font-mono hover:border-emerald-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                className="bg-[#0d1117] text-[#e6edf3] hover:text-[#e6edf3] hover:border-emerald-500/50 focus-visible:border-[#30363d] font-mono disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {loadingOAuth === 'google' ? (
                   <span className="w-4 h-4 border-2 border-[#e6edf3]/30 border-t-[#e6edf3] rounded-full animate-spin" />
@@ -140,7 +147,7 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
                   <svg className="w-4 h-4" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
                 )}
                 {loadingOAuth === 'google' ? 'Redirection…' : 'Continuer avec Google'}
-              </button>
+              </Button>
             </div>
 
             <div className="relative my-4">
@@ -183,24 +190,28 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
                 <p className="text-[#f85149] text-xs font-mono">{error}</p>
               )}
 
-              <button
+              <Button
                 type="submit"
+                variant="emerald"
+                size="tl-install-cta"
                 disabled={loading}
-                className="w-full min-h-11 py-2.5 rounded-lg bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-[#0d1117] font-semibold text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 transition-colors"
+                className="font-mono focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0"
               >
                 {loading ? '...' : mode === 'login' ? 'Se connecter' : 'Créer le compte'}
-              </button>
+              </Button>
             </form>
 
             <p className="mt-4 text-center text-xs text-[#8b949e] font-mono">
               {mode === 'login' ? "Pas encore de compte ? " : 'Déjà un compte ? '}
-              <button
+              <Button
                 type="button"
+                variant="link"
+                size="link-inline"
                 onClick={() => switchMode(mode === 'login' ? 'signup' : 'login')}
-                className="text-emerald-400 hover:text-emerald-300 focus-visible:outline-none focus-visible:underline transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 hover:no-underline focus-visible:underline focus-visible:ring-0 transition-colors"
               >
                 {mode === 'login' ? 'Créer un compte' : 'Se connecter'}
-              </button>
+              </Button>
             </p>
           </>
         )}

--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { LogOut, LogIn, User } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
+import { Button } from '../ui/button';
 
 interface UserMenuProps {
   syncStatus: 'local' | 'synced' | 'syncing' | 'error';
@@ -80,13 +81,15 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
           </div>
           {extraActions && <div className="flex items-center gap-1 shrink-0">{extraActions}</div>}
         </div>
-        <button
+        <Button
+          variant="emerald-soft"
+          size="link-inline"
           onClick={() => navigate('/')}
-          className="w-full flex items-center justify-center gap-2 py-1.5 rounded-md text-xs font-mono bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 hover:bg-emerald-500/20 hover:border-emerald-500/40 transition-all outline-none focus-visible:ring-1 focus-visible:ring-emerald-500"
+          className="w-full gap-2 py-1.5 rounded-md text-xs font-mono hover:border-emerald-500/40"
         >
           <LogIn size={12} aria-hidden="true" />
           Se connecter
-        </button>
+        </Button>
       </div>
     );
   }
@@ -121,14 +124,16 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
           </div>
           {extraActions && <div className="flex items-center gap-1 shrink-0">{extraActions}</div>}
         </div>
-        <button
+        <Button
+          variant="ghost"
+          size="link-inline"
           onClick={handleSignOut}
           disabled={signingOut}
-          className="w-full flex items-center justify-center gap-2 py-1.5 rounded-md text-xs font-mono text-[#f85149] border border-[#f85149]/20 hover:bg-[#f85149]/10 hover:border-[#f85149]/40 transition-all outline-none focus-visible:ring-1 focus-visible:ring-[#f85149] disabled:opacity-50"
+          className="w-full gap-2 py-1.5 rounded-md text-xs font-mono text-[#f85149] border border-[#f85149]/20 hover:bg-[#f85149]/10 hover:text-[#f85149] hover:border-[#f85149]/40 transition-all focus-visible:ring-[#f85149]/60 focus-visible:ring-2 focus-visible:ring-offset-0"
         >
           <LogOut size={12} aria-hidden="true" />
           {signingOut ? 'Déconnexion…' : 'Se déconnecter'}
-        </button>
+        </Button>
       </div>
     );
   }
@@ -136,19 +141,22 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
   // ── Variant compact — navbar / header ─────────────────────────────────────────
   return (
     <div ref={menuRef} className="relative">
-      <button
+      <Button
+        type="button"
+        variant="ghost"
+        size="link-inline"
         onClick={() => setOpen((o) => !o)}
         aria-label={`Compte de ${displayName} — ${sync.label}`}
         aria-expanded={open}
         aria-haspopup="true"
-        className="relative flex items-center justify-center rounded-full ring-2 ring-transparent hover:ring-emerald-500/50 focus-visible:ring-emerald-500 transition-all outline-none"
+        className="relative rounded-full ring-2 ring-transparent hover:ring-emerald-500/50 hover:bg-transparent focus-visible:ring-emerald-500 focus-visible:ring-2 focus-visible:ring-offset-0 transition-all"
       >
         <UserAvatar avatarUrl={avatarUrl} initials={initials} size="sm" />
         <span
           aria-hidden="true"
           className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[#0d1117] ${sync.dot}`}
         />
-      </button>
+      </Button>
 
       {open && (
         <div className="absolute right-0 top-full mt-2 z-50 w-60 bg-[#161b22] border border-[#30363d] rounded-xl shadow-2xl overflow-hidden">
@@ -164,14 +172,16 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
             </div>
           </div>
           <div className="py-1">
-            <button
+            <Button
+              variant="ghost"
+              size="link-inline"
               onClick={handleSignOut}
               disabled={signingOut}
-              className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-[#f85149] hover:bg-[#f85149]/10 font-mono transition-colors disabled:opacity-50 outline-none focus-visible:bg-[#f85149]/10"
+              className="w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[#f85149] font-mono hover:bg-[#f85149]/10 hover:text-[#f85149] rounded-none transition-colors focus-visible:ring-[#f85149]/60 focus-visible:ring-2 focus-visible:ring-offset-0"
             >
               <LogOut size={14} aria-hidden="true" />
               {signingOut ? 'Déconnexion…' : 'Se déconnecter'}
-            </button>
+            </Button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Migrates the last 11 `<button>` elements in `src/app/` to `<Button variant=... size=...>` using **only existing CVA entries**
- Files touched: `App.tsx`, `components/PrivacyPolicy.tsx`, `components/auth/UserMenu.tsx`, `components/auth/LoginModal.tsx`
- 4 UserMenu buttons (guest CTA, card sign-out, avatar trigger, dropdown sign-out)
- 5 LoginModal buttons (close X, GitHub OAuth, Google OAuth, submit, switch-mode link)
- 1 App error fallback + 1 PrivacyPolicy back nav

## A11y side-effects (positive)
- `PrivacyPolicy` back nav — now has `focus-visible` ring emerald (was missing)
- `UserMenu` dropdown sign-out — now has `focus-visible:ring-[#f85149]/60` (was `focus-visible:bg-*` only → failed WCAG 2.4.7)
- `LoginModal` submit — ring harmonised to `emerald-500/60` (was `emerald-300`)

## Out of scope → THI-105
- `Landing.tsx:153` env toggle — needs new `tl-env-pill-lg` size variant
- `components/ui/sidebar.tsx:286` — shadcn internal, preserve

## Baseline vs post
- Pre-PR: 13 native `<button>` elements
- Post-PR: 2 remain (Landing env + sidebar internal — both expected)

## Test plan
- [x] `npm run type-check` clean
- [x] `npm test` — 901 tests passing
- [x] 11 `<button>` → `<Button>` (grep confirms 2 remain)
- [ ] Vercel preview — desktop + iPhone 14 visual parity
- [ ] Keyboard focus rings visible on all migrated buttons
- [ ] Sourcery green

Closes THI-107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrer les derniers boutons natifs dans les flux d’authentification, la politique de confidentialité et le fallback d’erreur de l’application vers le composant partagé `shadcn Button` afin d’assurer une cohérence de style et une meilleure accessibilité.

Bug Fixes:
- Améliorer le style de `focus-visible` et des bordures de mise en évidence (`ring`) sur plusieurs éléments interactifs afin de mieux respecter les recommandations en matière d’accessibilité.

Enhancements:
- Unifier les boutons d’action de `LoginModal` (fermeture, fournisseurs OAuth, soumission et changement de mode) sur le composant `Button` partagé en utilisant les variantes de design existantes.
- Standardiser le CTA invité du `UserMenu`, le déclencheur d’avatar et les actions de déconnexion sur le composant `Button` partagé tout en préservant la hiérarchie visuelle.
- Aligner la navigation retour de `PrivacyPolicy` et l’action de fallback pour les erreurs au niveau de l’application avec le système de boutons partagé afin d’assurer un comportement d’interface cohérent.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate remaining native buttons in the auth flows, privacy policy, and app error fallback to the shared shadcn Button component for consistent styling and accessibility.

Bug Fixes:
- Improve focus-visible and ring styling on several interactive elements to better meet accessibility guidelines.

Enhancements:
- Unify LoginModal action buttons (close, OAuth providers, submit, and mode switch) on the shared Button component with existing design variants.
- Standardize UserMenu guest CTA, avatar trigger, and sign-out actions on the shared Button component while preserving visual hierarchy.
- Align the PrivacyPolicy back navigation and the app-level error fallback action with the shared Button system for consistent UI behavior.

</details>