### PR TITLE
chore(agents): deepen curriculum-validator + test-runner checks

### DIFF
--- a/.claude/agents/curriculum-validator.md
+++ b/.claude/agents/curriculum-validator.md
@@ -1,22 +1,41 @@
 ---
 name: curriculum-validator
-description: Validate curriculum.ts structure before any modification — checks env coverage (Linux/macOS/Windows), duplicate lesson IDs, missing tests in terminalEngine.test.ts, and module completeness. Auto-invoked before adding or modifying lessons or modules.
+description: Validate curriculum.ts structure before any modification — checks env coverage (Linux/macOS/Windows), duplicate lesson IDs, prerequisites chain integrity, validator import/export sync, orphan validators, missing tests in terminalEngine.test.ts, and module completeness. Auto-invoked before adding or modifying lessons or modules.
 tools: Read, Grep, Glob
 model: haiku
 ---
 
 Tu es un validateur de curriculum pédagogique pour Terminal Learning.
 
-Analyse `src/app/data/curriculum.ts` et `src/test/terminalEngine.test.ts`, puis produis un rapport structuré.
+Analyse `src/app/data/curriculum.ts`, `src/app/data/validators.ts`, `src/test/terminalEngine.test.ts` et `src/test/validators.test.ts`, puis produis un rapport structuré.
 
 ## Vérifications à effectuer
 
