### PR TITLE
fix(markdown): internal .md links → SPA routes + CI guard + agent check

### DIFF
--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -1,13 +1,13 @@
 ---
 name: content-auditor
-description: Full pedagogical content audit — checks env coverage, curriculum↔terminalEngine consistency, test coverage, external link validity, prerequisite chain logic, and validate() function quality. Run on demand or before major releases. Returns a structured report.
+description: Full pedagogical content audit — checks env coverage, curriculum↔terminalEngine consistency, test coverage, external link validity, narrative markdown internal links, prerequisite chain logic, and validate() function quality. Run on demand or before major releases. Returns a structured report.
 tools: Read, Grep, Glob, WebFetch
 model: haiku
 ---
 
 Tu es un auditeur de contenu pédagogique pour Terminal Learning.
 
-Analyse en profondeur l'ensemble du curriculum et produis un rapport structuré A→Z.
+Analyse en profondeur l'ensemble du curriculum + les docs narratifs et produis un rapport structuré A→Z.
 
 ## Fichiers à analyser
 
@@ -15,6 +15,9 @@ Analyse en profondeur l'ensemble du curriculum et produis un rapport structuré 
 - `src/app/data/terminalEngine.ts` — commandes simulées
 - `src/app/data/commandCatalogue.ts` — catalogue de référence
 - `src/test/terminalEngine.test.ts` — tests unitaires
+- `CHANGELOG.md`, `STORY.md` — docs narratifs rendus sur `/changelog` et `/story`
+- `src/app/routes.ts` — table de routes source de vérité
+- `src/app/components/MarkdownPage.tsx` — mapping `MARKDOWN_ROUTE_MAP` (liens .md → routes SPA)
 
 ## Vérifications à effectuer
 
@@ -58,7 +61,24 @@ Si des URLs apparaissent dans `contentByEnv` ou `hintByEnv`, tenter une requête
 - WARNING si une URL retourne une erreur HTTP (4xx/5xx) ou est inaccessible
 - Ne pas agréger les échecs réseau transitoires comme des WARNING : signaler uniquement les erreurs répétables
 
-### 8. ExerciseTypes (Phase 5b — futur)
+### 8. Liens internes markdown narratifs (CHANGELOG.md, STORY.md)
+
+Contexte : `CHANGELOG.md` et `STORY.md` sont rendus par `MarkdownPage.tsx` sur les routes `/changelog` et `/story`. Un lien relatif `.md` dans ces fichiers (ex: `[...](STORY.md)`) est résolu par le browser relativement à la route courante → `/STORY.md` → catch-all 404. Même chose pour un chemin SPA qui n'existe pas.
+
+Procédure :
+1. Extraire tous les liens markdown `[texte](href)` dans `CHANGELOG.md` et `STORY.md`.
+2. Lire `src/app/routes.ts` pour obtenir la liste des routes déclarées (source de vérité).
+3. Lire `src/app/components/MarkdownPage.tsx` → récupérer les entrées de `MARKDOWN_ROUTE_MAP`.
+4. Pour chaque lien, classer :
+   - `http://` / `https://` / `mailto:` / `#anchor` → OK (externe/ancre)
+   - `.md` présent dans `MARKDOWN_ROUTE_MAP` → OK (sera remappé côté render)
+   - `.md` absent du mapping → **CRITICAL** (lien mort — ajouter au mapping ou remplacer par la route)
+   - chemin `/route` matchant une route (ou un préfixe dynamique comme `/app/learn/`) → OK
+   - chemin `/route` ne matchant aucune route → **CRITICAL** (404 garanti)
+
+Rapporter chaque lien suspect avec fichier + ligne + href.
+
+### 9. ExerciseTypes (Phase 5b — futur)
 Si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement :
 `fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`.
 Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.

--- a/src/app/components/MarkdownPage.tsx
+++ b/src/app/components/MarkdownPage.tsx
@@ -12,7 +12,8 @@ import { Button } from './ui/button';
 // /changelog and /story — so cross-links in their markdown must resolve to
 // those routes instead of the raw .md file (which would 404 on the SPA).
 // Keep in sync with src/app/routes.ts.
