### PR TITLE
refactor(ui): consolidate button with Sidebar wrappers (THI-105)

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -10,6 +10,9 @@ import { useProgress } from '../context/ProgressContext';
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import { iconMap } from '../data/moduleIcons';
 import { Button } from './ui/button';
+import { SidebarRowButton } from './ui/sidebar-row-button';
+import { SidebarLessonButton } from './ui/sidebar-lesson-button';
+import { EnvPill } from './ui/env-pill';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -65,9 +68,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Button
             type="button"
             variant="tl-sidebar-icon"
-            size="tl-icon-44"
+            size="icon-lg"
             onClick={onClose}
-            className="lg:hidden -mr-2"
+            className="lg:hidden -mr-2 rounded-lg"
             aria-label="Fermer le menu"
           >
             <X size={18} aria-hidden="true" />
@@ -134,10 +137,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             return (
               <div key={mod.id}>
                 {/* Module header */}
-                <Button
+                <SidebarRowButton
                   type="button"
-                  variant={locked ? 'tl-sidebar-row-locked' : 'tl-sidebar-row'}
-                  size="tl-sidebar-row"
+                  locked={locked}
                   onClick={locked ? undefined : () => toggleModule(mod.id)}
                   disabled={locked}
                   aria-label={locked
@@ -164,7 +166,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       )}
                     </>
                   )}
-                </Button>
+                </SidebarRowButton>
 
                 {/* Locked hint */}
                 {locked && (
@@ -179,11 +181,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     {mod.lessons.map((lesson) => {
                       const done = isLessonCompleted(mod.id, lesson.id);
                       return (
-                        <Button
+                        <SidebarLessonButton
                           key={lesson.id}
                           type="button"
-                          variant="tl-sidebar-lesson"
-                          size="tl-sidebar-lesson"
                           onClick={() => handleLessonClick(mod.id, lesson.id)}
                         >
                           {done ? (
@@ -192,7 +192,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                             <Circle size={12} className="size-[12px] text-[#30363d] shrink-0 group-hover:text-[#8b949e]" />
                           )}
                           <span className="truncate">{lesson.title}</span>
-                        </Button>
+                        </SidebarLessonButton>
                       );
                     })}
                   </div>
@@ -214,15 +214,13 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 const meta = ENV_META[envId];
                 const active = selectedEnv === envId;
                 return (
-                  <Button
+                  <EnvPill
                     key={envId}
                     type="button"
-                    variant="tl-env-pill"
-                    size="tl-env-pill"
+                    active={active}
+                    activeClassName={`${meta.bgColor} ${meta.color} border ${meta.borderColor}`}
                     onClick={() => setEnvironment(envId)}
-                    className={active ? `${meta.bgColor} ${meta.color} border ${meta.borderColor}` : undefined}
                     title={`${meta.label} — ${meta.shell}`}
-                    aria-pressed={active}
                   >
                     {envId === 'linux' ? (
                       <Terminal size={10} className="size-[10px]" aria-hidden="true" />
@@ -232,7 +230,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       <span className="text-[9px] leading-none select-none" aria-hidden="true">⊞</span>
                     )}
                     {meta.label}
-                  </Button>
+                  </EnvPill>
                 );
               })}
             </div>
@@ -248,8 +246,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               <Button
                 asChild
                 variant="tl-sidebar-icon"
-                size="tl-icon-44-md"
-                className="hover:bg-[#21262d]"
+                size="icon-lg"
+                className="hover:bg-[#21262d] rounded-md"
               >
                 <NavLink
                   to="/"