-1. **Couverture environnement** : chaque leçon couvre-t-elle `linux`, `macos`, `windows` dans ses exemples ou commandes ? Note : certaines leçons peuvent légitimement être mono-OS (ex: commandes Windows-only comme `taskkill`). Dans ce cas, signaler en WARNING et non CRITICAL.
-2. **IDs uniques** : aucun `lessonId` ou `moduleId` dupliqué
-3. **Tests présents** : chaque commande référencée dans curriculum.ts a-t-elle un test dans terminalEngine.test.ts ?
-4. **Completeness** : modules sans leçons, leçons sans exercices, exercices sans solution attendue
-5. **SuccessMessage count** : le nombre de `successMessage` doit correspondre au nombre de leçons. WARNING si différent.
-6. **ExerciseTypes (Phase 5b — futur)** : si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement : `fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`. Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.
+### Structurelles (CRITICAL si échec)
+
+1. **Chaîne de prérequis** : pour chaque `module.prerequisites: string[]`, vérifier que chaque ID référencé existe dans `curriculum` (autre module). Un prérequis pointant vers un module inexistant = CRITICAL. Un module qui se liste lui-même comme prérequis = CRITICAL.
+2. **Import/export sync des validators** : toute fonction `validate*` référencée dans `curriculum.ts` (via `validate: validateX`) doit être importée depuis `./validators` ET exportée dans `validators.ts`. Toute référence cassée = CRITICAL.
+3. **IDs uniques** : aucun `lessonId` ou `moduleId` dupliqué (global, pas seulement au sein du module) = CRITICAL si duplicate.
+
+### Qualitatives (WARNING)
+
+4. **Orphan validators** : fonction `validate*` exportée dans `validators.ts` mais jamais référencée dans `curriculum.ts` → WARNING (dead code).
+5. **Couverture environnement** : chaque leçon couvre-t-elle `linux`, `macos`, `windows` dans ses exemples ou commandes ? Note : certaines leçons peuvent légitimement être mono-OS (ex: commandes Windows-only comme `taskkill`). Dans ce cas, signaler en WARNING et non CRITICAL.
+6. **Tests présents** : chaque commande référencée dans curriculum.ts a-t-elle un test dans `terminalEngine.test.ts` ? chaque validator a-t-il des tests dans `validators.test.ts` ? → WARNING si absent.
+7. **Cohérence level module ↔ leçons** : une leçon avec un `level` drastiquement supérieur au `module.level` = WARNING pédagogique.
+8. **Leçons sans bloc `code`** : une leçon qui ne contient que des blocs `text` / `info` / `tip` sans bloc `code` exécutable = WARNING (expérience d'apprentissage dégradée).
+9. **SuccessMessage count** : le nombre de `successMessage` doit correspondre au nombre de leçons. WARNING si différent.
+10. **Completeness** : modules sans leçons, leçons sans exercices, exercices sans `validate` fn = WARNING.
+
+### Reserved (futures extensions — ignorer si absent)
+
+11. **ExerciseTypes (Phase 5b)** : si un champ `type` existe sur les exercices, vérifier qu'il utilise uniquement : `fill-flag`, `objective`, `error-fix`, `pipeline`, `scenario`, `quiz-mcq`, `quiz-recall`. Si le champ n'existe pas encore dans l'interface TypeScript, ignorer cette vérification.
+
+## Méthodes de détection
+
+- **Prérequis chain** : extraire tous les `id:` de modules, puis pour chaque `prerequisites: [...]` vérifier que chaque entrée est dans ce Set.
+- **Import/export sync** : `grep -E "validate:\s*validate\w+" curriculum.ts` → liste des validators référencés ; `grep -E "^export const validate\w+" validators.ts` → liste des validators exportés ; `grep -E "^\s*validate\w+," curriculum.ts` (dans le bloc import du haut) → liste des validators importés. Recouper les 3 ensembles.
+- **Orphan validators** : `exported \ (referenced ∩ imported)`.
 
 ## Format de rapport obligatoire
 
@@ -24,16 +43,22 @@ Analyse `src/app/data/curriculum.ts` et `src/test/terminalEngine.test.ts`, puis 
 CURRICULUM VALIDATION REPORT
 =============================
 Modules : N  |  Leçons : N  |  Exercices : N
+Validators : N exported  |  N imported  |  N referenced
 
 CRITICAL (bloquants pour merge) :
-  ❌ Lesson "X" (module Y) — missing windows example
+  ❌ Lesson "X" (module Y) — prerequisite 'Z' not found in curriculum
+  ❌ Validator 'validateX' referenced in lesson Y but not imported in curriculum.ts
   ❌ Duplicate lessonId "Z"
 
 WARNINGS (à corriger prochain sprint) :
+  ⚠️  Orphan validator 'validateDeprecated' — exported but never referenced
   ⚠️  Command "X" in lesson Y — no test in terminalEngine.test.ts
-  ⚠️  Lesson "Z" — no exercises defined
+  ⚠️  Lesson "Z" — no code block (only text/info/tip)
+  ⚠️  Lesson "W" level 5 in module level 2 — level drift
 
 OK :
+  ✅ Prerequisites chain : all refs resolved
+  ✅ Validators : N exported, N imported, 0 orphans
   ✅ Env coverage : N/N leçons complètes
   ✅ IDs : tous uniques
 ```

--- a/.claude/agents/curriculum-validator.md
+++ b/.claude/agents/curriculum-validator.md
@@ -33,7 +33,7 @@ Analyse `src/app/data/curriculum.ts`, `src/app/data/validators.ts`, `src/test/te
 
 ## Méthodes de détection
 
-- **Prérequis chain** : extraire tous les `id:` de modules, puis pour chaque `prerequisites: [...]` vérifier que chaque entrée est dans ce Set.
+- **Chaîne de prérequis** : extraire tous les `id:` des modules, puis pour chaque `prerequisites: [...]` vérifier que chaque entrée est dans ce Set.
 - **Import/export sync** : `grep -E "validate:\s*validate\w+" curriculum.ts` → liste des validators référencés ; `grep -E "^export const validate\w+" validators.ts` → liste des validators exportés ; `grep -E "^\s*validate\w+," curriculum.ts` (dans le bloc import du haut) → liste des validators importés. Recouper les 3 ensembles.
 - **Orphan validators** : `exported \ (referenced ∩ imported)`.
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -66,10 +66,16 @@ Extrait uniquement :
 Détecter les `.only(` et `.skip(` **commités** dans les fichiers de tests — ils font passer la CI avec un sous-ensemble silencieusement.
 
 ```bash
-grep -rnE "\.(only|skip)\(" src/test/ e2e/ 2>/dev/null
+# Match only test runner calls (it/describe/test/suite), then filter out comment lines
+grep -rnE "\b(it|describe|test|suite)\.(only|skip)\(" src/test/ e2e/ 2>/dev/null \
+  | grep -vE ":\s*(//|/\*|\*\s|\*$)"
 ```
 
-Toute occurrence = CRITICAL (hors commentaires). Rapport : `file:line — .only/.skip leaked, test suite biased`.
+Filtres :
+- Pattern précis `(it|describe|test|suite)\.(only|skip)\(` → évite les faux positifs sur des strings comme `"using .only("` ou des références hors test (`Object.skip`).
+- Post-filter `grep -v` exclut les lignes dont le contenu commence par un commentaire JS (`//`, `/*`, ` *`).
+
+Toute occurrence restante = CRITICAL. Rapport : `file:line — .only/.skip leaked, test suite biased`.
 
 ## Étape 5 — Couverture commandes (WARNING)
 
@@ -87,11 +93,15 @@ Comparer avec les `describe('validateX'` dans `validators.test.ts`.
 
 ## Étape 7 — Delta code/tests (WARNING)
 
-Comparer le volume de code applicatif modifié vs le volume de tests ajoutés sur la branche actuelle (depuis `main`).
+Comparer le volume de code applicatif modifié vs le volume de tests ajoutés sur la branche actuelle (depuis le tronc).
 
 ```bash
-git diff --stat main...HEAD -- 'src/app/**/*.ts' 'src/app/**/*.tsx' ':!src/app/**/*.test.ts'
-git diff --stat main...HEAD -- 'src/test/**/*.ts' 'e2e/**/*.ts'
+# Use origin/main as base (refresh first) so branches not rebased on local main are still correctly compared.
+# Override with BASE_BRANCH env var if your trunk is different (e.g. BASE_BRANCH=origin/develop).
+git fetch origin --quiet
+BASE="${BASE_BRANCH:-origin/main}"
+git diff --stat "$BASE"...HEAD -- 'src/app/**/*.ts' 'src/app/**/*.tsx' ':!src/app/**/*.test.ts'
+git diff --stat "$BASE"...HEAD -- 'src/test/**/*.ts' 'e2e/**/*.ts'
 ```
 
 - Si > 50 lignes de code applicatif ajoutées **et** 0 ligne de test ajoutée → WARNING "code added without tests".

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,18 +1,18 @@
 ---
 name: test-runner
-description: Run the vitest test suite and return only failures and missing coverage. Invoke after any modification to curriculum.ts, terminalEngine.ts, or test files. Filters verbose output — only surfaces failures and gaps.
+description: Run vitest + type-check + lint, detect leaked .only/.skip isolation, flag code-vs-test delta imbalance, and surface missing coverage (commands & validators). Invoke after any modification to curriculum.ts, terminalEngine.ts, validators.ts, or test files. Filters verbose output — only surfaces failures and gaps.
 tools: Bash, Read, Grep
 model: haiku
 ---
 
-Tu es un analyseur de résultats de tests pour Terminal Learning.
+Tu es un analyseur de résultats de tests + qualité statique pour Terminal Learning.
 
 ## Scope — working copy vs branche distante
 
 **Par défaut** : tester le working copy de la branche actuelle.
 
 **Si le prompt invoquant contient `branches: <branch1>,<branch2>,...`** :
-pour chaque branche, créer un worktree **hors du projet** (dans `$TMPDIR` ou `${TEMP:-/tmp}`), installer les deps, lancer vitest. Préfixer chaque section du rapport par `[branch: <name>]`.
+pour chaque branche, créer un worktree **hors du projet** (dans `$TMPDIR` ou `${TEMP:-/tmp}`), installer les deps, lancer la pipeline complète. Préfixer chaque section du rapport par `[branch: <name>]`.
 
 ```bash
 TMPBASE="${TMPDIR:-${TEMP:-/tmp}}"
@@ -22,7 +22,7 @@ trap cleanup EXIT
 for BR in <branches>; do
   WT="$TMPBASE/test-${BR//\//_}"
   git worktree add -f "$WT" "origin/$BR" >/dev/null 2>&1 || continue
-  (cd "$WT" && npm ci --silent && npx vitest run 2>&1)
+  (cd "$WT" && npm ci --silent && npm run type-check && npm run lint && npx vitest run 2>&1)
   git worktree remove --force "$WT"
 done
 ```
@@ -33,15 +33,27 @@ done
 
 Si aucune branche n'est listée → test du working copy uniquement.
 
-## Étape 1 — Lancer les tests
+## Étape 1 — Type-check (CRITICAL)
 
-Depuis la racine du projet (détectée automatiquement via `git rev-parse --show-toplevel`) :
+```bash
+cd "$(git rev-parse --show-toplevel)" && npm run type-check 2>&1
+```
+
+Tout fichier avec erreur TS = CRITICAL. Extraire : `file:line: error TSxxxx: message`.
+
+## Étape 2 — Lint (CRITICAL)
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && npm run lint 2>&1
+```
+
+Toute erreur eslint (pas warning) = CRITICAL. Les warnings remontent en WARNING section.
+
+## Étape 3 — Tests unitaires (CRITICAL si fail)
 
 ```bash
 cd "$(git rev-parse --show-toplevel)" && npx vitest run 2>&1
 ```
-
-## Étape 2 — Filtrer les résultats
 
 Extrait uniquement :
 - Nombre total : pass / fail / skip
@@ -49,35 +61,67 @@ Extrait uniquement :
 - Tests skippés si > 5
 - Si 0 failures : confirme "✅ All N tests pass"
 
-## Étape 3 — Vérifier la couverture commandes
+## Étape 4 — Leaked isolation (CRITICAL)
+
+Détecter les `.only(` et `.skip(` **commités** dans les fichiers de tests — ils font passer la CI avec un sous-ensemble silencieusement.
+
+```bash
+grep -rnE "\.(only|skip)\(" src/test/ e2e/ 2>/dev/null
+```
+
+Toute occurrence = CRITICAL (hors commentaires). Rapport : `file:line — .only/.skip leaked, test suite biased`.
+
+## Étape 5 — Couverture commandes (WARNING)
 
 Identifie les commandes présentes dans `src/app/data/curriculum.ts` qui n'ont aucun test correspondant dans `src/test/terminalEngine.test.ts`. Compare par nom de commande (ex: `ping`, `curl`, `ssh`).
 
-## Étape 4 — Vérifier la couverture validators
+## Étape 6 — Couverture validators (WARNING)
 
-Identifie les fonctions `validate*` exportées dans `src/app/data/validators.ts` qui n'ont aucun test correspondant dans `src/test/validators.test.ts`. Lister les fonctions manquantes.
+Identifie les fonctions `validate*` exportées dans `src/app/data/validators.ts` qui n'ont aucun test correspondant dans `src/test/validators.test.ts`.
 
 ```bash
 grep "^export const validate" src/app/data/validators.ts | sed 's/export const //' | sed 's/:.*//'
 ```
 
-Comparer avec les describe/it dans validators.test.ts.
+Comparer avec les `describe('validateX'` dans `validators.test.ts`.
+
+## Étape 7 — Delta code/tests (WARNING)
+
+Comparer le volume de code applicatif modifié vs le volume de tests ajoutés sur la branche actuelle (depuis `main`).
+
+```bash
+git diff --stat main...HEAD -- 'src/app/**/*.ts' 'src/app/**/*.tsx' ':!src/app/**/*.test.ts'
+git diff --stat main...HEAD -- 'src/test/**/*.ts' 'e2e/**/*.ts'
+```
+
+- Si > 50 lignes de code applicatif ajoutées **et** 0 ligne de test ajoutée → WARNING "code added without tests".
+- Si ratio tests/code < 0.2 sur un diff > 100 lignes → WARNING "low test-to-code ratio".
+- Ignorer les diffs purement de renommage / déplacement (détecter via `git diff --stat -M`).
 
 ## Format de rapport obligatoire
 
 ```
-TEST REPORT
-===========
-Results : N pass / N fail / N skip
+TEST & QUALITY REPORT
+=====================
+Type-check : ✅ clean | ❌ N errors
+Lint       : ✅ clean | ❌ N errors | ⚠️  N warnings
+Vitest     : N pass / N fail / N skip
+Isolation  : ✅ no .only/.skip leaked | ❌ N leaks
+Delta      : +N code lines / +N test lines (ratio N.NN)
 
-FAILURES :
-  ❌ [nom du test] : [message d'erreur court]
+CRITICAL (bloquants pour merge) :
+  ❌ type-check: src/foo.ts:42 error TS2345: Argument of type 'X' not assignable
+  ❌ lint: src/bar.ts:12 no-unused-vars
+  ❌ vitest: "should parse CSV" — expected 3, got 2
+  ❌ isolation: src/test/validators.test.ts:88 — .only leaked
 
-MISSING TESTS (commandes sans test) :
-  ⚠️  "ping" — présent dans curriculum, absent dans terminalEngine.test.ts
-  ⚠️  "ssh" — idem
+WARNINGS (à corriger prochain sprint) :
+  ⚠️  lint warning: src/baz.tsx:5 react-hooks/exhaustive-deps
+  ⚠️  Command "ssh" — présent dans curriculum, absent dans terminalEngine.test.ts
+  ⚠️  Validator 'validateFoo' — exporté mais jamais testé
+  ⚠️  Delta: +180 lines code / +12 lines test (ratio 0.07) — low test-to-code ratio
 
 VERDICT : ✅ Merge OK | ❌ Fix required before merge
 ```
 
-Retourne UNIQUEMENT ce rapport. Pas les logs complets de vitest.
+Retourne UNIQUEMENT ce rapport. Pas les logs complets de vitest / tsc / eslint.


### PR DESCRIPTION
## Summary

Upgrades 2 local agents with structural depth checks — both stay on Haiku (pattern-matching only, no judgment calls).

### curriculum-validator
- **CRITICAL** prerequisites chain integrity (broken refs, self-reference)
- **CRITICAL** validator import/export sync (curriculum ↔ validators.ts)
- **WARNING** orphan validators (exported but never referenced)
- **WARNING** module↔lesson level coherence
- **WARNING** lessons without executable code block
- Added grep-based detection methods for each check

### test-runner
- **CRITICAL** `npm run type-check` integrated into pipeline
- **CRITICAL** `npm run lint` integrated into pipeline
- **CRITICAL** leaked `.only(` / `.skip(` detection (committed isolation bypass)
- **WARNING** delta code/tests ratio (flag +50 lines code / 0 test)
- Restructured report with CRITICAL/WARNINGS split

## Rationale

Earlier sessions hit gaps where the agents reported "all green" but:
- a validator was imported but never exported (hidden runtime crash)
- `.only` was left in a test file (CI passed with 1 test out of 900)
- code added without tests slipped through

These are all structural / greppable — no need to escalate to Sonnet.

## Test plan

- [ ] Run `curriculum-validator` against current `main` → expect clean report
- [ ] Run `test-runner` against current `main` → expect ✅ Merge OK
- [ ] Inject a fake `.only` in a test file → `test-runner` must flag CRITICAL
- [ ] Inject a fake `validateGhost` reference in curriculum.ts (not exported) → `curriculum-validator` must flag CRITICAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Renforcer les agents Claude internes pour la validation de curriculum et l’exécution des tests grâce à des vérifications structurelles plus poussées, une distinction plus claire entre rapports critiques et avertissements, et des garde-fous de qualité statique étendus.

Améliorations :
- Étendre l’agent test-runner pour exécuter la vérification de types et le linting en plus de Vitest, détecter les fuites de drapeaux d’isolation de tests, analyser les différences entre le code et les tests, et produire un rapport unifié TEST & QUALITY REPORT avec des sections CRITICAL et WARNING.
- Élargir l’agent curriculum-validator afin de faire respecter l’intégrité des chaînes de prérequis, la cohérence d’import/export des validateurs, détecter les validateurs orphelins, et ajouter plusieurs avertissements de qualité pédagogique et structurelle pour les leçons et les modules, avec un résumé enrichi dans son rapport.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen internal Claude agents for curriculum validation and test running with deeper structural checks, clearer critical vs warning reporting, and expanded static quality gates.

Enhancements:
- Extend the test-runner agent to run type-checking and linting alongside Vitest, detect leaked test isolation flags, assess code-versus-test diffs, and produce a unified TEST & QUALITY REPORT with CRITICAL and WARNING sections.
- Broaden the curriculum-validator agent to enforce prerequisite chain integrity, validator import/export consistency, detect orphan validators, and add several pedagogical and structural quality warnings for lessons and modules, with an expanded summary in its report.

</details>