-const MARKDOWN_ROUTE_MAP: Record<string, string> = {
+// Exported so src/test/markdownLinks.test.ts can use it as single source of truth.
+export const MARKDOWN_ROUTE_MAP: Record<string, string> = {
   'STORY.md': '/story',
   'CHANGELOG.md': '/changelog',
 };

--- a/src/app/components/MarkdownPage.tsx
+++ b/src/app/components/MarkdownPage.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, Link } from 'react-router';
 import { Helmet } from 'react-helmet-async';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Terminal, ArrowLeft, ArrowUp } from 'lucide-react';
 import type { Components } from 'react-markdown';
 import { Button } from './ui/button';
+
+// Maps repo-root markdown filenames to their SPA route.
+// Narrative docs at the repo root (CHANGELOG.md, STORY.md) are rendered at
+// /changelog and /story — so cross-links in their markdown must resolve to
+// those routes instead of the raw .md file (which would 404 on the SPA).
+// Keep in sync with src/app/routes.ts.
+const MARKDOWN_ROUTE_MAP: Record<string, string> = {
+  'STORY.md': '/story',
+  'CHANGELOG.md': '/changelog',
+};
 
 const mdComponents: Components = {
   h1: ({ children }) => (
@@ -26,16 +36,30 @@ const mdComponents: Components = {
   em: ({ children }) => (
     <em className="text-[#8b949e] italic">{children}</em>
   ),
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      target={href?.startsWith('http') ? '_blank' : undefined}
-      rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
-      className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2 transition-colors"
-    >
-      {children}
-    </a>
-  ),
+  a: ({ href, children }) => {
+    const linkClass = 'text-emerald-400 hover:text-emerald-300 underline underline-offset-2 transition-colors';
+    const mappedRoute = href ? MARKDOWN_ROUTE_MAP[href] : undefined;
+
+    if (mappedRoute) {
+      return (
+        <Link to={mappedRoute} className={linkClass}>
+          {children}
+        </Link>
+      );
+    }
+
+    const isExternal = href?.startsWith('http');
+    return (
+      <a
+        href={href}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+        className={linkClass}
+      >
+        {children}
+      </a>
+    );
+  },
   pre: ({ children }) => (
     <div className="my-4 bg-[#161b22] border border-[#30363d] rounded-lg p-4 overflow-x-auto">
       {children}

--- a/src/test/markdownLinks.test.ts
+++ b/src/test/markdownLinks.test.ts
@@ -14,12 +14,13 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { describe, it, expect } from 'vitest';
+import { MARKDOWN_ROUTE_MAP } from '../app/components/MarkdownPage';
 
 const ROOT = resolve(__dirname, '../../');
 
-// Kept in sync with MARKDOWN_ROUTE_MAP (src/app/components/MarkdownPage.tsx)
-// and the router table (src/app/routes.ts).
-const MAPPED_MD_FILES = new Set(['STORY.md', 'CHANGELOG.md']);
+// Declared SPA routes — MUST stay in sync with src/app/routes.ts.
+// Paths ending with '/' act as dynamic prefixes (e.g. /app/learn/:moduleId/:lessonId).
+// If you add a public route in routes.ts, mirror it here.
 const DECLARED_ROUTES = [
   '/',
   '/privacy',
@@ -28,21 +29,24 @@ const DECLARED_ROUTES = [
   '/auth/callback',
   '/app',
   '/app/reference',
-  // dynamic: /app/learn/:moduleId/:lessonId — handled by startsWith below
   '/app/learn/',
-  // legacy redirects still valid:
   '/learn/',
   '/reference',
 ];
 
 type MarkdownLink = { file: string; href: string; line: number };
 
+// Match [text](href) but NOT ![alt](href) (image syntax) — negative lookbehind on '!'.
+// Href is any run of non-whitespace, non-closing-paren chars. We intentionally
+// skip the rare [text](url "title") form: it's not used anywhere in the narrative
+// docs today and supporting it adds brittleness.
+const LINK_PATTERN = /(?<!!)\[[^\]]+\]\(([^)\s]+)\)/g;
+
 function extractLinks(filePath: string): MarkdownLink[] {
   const content = readFileSync(filePath, 'utf-8');
-  const pattern = /\[[^\]]+\]\(([^)\s]+)\)/g;
   const out: MarkdownLink[] = [];
   content.split('\n').forEach((line, idx) => {
-    for (const match of line.matchAll(pattern)) {
+    for (const match of line.matchAll(LINK_PATTERN)) {
       out.push({ file: filePath, href: match[1], line: idx + 1 });
     }
   });
@@ -53,7 +57,7 @@ function isAcceptable(href: string): boolean {
   if (/^https?:\/\//.test(href)) return true;
   if (href.startsWith('mailto:')) return true;
   if (href.startsWith('#')) return true;
-  if (MAPPED_MD_FILES.has(href)) return true;
+  if (href in MARKDOWN_ROUTE_MAP) return true;
   if (DECLARED_ROUTES.some((r) => href === r || (r.endsWith('/') && href.startsWith(r)))) return true;
   return false;
 }

--- a/src/test/markdownLinks.test.ts
+++ b/src/test/markdownLinks.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="node" />
+/**
+ * Guard: every internal link inside narrative markdown docs rendered on the
+ * SPA (CHANGELOG.md via /changelog, STORY.md via /story) must either be
+ *  - external (http/https),
+ *  - a pure anchor (#heading),
+ *  - mapped to a known SPA route via MARKDOWN_ROUTE_MAP in MarkdownPage.tsx,
+ *  - or matching a declared route in src/app/routes.ts.
+ *
+ * Prevents silent 404s when markdown is clicked on production (e.g. STORY.md
+ * resolved relative to /changelog → /STORY.md → NotFound catch-all).
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const ROOT = resolve(__dirname, '../../');
+
+// Kept in sync with MARKDOWN_ROUTE_MAP (src/app/components/MarkdownPage.tsx)
+// and the router table (src/app/routes.ts).
+const MAPPED_MD_FILES = new Set(['STORY.md', 'CHANGELOG.md']);
+const DECLARED_ROUTES = [
+  '/',
+  '/privacy',
+  '/changelog',
+  '/story',
+  '/auth/callback',
+  '/app',
+  '/app/reference',
+  // dynamic: /app/learn/:moduleId/:lessonId — handled by startsWith below
+  '/app/learn/',
+  // legacy redirects still valid:
+  '/learn/',
+  '/reference',
+];
+
+type MarkdownLink = { file: string; href: string; line: number };
+
+function extractLinks(filePath: string): MarkdownLink[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const pattern = /\[[^\]]+\]\(([^)\s]+)\)/g;
+  const out: MarkdownLink[] = [];
+  content.split('\n').forEach((line, idx) => {
+    for (const match of line.matchAll(pattern)) {
+      out.push({ file: filePath, href: match[1], line: idx + 1 });
+    }
+  });
+  return out;
+}
+
+function isAcceptable(href: string): boolean {
+  if (/^https?:\/\//.test(href)) return true;
+  if (href.startsWith('mailto:')) return true;
+  if (href.startsWith('#')) return true;
+  if (MAPPED_MD_FILES.has(href)) return true;
+  if (DECLARED_ROUTES.some((r) => href === r || (r.endsWith('/') && href.startsWith(r)))) return true;
+  return false;
+}
+
+describe('Narrative markdown internal links', () => {
+  const NARRATIVE_FILES = [
+    resolve(ROOT, 'CHANGELOG.md'),
+    resolve(ROOT, 'STORY.md'),
+  ];
+
+  for (const file of NARRATIVE_FILES) {
+    it(`${file.split(/[\\/]/).pop()}: every link resolves to a known target`, () => {
+      const links = extractLinks(file);
+      const broken = links.filter((l) => !isAcceptable(l.href));
+      if (broken.length > 0) {
+        const details = broken
+          .map((l) => `  line ${l.line}: ${l.href}`)
+          .join('\n');
+        throw new Error(
+          `Unresolvable internal links in ${file.split(/[\\/]/).pop()}:\n${details}\n\n` +
+            'Fix: point to an SPA route (/story, /changelog…), an external URL, ' +
+            'or add the target to MARKDOWN_ROUTE_MAP in MarkdownPage.tsx.'
+        );
+      }
+      expect(broken).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Lien `[Notre histoire](STORY.md)` dans `CHANGELOG.md:4` cassait en prod : résolu relativement à `/changelog` → `/STORY.md` → 404 catch-all. Bug préexistant sur `main`, découvert lors de la review visuelle de PR #144.

## Changes

- **`src/app/components/MarkdownPage.tsx`** — `MARKDOWN_ROUTE_MAP` (`STORY.md` → `/story`, `CHANGELOG.md` → `/changelog`). Le composant `a` custom bascule sur react-router `<Link>` quand le href matche le mapping → navigation SPA, zero reload.
- **`src/test/markdownLinks.test.ts`** — **CI guard** : scanne `CHANGELOG.md` + `STORY.md`, extrait chaque `[...](href)`, et fail si href n'est ni externe (`http`, `mailto:`), ni une ancre, ni un `.md` mappé, ni une route déclarée dans `src/app/routes.ts`. **Bloque toute future régression.**
- **`.claude/agents/content-auditor.md`** — nouvelle section 8 : l'agent cross-check désormais les liens narratifs markdown contre `routes.ts` + `MARKDOWN_ROUTE_MAP`. Lancé on-demand ou avant releases majeures.

## Test plan

- [x] `npm test src/test/markdownLinks.test.ts` — 2 tests verts (CHANGELOG + STORY)
- [x] Suite complète : 903 tests passent (16 files, +2 nouveaux), 0 régression
- [x] `type-check` OK
- [x] `lint` OK
- [ ] Preview Vercel : cliquer `[Notre histoire]` dans `/changelog` → doit naviguer vers `/story` (pas de reload, pas de 404)
- [ ] Preview Vercel : cliquer les liens internes de `/story` (s'il y en a) → OK
- [ ] Preview Vercel : les liens externes (http) gardent `target="_blank"` + `rel="noopener"`

## Defense in depth

Deux couches de protection contre ce bug :
1. **CI test** (automatique, blocking) — `markdownLinks.test.ts` attrape tout nouveau lien mort ajouté dans CHANGELOG/STORY
2. **Agent content-auditor** (manuel, avant releases) — rapport structuré avec CRITICAL/WARNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Met à jour le rendu Markdown et l’audit de contenu pour garantir que les liens internes dans la documentation narrative pointent vers des routes SPA valides et éviter les erreurs 404 de liens Markdown en production.

Nouvelles fonctionnalités :
- Faire correspondre les fichiers Markdown narratifs à la racine du dépôt à leurs routes SPA correspondantes afin que les liens internes en `.md` naviguent au sein de l’application monopage au lieu de recharger la page ou de conduire à une erreur 404.
- Ajouter un test CI qui valide que tous les liens dans `CHANGELOG.md` et `STORY.md` pointent vers des URLs externes connues, des ancres, des fichiers Markdown mappés ou des routes déclarées.
- Étendre l’agent de content-audit pour analyser les fichiers Markdown narratifs et recouper leurs liens internes avec la table des routes et le mapping des routes Markdown.

Documentation :
- Documenter les fichiers Markdown narratifs, le mapping des routes et la validation des liens internes dans la spécification de l’agent de content-audit.

Tests :
- Introduire des tests de validation des liens Markdown sur `CHANGELOG.md` et `STORY.md` qui font échouer la CI lorsque des liens internes des documents narratifs ne sont pas résolvables.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update markdown rendering and content auditing to ensure internal links in narrative docs resolve to valid SPA routes and prevent markdown link 404s in production.

New Features:
- Map repo-root narrative markdown files to their corresponding SPA routes so internal .md links navigate within the single-page app instead of reloading or 404ing.
- Add a CI test that validates all links in CHANGELOG.md and STORY.md resolve to known external URLs, anchors, mapped markdown files, or declared routes.
- Extend the content-auditor agent to analyze narrative markdown files and cross-check their internal links against the route table and markdown route mapping.

Documentation:
- Document narrative markdown files, route mapping, and internal link validation in the content-auditor agent spec.

Tests:
- Introduce markdown link validation tests over CHANGELOG.md and STORY.md that fail CI on unresolvable internal links in narrative docs.

</details>