@@ -273,9 +271,9 @@ export function MenuButton({ onClick }: { onClick: () => void }) {
     <Button
       type="button"
       variant="tl-menu-fab"
-      size="tl-icon-44"
+      size="icon-lg"
       onClick={onClick}
-      className="lg:hidden shrink-0"
+      className="lg:hidden shrink-0 rounded-lg"
       aria-label="Ouvrir le menu de navigation"
     >
       <Menu size={18} className="size-[18px]" aria-hidden="true" />

--- a/src/app/components/auth/LoginModal.tsx
+++ b/src/app/components/auth/LoginModal.tsx
@@ -99,10 +99,10 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
           <Button
             type="button"
             variant="tl-icon-ghost"
-            size="tl-icon-44"
+            size="icon-lg"
             onClick={handleClose}
             aria-label="Fermer"
-            className="-mr-2 text-xl leading-none"
+            className="-mr-2 text-xl leading-none rounded-lg"
           >
             ×
           </Button>

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -97,10 +97,8 @@ const buttonVariants = cva(
         "tl-tab-size": "h-auto flex-1 py-2.5 text-xs",
         // Terminal Learning — CommandReference filter pill
         "tl-filter-pill-size": "h-auto min-h-11 px-3 py-1.5 text-xs rounded-full",
-        // Terminal Learning — 44x44 icon button (sidebar close, install, menu FAB)
-        "tl-icon-44": "size-11 rounded-lg",
-        // Terminal Learning — 44x44 icon button (rounded-md variant for install button in UserMenu)
-        "tl-icon-44-md": "size-11 rounded-md",
+        // Terminal Learning — 44x44 icon button, neutral on rounded — apply rounded-lg/md via className
+        "icon-lg": "size-11",
         // Terminal Learning — Sidebar module row
         "tl-sidebar-row": "h-auto min-h-11 px-3 py-2 text-sm rounded-lg",
         // Terminal Learning — Sidebar lesson subitem

--- a/src/app/components/ui/env-pill.tsx
+++ b/src/app/components/ui/env-pill.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Button } from './button';
+import { cn } from './utils';
+
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+interface EnvPillProps extends Omit<ButtonProps, 'variant' | 'size'> {
+  active?: boolean;
+  activeClassName?: string;
+}
+
+export function EnvPill({
+  active = false,
+  activeClassName,
+  className,
+  ...props
+}: EnvPillProps) {
+  return (
+    <Button
+      variant="tl-env-pill"
+      size="tl-env-pill"
+      aria-pressed={active}
+      className={cn(active && activeClassName, className)}
+      {...props}
+    />
+  );
+}

--- a/src/app/components/ui/sidebar-lesson-button.tsx
+++ b/src/app/components/ui/sidebar-lesson-button.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { Button } from './button';
+
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+type SidebarLessonButtonProps = Omit<ButtonProps, 'variant' | 'size'>;
+
+export function SidebarLessonButton(props: SidebarLessonButtonProps) {
+  return <Button variant="tl-sidebar-lesson" size="tl-sidebar-lesson" {...props} />;
+}

--- a/src/app/components/ui/sidebar-row-button.tsx
+++ b/src/app/components/ui/sidebar-row-button.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Button } from './button';
+
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+interface SidebarRowButtonProps extends Omit<ButtonProps, 'variant' | 'size'> {
+  locked?: boolean;
+}
+
+export function SidebarRowButton({
+  locked = false,
+  ...props
+}: SidebarRowButtonProps) {
+  return (
+    <Button
+      variant={locked ? 'tl-sidebar-row-locked' : 'tl-sidebar-row'}
+      size="tl-sidebar-row"
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Consolide `button.tsx` avec 3 wrappers expressifs + 1 size neutre sur le rounded, suivant les suggestions Sourcery sur [PR #139](https://github.com/thierryvm/TerminalLearning/pull/139#discussion_r3103149501) post-migration shadcn THI-91.

- **3 nouveaux wrappers Sidebar** : `SidebarRowButton({ locked })`, `SidebarLessonButton`, `EnvPill({ active, activeClassName })`
- **Icon size consolidé** : `icon-lg` (size-11 neutre) remplace `tl-icon-44` (rounded-lg) et `tl-icon-44-md` (rounded-md) — le rounded passe par className au call-site
- **Encapsulation stricte** : les variants `tl-sidebar-*` / `tl-env-*` ne sont plus référencés qu'à l'intérieur des wrappers
- **EnvPill** : expose `active` et `activeClassName` proprement — plus de className ternaire au call-site + `aria-pressed` intégré

## Scope

- `src/app/components/ui/button.tsx` — ajoute `icon-lg`, retire `tl-icon-44` + `tl-icon-44-md`
- `src/app/components/ui/sidebar-row-button.tsx` — nouveau wrapper
- `src/app/components/ui/sidebar-lesson-button.tsx` — nouveau wrapper
- `src/app/components/ui/env-pill.tsx` — nouveau wrapper
- `src/app/components/Sidebar.tsx` — utilise les 3 wrappers + 3× `icon-lg` (close X, Home asChild, MenuButton)
- `src/app/components/auth/LoginModal.tsx` — X close → `icon-lg` + `rounded-lg`

## Hors scope délibéré

- Nettoyage interne des variants `tl-*` (séparation layout/apparence) — les wrappers masquent déjà la complexité au call-site, second chantier non-sollicité
- LessonPage, Dashboard, Landing, MarkdownPage — non ciblés par l'issue (aucun gain clair sans wrappers additionnels)

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 903 tests pass, 0 fail
- [x] `npm run build` — Landing 94.68kB / 26.68kB gzip (stable)
- [x] Desktop Chrome 1280×720 — Sidebar unlocked/locked/env switcher rendus OK, 0 console error
- [x] iPhone 14 emulation (390×844) — Sidebar mobile ouverte via MenuButton, X close rendu OK, EnvPill actif visible, Home asChild rendu OK
- [ ] Validation visuelle par Thierry sur preview Vercel (Chrome + mobile)

Closes THI-105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolider l’utilisation des boutons liés à la barre latérale autour de nouveaux wrappers expressifs et d’une taille d’icône neutre afin de simplifier les points d’appel et de centraliser le style.

Améliorations :
- Introduire les composants `SidebarRowButton` et `SidebarLessonButton` pour encapsuler les variantes de boutons de ligne et de leçon de la barre latérale.
- Introduire un composant `EnvPill` pour encapsuler le comportement des « pills » d’environnement, y compris le style d’état actif et la gestion de `aria-pressed`.
- Remplacer les tailles de bouton `tl-icon-44` et `tl-icon-44-md` par une taille unique `icon-lg` et déplacer le style arrondi vers les points d’appel.
- Mettre à jour `Sidebar` et `LoginModal` pour utiliser les nouveaux wrappers et la taille `icon-lg` afin d’assurer un style de boutons cohérent et centralisé.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate sidebar-related button usage around new expressive wrappers and a neutral icon size to simplify call sites and centralize styling.

Enhancements:
- Introduce SidebarRowButton and SidebarLessonButton components to encapsulate sidebar row and lesson button variants.
- Introduce an EnvPill component to encapsulate environment pill behavior, including active state styling and aria-pressed handling.
- Replace tl-icon-44 and tl-icon-44-md button sizes with a single icon-lg size and move rounded styling to call sites.
- Update Sidebar and LoginModal to use the new wrappers and icon-lg size for consistent, centralized button styling.

</details>