### PR TITLE
feat(curriculum): merge-strategies lesson — merge commit / squash / rebase (THI-108)

### DIFF
--- a/src/app/data/curriculum.ts
+++ b/src/app/data/curriculum.ts
@@ -8,7 +8,7 @@ import {
   validateEnvVars, validatePathVariable, validateShellConfig, validateDotenv, validateScripts, validateCron,
   validatePing, validateCurl, validateWget, validateDns, validateSsh, validateScp,
   validateGitInit, validateGitConfig, validateGitAddCommit, validateGitStatusLog, validateGitDiffGitignore, validateGitBranch, validateGitMerge,
-  validateGitRemote, validateGitPushPull, validateGitFetchClone, validatePullRequests, validateConflicts, validateGithubActions,
+  validateGitRemote, validateGitPushPull, validateGitFetchClone, validatePullRequests, validateMergeStrategies, validateConflicts, validateGithubActions,
   validateAiHelp, validateAiHelpCapabilities, validateAiHelpLimits, validateAiHelpPrompts,
   validateAiHelpContext, validateAiHelpValidate, validateAiHelpDebug, validateAiHelpSecurity,
   validateAiHelpClaudeCli, validateAiHelpCareers, validateAiHelpSenior, validateAiHelpWorkflow,
@@ -2522,6 +2522,52 @@ export const curriculum: Module[] = [
           hint: 'Tapez: git checkout -b feature/nouvelle-feature',
           validate: validatePullRequests,
           successMessage: 'Branche feature créée ! Dans un vrai projet, vous développeriez ici puis ouvreriez une PR vers main.',
+        },
+      },
+      {
+        id: 'merge-strategies',
+        title: 'Stratégies de merge — Merge commit, Squash, Rebase',
+        description: 'Choisissez la bonne stratégie de merge selon le contexte (feature, hotfix, historique propre)',
+        blocks: [
+          {
+            type: 'text',
+            content:
+              'Quand vous fermez une Pull Request, GitHub vous propose trois boutons : **Create a merge commit**, **Squash and merge**, **Rebase and merge**. Chacun produit un historique différent sur `main`. Ce choix n\'est pas cosmétique — il détermine la lisibilité du `git log`, la facilité à revenir en arrière, et la traçabilité des features.',
+          },
+          {
+            type: 'code',
+            content: '# Stratégie 1 : Merge commit (--no-ff)\n# Garde la branche comme un bloc identifiable dans l\'historique\n\n$ git checkout main\n$ git merge --no-ff feature/panier\nMerge made by the \'ort\' strategy.\n panier.html | 42 ++++++\n cart.js     | 18 +++++\n 2 files changed, 60 insertions(+)\n\n$ git log --oneline --graph\n*   d4f8a91 Merge branch \'feature/panier\'\n|\\\n| * b7e2d45 feat(panier): add cart UI\n| * a3f8c12 feat(panier): init cart model\n|/\n* c1d2e34 chore: bump version',
+            label: '1️⃣ Merge commit (--no-ff)',
+          },
+          {
+            type: 'code',
+            content: '# Stratégie 2 : Squash merge (--squash)\n# Condense toute la branche en UN SEUL commit sur main\n\n$ git checkout main\n$ git merge --squash feature/panier\n$ git commit -m "feat(panier): add cart module (#42)"\n\n$ git log --oneline\n* e5f6a78 feat(panier): add cart module (#42)\n* c1d2e34 chore: bump version\n\n# Équivalent via GitHub CLI :\n$ gh pr merge 42 --squash --delete-branch',
+            label: '2️⃣ Squash merge (--squash)',
+          },
+          {
+            type: 'code',
+            content: '# Stratégie 3 : Rebase merge (--rebase)\n# Rejoue les commits de la branche au sommet de main (historique linéaire, pas de merge commit)\n\n$ git checkout feature/panier\n$ git rebase main\n$ git checkout main\n$ git merge feature/panier  # fast-forward, linéaire\n\n$ git log --oneline\n* b7e2d45 feat(panier): add cart UI\n* a3f8c12 feat(panier): init cart model\n* c1d2e34 chore: bump version\n\n# Équivalent via GitHub CLI :\n$ gh pr merge 42 --rebase --delete-branch',
+            label: '3️⃣ Rebase merge (--rebase)',
+          },
+          {
+            type: 'info',
+            content:
+              '**Tableau de décision — quand choisir quoi ?**\n\n• **Merge commit (--no-ff)** → feature large, plusieurs commits qui racontent une histoire utile (refactor progressif, spike documenté). On garde la branche visible pour pouvoir la revisiter 6 mois plus tard.\n\n• **Squash (--squash)** → petit fix, feature courte, PR avec 12 commits "wip" / "oops typo" / "fix tests". Un seul commit propre sur main = `git log` lisible, `git bisect` fiable.\n\n• **Rebase (--rebase)** → équipe qui tient un historique strictement linéaire, pas de merge commits. Demande de la discipline (jamais rebaser une branche déjà partagée) et une bonne maîtrise des conflits.',
+          },
+          {
+            type: 'tip',
+            content: 'Dans les **Settings → General → Pull Requests** d\'un repo GitHub, on peut désactiver les stratégies qu\'on ne veut pas voir utilisées. La plupart des équipes pro activent **Squash only** pour la cohérence : un commit sur main = une PR = une feature identifiable.',
+          },
+          {
+            type: 'warning',
+            content: '**Règle absolue du rebase** : ne jamais rebaser une branche déjà poussée et partagée avec d\'autres développeurs. Rebaser réécrit l\'historique — si quelqu\'un a pullé votre branche, son repo local sera incohérent avec le remote après votre force-push.',
+          },
+        ],
+        exercise: {
+          instruction: 'Fusionnez la branche `feature/ma-feature` avec un **merge commit explicite** (option `--no-ff`) : `git merge --no-ff feature/ma-feature`.',
+          hint: 'Tapez: git merge --no-ff feature/ma-feature',
+          validate: validateMergeStrategies,
+          successMessage: 'Merge commit créé ! Votre branche reste identifiable dans l\'historique — utile pour retrouver le contexte d\'une feature 6 mois plus tard.',
         },
       },
       {

--- a/src/app/data/validators.ts
+++ b/src/app/data/validators.ts
@@ -258,7 +258,14 @@ export const validatePullRequests: ValidateFn = (cmd) => {
 
 export const validateConflicts: ValidateFn = (cmd) => /^git\s+merge\s+\S+/.test(cmd.trim().toLowerCase());
 
-export const validateMergeStrategies: ValidateFn = (cmd) => /^git\s+merge\s+--no-ff\s+\S+/.test(cmd.trim().toLowerCase());
+export const validateMergeStrategies: ValidateFn = (cmd) => {
+  const c = cmd.trim().toLowerCase();
+  if (!/^git\s+merge\b/.test(c)) return false;
+  const tokens = c.split(/\s+/).slice(2);
+  if (!tokens.includes('--no-ff')) return false;
+  if (tokens.some((t) => t === '--squash' || t === '--ff-only' || t === '--ff')) return false;
+  return tokens.some((t) => !t.startsWith('-'));
+};
 
 export const validateGithubActions: ValidateFn = (cmd) => /^git\s+status/.test(cmd.trim().toLowerCase());
 

--- a/src/app/data/validators.ts
+++ b/src/app/data/validators.ts
@@ -258,6 +258,8 @@ export const validatePullRequests: ValidateFn = (cmd) => {
 
 export const validateConflicts: ValidateFn = (cmd) => /^git\s+merge\s+\S+/.test(cmd.trim().toLowerCase());
 
+export const validateMergeStrategies: ValidateFn = (cmd) => /^git\s+merge\s+--no-ff\s+\S+/.test(cmd.trim().toLowerCase());
+
 export const validateGithubActions: ValidateFn = (cmd) => /^git\s+status/.test(cmd.trim().toLowerCase());
 
 // ── Module 11 — L'IA comme outil dev ─────────────────────────────────────────

--- a/src/test/curriculumTypes.test.ts
+++ b/src/test/curriculumTypes.test.ts
@@ -96,10 +96,10 @@ describe('curriculum types', () => {
       }
     });
 
-    it('total lessons should be 64', () => {
-      // 39 (Modules 1–8) + 7 (Module 9 Git) + 6 (Module 10 GitHub) + 12 (Module 11 IA) = 64
+    it('total lessons should be 65', () => {
+      // 39 (Modules 1–8) + 7 (Module 9 Git) + 7 (Module 10 GitHub, +merge-strategies) + 12 (Module 11 IA) = 65
       const total = curriculum.reduce((acc, mod) => acc + mod.lessons.length, 0);
-      expect(total).toBe(64);
+      expect(total).toBe(65);
     });
 
     it('module ids are unique (no duplicate modules)', () => {

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -1935,6 +1935,14 @@ describe('git', () => {
     expect(r.lines[0].type).toBe('error');
   });
 
+  it('git merge --no-ff <branch> skips the flag and creates a merge commit', () => {
+    const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main', 'feature/panier'], stagedFiles: [], commits: [], remotes: {} } });
+    const r = processCommand(s, 'git merge --no-ff feature/panier');
+    expect(r.lines[0].type).toBe('success');
+    expect(r.newState.git?.commits).toHaveLength(1);
+    expect(r.newState.git?.commits[0].message).toContain('feature/panier');
+  });
+
   // ── git remote ────────────────────────────────────────────────────────────────
   it('git remote -v shows configured remotes', () => {
     const s = makeState({ git: { initialized: true, branch: 'main', branches: ['main'], stagedFiles: [], commits: [], remotes: { origin: 'https://github.com/user/repo.git' } } });

--- a/src/test/validators.test.ts
+++ b/src/test/validators.test.ts
@@ -439,12 +439,24 @@ describe('validateMergeStrategies', () => {
     expect(validateMergeStrategies('git merge --no-ff feature/ma-feature')).toBe(true));
   it('accepts "git merge --no-ff bugfix/123"', () =>
     expect(validateMergeStrategies('git merge --no-ff bugfix/123')).toBe(true));
+  it('accepts flag-after-branch "git merge feature/ma-feature --no-ff"', () =>
+    expect(validateMergeStrategies('git merge feature/ma-feature --no-ff')).toBe(true));
+  it('accepts "git merge --no-ff feature/ma-feature -m \"msg\""', () =>
+    expect(validateMergeStrategies('git merge --no-ff feature/ma-feature -m "msg"')).toBe(true));
+  it('accepts "git merge --no-ff --no-edit feature/x" (extra harmless flag)', () =>
+    expect(validateMergeStrategies('git merge --no-ff --no-edit feature/x')).toBe(true));
   it('rejects plain "git merge feature/ma-feature" (no --no-ff)', () =>
     expect(validateMergeStrategies('git merge feature/ma-feature')).toBe(false));
   it('rejects "git merge --squash feature/ma-feature"', () =>
     expect(validateMergeStrategies('git merge --squash feature/ma-feature')).toBe(false));
-  it('rejects bare "git merge --no-ff"', () =>
+  it('rejects "git merge --no-ff --squash feature/x" (conflicting strategies)', () =>
+    expect(validateMergeStrategies('git merge --no-ff --squash feature/x')).toBe(false));
+  it('rejects "git merge --no-ff --ff-only feature/x" (conflicting strategies)', () =>
+    expect(validateMergeStrategies('git merge --no-ff --ff-only feature/x')).toBe(false));
+  it('rejects bare "git merge --no-ff" (no branch arg)', () =>
     expect(validateMergeStrategies('git merge --no-ff')).toBe(false));
+  it('rejects "git mergeit --no-ff feature/x" (typo on subcommand)', () =>
+    expect(validateMergeStrategies('git mergeit --no-ff feature/x')).toBe(false));
 });
 
 describe('validateConflicts', () => {

--- a/src/test/validators.test.ts
+++ b/src/test/validators.test.ts
@@ -50,6 +50,7 @@ import {
   validateGitPushPull,
   validateGitFetchClone,
   validatePullRequests,
+  validateMergeStrategies,
   validateConflicts,
   validateGithubActions,
   validateAiHelp,
@@ -431,6 +432,19 @@ describe('validatePullRequests', () => {
   it('accepts "git checkout -b feature/my-pr"', () => expect(validatePullRequests('git checkout -b feature/my-pr')).toBe(true));
   it('accepts "git switch -c feature/my-pr"', () => expect(validatePullRequests('git switch -c feature/my-pr')).toBe(true));
   it('rejects "git checkout -b fix/bug"', () => expect(validatePullRequests('git checkout -b fix/bug')).toBe(false));
+});
+
+describe('validateMergeStrategies', () => {
+  it('accepts "git merge --no-ff feature/ma-feature"', () =>
+    expect(validateMergeStrategies('git merge --no-ff feature/ma-feature')).toBe(true));
+  it('accepts "git merge --no-ff bugfix/123"', () =>
+    expect(validateMergeStrategies('git merge --no-ff bugfix/123')).toBe(true));
+  it('rejects plain "git merge feature/ma-feature" (no --no-ff)', () =>
+    expect(validateMergeStrategies('git merge feature/ma-feature')).toBe(false));
+  it('rejects "git merge --squash feature/ma-feature"', () =>
+    expect(validateMergeStrategies('git merge --squash feature/ma-feature')).toBe(false));
+  it('rejects bare "git merge --no-ff"', () =>
+    expect(validateMergeStrategies('git merge --no-ff')).toBe(false));
 });
 
 describe('validateConflicts', () => {


### PR DESCRIPTION
## Summary
- Nouvelle leçon `merge-strategies` dans le module `github` (GitHub & Collaboration), insérée entre `pull-requests` et `conflicts`.
- 3 démos côte à côte (`--no-ff` / `--squash` / `--rebase`) + tableau de décision + tip settings GitHub + warning rebase de branche partagée.
- Exercice : `git merge --no-ff feature/ma-feature` (seule stratégie simulable dans notre sandbox — le reste toucherait la couche PR non émulée).
- Validator `validateMergeStrategies` avec 5 unit tests + 1 engine test vérifiant que le parser d'args ignore correctement `--no-ff`.
- Vitest 903 → 909 pass (+6 nouveaux tests + bump count 64 → 65).

Closes THI-108.

## Test plan
- [x] `npx vitest run` — 909 pass / 20 skip / 0 fail
- [x] `npm run type-check` — OK
- [x] `npm run lint` — OK
- [x] `npm run build` — OK (curriculum-DqdyjQYs.js : 138.80 kB gzip 41.34 kB, delta négligeable)
- [x] `curriculum-validator` agent — GO, no CRITICAL
- [ ] Validation visuelle Vercel preview (Chrome + mobile) par Thierry : leçon accessible depuis `/app`, prérequis `git` + `reseau` respectés, exercice validé sur `git merge --no-ff feature/ma-feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajoute une nouvelle leçon du cursus GitHub sur les stratégies de fusion et intègre sa validation et ses tests dans la plateforme de formation existante.

Nouvelles fonctionnalités :
- Introduire une leçon « merge-strategies » dans le module GitHub, couvrant les options de commit de fusion, squash et rebase, avec des explications et des conseils associés.
- Ajouter un exercice interactif nécessitant explicitement un commit de fusion `git merge --no-ff`, validé par un validateur dédié.

Améliorations :
- Étendre l’ensemble des validateurs de commandes et le moteur de terminal pour reconnaître `git merge --no-ff <branch>` et le traiter comme un commit de fusion dans le bac à sable.
- Mettre à jour les tests de métadonnées du cursus pour prendre en compte la leçon GitHub supplémentaire et le nombre total de leçons.

Tests :
- Ajouter des tests unitaires pour le nouveau validateur de stratégies de fusion, ainsi qu’un test du moteur de terminal garantissant que `--no-ff` est correctement analysé et ignoré par le moteur pour le comportement de fusion.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new GitHub curriculum lesson on merge strategies and wire its validation and tests into the existing training platform.

New Features:
- Introduce a 'merge-strategies' lesson in the GitHub module covering merge commit, squash, and rebase options with accompanying explanations and tips.
- Add an interactive exercise requiring an explicit `git merge --no-ff` merge commit, validated by a dedicated validator.

Enhancements:
- Extend the command validator set and terminal engine to recognize `git merge --no-ff <branch>` and treat it as a merge commit in the sandbox.
- Update curriculum metadata tests to account for the additional GitHub lesson and total lesson count.

Tests:
- Add unit tests for the new merge strategies validator and a terminal engine test ensuring `--no-ff` is correctly parsed and ignored by the engine for merge behavior.

</details>