### PR TITLE
docs: close shadcn migration saga (THI-85/91/106/107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 
 ---
 
+## Migration shadcn/ui — clôturée
+*17–18 avril 2026 · THI-85 / THI-91 / THI-106 / THI-107*
+
+**Le défi :** 39 composants Radix UI étaient installés depuis la Phase 3, mais l'UI était 100% custom Tailwind — un écart silencieux entre ce que `package.json` annonçait et ce que le code utilisait réellement. Chaque `<button>` natif recodait ses propres focus rings, ses propres couleurs hover, ses propres tailles — sans garantie de cohérence d'une page à l'autre.
+
+**La méthode :** Migration page par page pilotée par l'agent `ui-auditor` qui scanne avant chaque PR : Dashboard (THI-95), LessonPage (THI-91 chunk D), Landing chunks B/C, Sidebar (THI-91 chunk A), NotFound (THI-85). Puis clôture en deux temps : d'abord un fix a11y sur 5 variantes Button qui n'avaient pas de `focus-visible` ring (THI-106), puis la migration des 11 derniers `<button>` natifs de `src/app/` (THI-107) — App FallbackUI, LoginModal (close + OAuth GitHub/Google + submit + link switch), UserMenu (guest CTA + card/dropdown sign-out + avatar toggle), PrivacyPolicy back nav.
+
+**Ce qui a été livré :**
+- Tous les éléments interactifs passent par `<Button variant=... size=...>` avec variantes CVA centralisées dans `src/app/components/ui/button.tsx`
+- `focus-visible` ring emerald (`ring-emerald-500/60 ring-2`) harmonisé sur l'ensemble du codebase
+- Sidebar modules verrouillés : `disabled={locked}` natif (sortis du tab order) + `disabled:opacity-100` pour préserver le contraste AA sur fond `#0d1117`
+- Cleanup des `aria-disabled` redondants (LessonPage)
+- 2 natives délibérées restantes : `sidebar.tsx` (shadcn interne) + `Landing.tsx:153` toggle env (différé à THI-105 qui ajoutera une size `tl-env-pill-lg`)
+
+**Validation :**
+- 901 tests unitaires verts sur chaque PR
+- Sourcery review OK sur #140, #141, #142, #143
+- Vérification visuelle Chrome DevTools MCP desktop + iPhone 14 sur Landing, LoginModal, PrivacyPolicy, Dashboard sidebar — zéro régression
+- `ui-auditor` post-PR : baseline 2 natives restantes confirmée, zéro nouvelle violation
+
+**Pourquoi c'est important :** Un design system n'est pas une dépendance qu'on installe — c'est une discipline qu'on applique. Avoir Radix UI dans `package.json` sans l'utiliser, c'était vivre avec un mensonge de 50 lignes. La clôture de cette saga signifie qu'à partir de maintenant, toute nouvelle UI passera par le composant `<Button>` (ou équivalent `<Card>`, `<Badge>`) — et `ui-auditor` est là pour s'assurer que personne n'oublie.
+
+**Leçon :** Quand une refactor s'étend sur plusieurs PRs, un umbrella issue (ici THI-91) qui liste les sous-chantiers et un agent qui audite avant chaque merge suffisent pour éviter le drift. Les petites corrections a11y trouvées en route (THI-106) ne méritent pas leur propre saga — elles se greffent à la PR en cours et avancent en même temps.
+
+---
+
 ## Web 2026 compliance — mobile + clavier, 6 PRs livrées en 48h
 *14–16 avril 2026 · Epic THI-96 (THI-97 → THI-102)*
 

--- a/STORY.md
+++ b/STORY.md
@@ -299,8 +299,8 @@ Et ce qu'on retient aussi, plus personnellement : **on peut soulever des montagn
 
 ### Ce sur quoi on travaille maintenant
 
-**Migration shadcn/ui (THI-85)**
-39 composants Radix UI sont installés, mais l'UI est 100% custom Tailwind. La migration se fera page par page — Dashboard d'abord, puis LessonPage, puis Landing. L'agent ui-auditor guidera chaque étape.
+**Migration shadcn/ui — clôturée (THI-85 / THI-91 / THI-106 / THI-107)**
+La migration page par page est finie. Dashboard (THI-95), LessonPage (THI-91 chunk D), Landing chunks B/C, Sidebar (chunk A), NotFound, puis dans la dernière passe LoginModal / UserMenu / PrivacyPolicy / App FallbackUI (THI-107). L'agent ui-auditor a servi de filet à chaque étape — trois findings a11y côté variants Button ont été corrigés en passant (THI-106). Il reste deux natives délibérées : un bouton interne à shadcn (`sidebar.tsx`) et le toggle d'environnement du Landing, qui a besoin d'une nouvelle size `tl-env-pill-lg`. Ce dernier chantier est tracé sous THI-105 — c'est un refactor CVA (extraction des tokens GitHub-dark, regroupement des variantes `tl-*` par famille), pas une migration.
 
 **Admin Panel institutionnel (Phase 9)**
 Les outils pour les enseignants : vue classe, heatmaps d'activité, suivi de progression par élève. La plateforme peut maintenant accueillir des établissements — il faut maintenant leur donner les outils pour que ça soit utile.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Terminal Learning
 
-> Last updated: 17 April 2026 — **Strategic vision consolidated (ADRs 001-004)**: LTI-first positioning, OpenRouter BYOK 4-tiers, TTFR KPI, Classroom Composer UI — **Epic THI-96 Web 2026 Compliance** 🔄 6/8 sub-issues shipped (THI-97 → THI-102) — viewport-fit=cover, min-h-dvh, safe-area-inset-bottom, WCAG 2.2 AAA touch targets (44px), focus-visible rings emerald, autoComplete/inputMode on LoginModal, clamp() fluid typography on 404 — remaining: Desktop a11y + CSS moderne 2026 — INP fix THI-90 ✅ (PR #114 merged), lab 515ms → 26ms (−95%) — Phase 4c Bundle Optimization ✅ (PR #108 merged) — 11 modules / 64 lessons / 901 tests — **Next priorities**: landing interactive demo, BYOK OpenRouter + AI tutor socratic A1, multi-tenancy RLS audit, i18n FR/NL/EN setup
+> Last updated: 18 April 2026 — **Strategic vision consolidated (ADRs 001-004)**: LTI-first positioning, OpenRouter BYOK 4-tiers, TTFR KPI, Classroom Composer UI — **Epic THI-96 Web 2026 Compliance** 🔄 6/8 sub-issues shipped (THI-97 → THI-102) — viewport-fit=cover, min-h-dvh, safe-area-inset-bottom, WCAG 2.2 AAA touch targets (44px), focus-visible rings emerald, autoComplete/inputMode on LoginModal, clamp() fluid typography on 404 — remaining: Desktop a11y + CSS moderne 2026 — **shadcn/ui migration ✅ closed** (THI-91 umbrella, THI-106 a11y fix, THI-107 11 native buttons migrated — PRs #131/#134/#135/#137/#139/#140/#142) — INP fix THI-90 ✅ (PR #114 merged), lab 515ms → 26ms (−95%) — Phase 4c Bundle Optimization ✅ (PR #108 merged) — 11 modules / 64 lessons / 901 tests — **Next priorities**: THI-105 button.tsx refactor (CVA tokens + tl-env-pill-lg), landing interactive demo, BYOK OpenRouter + AI tutor socratic A1, multi-tenancy RLS audit, i18n FR/NL/EN setup
 
 ---
 
@@ -71,10 +71,12 @@ professionals who leverage AI as a tool, not a replacement.
 - [x] Agent `ui-auditor` — design system compliance guard
 - [x] INP fix — `setEnvironment` wrappé dans `startTransition` au context owner, lab CPU 4× : 515ms → 26ms (−95%) sur env switcher (PR #114, THI-90)
 
-## Phase 4d — Design System Compliance 🔮 Planned (THI-85)
-- [ ] Migrate custom components to shadcn/ui — page by page (Dashboard → LessonPage → Landing → NotFound)
-- [ ] Integrate `ui-auditor` agent into mandatory session protocol (THI-86)
-- [ ] Zero custom `<button>`, `<card>`, `<badge>` patterns where shadcn equivalent exists
+## Phase 4d — Design System Compliance ✅ Done (THI-85 / THI-91 / THI-106 / THI-107)
+- [x] Migrate custom components to shadcn/ui — NotFound (THI-85), Dashboard (THI-95), LessonPage (THI-91 chunk D), Landing chunk B/C (THI-91 chunks B/C), Sidebar (THI-91 chunk A), LoginModal / UserMenu / PrivacyPolicy / App FallbackUI (THI-107)
+- [x] `ui-auditor` agent integrated into mandatory session protocol (THI-86)
+- [x] A11y harmonisation on Button CVA variants — focus-visible rings emerald, native `disabled` on Sidebar locked rows (THI-106)
+- [x] Zero native `<button>` in src/app/ except 2 intentional exceptions: `src/app/components/ui/sidebar.tsx` (shadcn internal) + `src/app/components/Landing.tsx:153` env toggle (deferred to THI-105 — needs new `tl-env-pill-lg` size)
+- [ ] **THI-105** — `button.tsx` post-migration refactor: extract GitHub-dark hex tokens (`#0d1117`, `#161b22`, etc.) to `tailwind.config.ts` or CSS vars, group `tl-*` variants by family (sidebar / nav / filter / tab), add `tl-env-pill-lg` size, migrate Landing env toggle, document prefix convention 🔮 Backlog
 
 ## Phase 4e — Web 2026 Compliance 🔄 Epic THI-96 (14–16 April 2026)
 > Full desktop + mobile conformance to 2026 web standards. 6/8 sub-issues shipped in 48h. Target users: iPhone SE 2016, Chromebook 2019, keyboard-only navigators (motor accessibility), photosensitive users.


### PR DESCRIPTION
## Summary

Clôture narrative de la saga shadcn/ui après merge des PRs #140/#141/#142/#143.

- **CHANGELOG.md** : nouvelle entrée "Migration shadcn/ui — clôturée" (THI-85 / 91 / 106 / 107) — défi, méthode, livrables, validation, leçon
- **STORY.md** : section "Ce sur quoi on travaille maintenant" mise à jour (migration → clôturée, THI-105 tracé comme refactor CVA restant)
- **docs/ROADMAP.md** : Phase 4d passée de 🔮 Planned à ✅ Done, 2 exceptions natives documentées, THI-105 ajouté en Backlog

## Test plan

- [ ] CI verte (type-check + lint + 901 tests + build)
- [ ] Sourcery review OK (ou SKIPPED)
- [ ] Preview Vercel : `/changelog` affiche la nouvelle entrée en tête
- [ ] Preview Vercel : `/story` affiche la section "clôturée" mise à jour
- [ ] Aucun changement de code → aucune régression UI attendue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documenter l’achèvement de la migration vers shadcn/ui et mettre à jour la feuille de route et l’histoire pour refléter la clôture de la phase de conformité au système de design et le refactoring de suivi restant.

Documentation :
- Ajouter une entrée de changelog détaillée décrivant l’achèvement de la migration vers shadcn/ui, sa portée, sa validation et les enseignements tirés.
- Mettre à jour `STORY.md` pour marquer la migration vers shadcn/ui comme terminée et décrire les pages complétées, les boutons natifs restants intentionnels, ainsi que le ticket de refactoring de suivi `THI-105`.
- Mettre à jour `docs/ROADMAP.md` pour marquer la Phase 4d « Design System Compliance » comme terminée, enregistrer la clôture de la migration vers shadcn/ui et ajouter `THI-105` comme élément de refactoring dans le backlog.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document completion of the shadcn/ui migration and update roadmap and story to reflect the closed design system compliance phase and remaining follow-up refactor.

Documentation:
- Add a detailed changelog entry narrating the completion of the shadcn/ui migration, its scope, validation, and lessons learned.
- Update STORY.md to mark the shadcn/ui migration as closed and describe the completed pages, remaining intentional native buttons, and follow-up refactor issue THI-105.
- Update docs/ROADMAP.md to mark Phase 4d Design System Compliance as done, record the shadcn/ui migration closure, and add THI-105 as a backlog refactor item.

</details>