### PR TITLE
docs: sync CLAUDE.md + next-session-plan.md post-THI-115

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pnpm-debug.log*
 # Local screenshots from preview testing (not for repo)
 .screenshots/
 .claude/screenshots/
+.claude-screenshots/
 
 # Supabase CLI temp files
 supabase/.temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,13 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - THI-87 ✅ Bundle optimization — motion/react retiré, 22 deps inutilisées supprimées, 8 composants shadcn dormants supprimés (PR #108, 13 avril 2026)
 - Phase 4c ✅ Bundle Optimization complète — Landing chunk ~65kB→~25kB gzip
 - THI-90 ✅ INP fix — `setEnvironment` wrappé dans `startTransition`, lab CPU 4× : 515ms → 26ms (−95%) sur env switcher (PR #114, 14 avril 2026)
-- THI-85 🔄 shadcn migration — NotFound.tsx ✅ (PR #116, 14 avril 2026, variantes `emerald`/`ghost-gh`/`pill-*`, pixel-perfect desktop + mobile) + Enhance 404 (PR #117, 14 avril 2026, bloc "Pages utiles" crawlable + fix contraste footer iPhone 14). Reste : Dashboard, LessonPage, Landing, ChangelogPage, StoryPage, CommandReference.
+- THI-85 ✅ shadcn migration — NotFound.tsx (PR #116, 14 avril 2026)
+- THI-91 ✅ shadcn migration umbrella — Dashboard, LessonPage, Landing A/B/C, ChangelogPage, StoryPage, CommandReference migrés (PRs #131/134/135/137/139/140/142, 15-17 avril 2026)
+- THI-105 ✅ button.tsx consolidation — Sidebar wrappers + `icon-lg` neutre (PR #147, 18 avril 2026)
+- THI-107 ✅ A11y focus-visible + 11 native `<button>` migrés (PRs #140/142, 17 avril 2026)
+- THI-96 🔄 Web 2026 compliance — 6/8 sub-issues shipped (THI-97 à 102), reste desktop a11y + CSS moderne 2026
+- THI-115 ✅ Doc alignment ADR-002 + ADR-005 (AI Tutor V1) — plan.md Phase 7b réécrit, 4 décisions figées (PR #151, 18 avril 2026)
+- **Phase 7b 🔄 AI Tutor V1 (chaîne ADR-005)** — THI-109 (prompt-guardrail-auditor agent) → THI-110 (key manager V1) → THI-111 (AiTutorPanel + providers + sanitizer) → THI-112 (onboarding AiKeySetup/AiConsentModal) → THI-113 (audit final) · THI-114 (Web Worker isolation V1.5 post-ship)
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative

--- a/docs/processes/next-session-plan.md
+++ b/docs/processes/next-session-plan.md
@@ -1,169 +1,97 @@
-# Next Session Plan — 17 avril 2026 (matin)
+# Next Session Plan — 18-19 avril 2026 (chaîne ADR-005 AI Tutor V1)
 
 > Fichier lu automatiquement par `session-kickoff.md` étape 5.
-> À supprimer ou archiver une fois les actions exécutées.
-> Créé : 16 avril 2026, fin de session tardive.
+> À supprimer ou archiver une fois la chaîne ADR-005 close (post-merge THI-113).
+> Créé : 18 avril 2026 après merge PR #151 (THI-115 Done).
 
 ---
 
 ## Contexte d'entrée
 
-Session précédente (16 avril 2026, soir) : vision stratégique consolidée via 4 ADRs (LTI-first, BYOK OpenRouter, TTFR KPI, Classroom Composer UI). Mémoires `project_platform_vision_v2.md`, `user_health_signals.md`, `project_internationalization.md` créées. Process docs `session-kickoff.md`, `release-sync-checklist.md`, `adr-template.md` livrés.
+Session précédente (18 avril 2026) : PR #151 mergée, THI-115 Done. `docs/plan.md` Phase 7b + ADR-005 alignés sur la nouvelle architecture BYOK 4-tiers OpenRouter (ADR-002). La chaîne d'implémentation AI Tutor V1 est débloquée — le gate zéro est **THI-109** (aucune dépendance entrante).
 
-**Scope ce matin** : transformer la vision en backlog Linear actionnable + finaliser les docs `.md` restantes.
+**Scope prochaine session** : démarrer THI-109 (agent `prompt-guardrail-auditor`) pour poser le test harness AVANT la première ligne de code fonctionnel.
 
 ---
 
 ## Étape 1 — Checks santé (obligatoire, protocole standard)
 
-Exécuter `session-kickoff.md` étapes 1 à 7. Si signal rouge santé → **stop**, proposer scope réduit à Thierry.
+Exécuter `session-kickoff.md` étapes 1 à 7. Si signal rouge santé → **stop**, proposer scope réduit.
 
 ---
 
-## Étape 2 — Finaliser les docs `.md` en attente
+## Étape 2 — Démarrer THI-109 (gate zéro ADR-005)
 
-Ces fichiers n'ont pas pu être mis à jour hier soir (budget tokens épuisé). Les faire **avant** de créer les issues Linear.
+**Issue** : [THI-109 — Agent prompt-guardrail-auditor (pre-implementation gate)](https://linear.app/thierryvm/issue/THI-109/agent-prompt-guardrail-auditor-pre-implementation-gate)
 
-### 2.1 `docs/ROADMAP.md` (priorité 1)
+### Livrables
 
-- Header : déjà OK (17 avril 2026 + note vision consolidée)
-- **À ajouter** après Phase 9 : 4 nouvelles phases
-  - **Phase 10** — Agent IA Tuteur BYOK (OpenRouter tier 0) — 4 semaines
-  - **Phase 11** — LTI 1.3 Provider (AGS + NRPS) — 6-8 semaines
-  - **Phase 12** — Classroom Composer UI (+ 5 templates par défaut) — 4 semaines
-  - **Phase 13** — Internationalisation (FR + NL + EN) — 3 semaines
+- Nouveau fichier `.claude/agents/prompt-guardrail-auditor.md` avec :
+  - Frontmatter : `model: haiku`, `tools: Read, Grep, Glob`
+  - Batterie de patterns d'injection connus (jailbreaks, prompt leaks, system prompt overrides, "ignore previous instructions", base64/unicode, role-play subversif)
+  - Analyse future `src/lib/ai/systemPrompt.ts` → détecte instructions faibles, absence de role enforcement
+  - Analyse future `src/lib/ai/sanitizer.ts` → détecte bypass triviaux
+  - Analyse future `AiTutorPanel.tsx`, `AiHintBubble.tsx` → rendu réponse LLM (anti-XSS)
+  - Rapport : CRITICAL (bloque merge) / WARNINGS / RECOMMENDATIONS
+- Mention dans `CLAUDE.md` projet (section Agents disponibles)
+- Test à blanc sur le repo actuel (aucun composant AI encore) → l'agent doit retourner "No AI components found, ready to audit once implementation starts"
 
-Pour chaque phase : objectifs, livrables, KPIs, dépendances, lien vers ADR.
+### Critères de merge
 
-### 2.2 `docs/ARCHITECTURE.md` (priorité 2)
+- CI verte (type-check + lint + test + build)
+- Sourcery OK (ou SKIPPED rate limit acceptable)
+- **Preview Vercel pas nécessaire** (agent = fichier markdown, zéro changement visuel)
+- Branche : `feature/thi-109-prompt-guardrail-auditor`
+- Passer THI-109 en **In Review** dès PR push, puis **Done** au merge
 
-Sections à ajouter :
-- **BYOK multi-tiers** — détection par préfixe clé, SDK OpenAI-compatible unique (ref ADR-002)
-- **Multi-tenancy RLS** — isolation par `institution_id` sur toutes les tables métier
-- **i18n architecture** — `react-i18next`, routes `/fr/*`, `/nl/*`, `/en/*`, stratégie curriculum (à trancher : fichiers séparés vs clés i18n)
-- **LTI 1.3 Provider** — endpoints, JWK rotation, deep linking flow (ref ADR-001)
+### Dépendances
 
-### 2.3 `docs/GUIDELINES.md` (priorité 3)
+- Aucune — c'est le gate zéro.
 
-Nouvelle section **Crédibilité B2B** :
-- ❌ Aucun claim non vérifiable dans le pitch institutionnel
-- ❌ Aucune métrique inventée (jamais "100 écoles utilisent")
-- ❌ Aucune référence à des features pas encore live
-- ✅ Transparence sur l'état réel (bénévole solo, stack open source, en développement)
-- ✅ Source code lien pour auditabilité
-- ✅ Statut phases affiché clairement (✅ livré / 🔄 en cours / 📋 planifié)
+### Débloque
 
-### 2.4 `CLAUDE.md` projet (priorité 4)
-
-- Ajouter section **ADRs** avec liens vers les 4 ADRs
-- Ajouter règle **Health signals** (ref `user_health_signals.md`)
-- Ajouter règle **Crédibilité B2B** (ref GUIDELINES)
+- THI-110 (key manager V1) → THI-111 (AiTutorPanel) → THI-112 (onboarding) → THI-113 (audit final) → merge Phase 7b
+- THI-114 (Web Worker isolation V1.5) — post-ship
 
 ---
 
-## Étape 3 — Créer les issues Linear + branches GitHub
+## Étape 3 — Vérification finale
 
-**Ordre d'exécution** : créer toutes les issues d'abord, puis les branches associées en parallèle.
+Après merge THI-109 :
 
-### Issues à créer (projet THI, equipe Thierry)
-
-#### Phase 10 — Agent IA Tuteur BYOK
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-105 | Agent IA Tuteur — scaffolding BYOK multi-tiers | High | `phase-10`, `ai`, `byok` | Détection clé par préfixe (sk-or-v1-*, sk-ant-*, sk-*), SDK OpenAI-compat unique, fallback entre tiers. Ref ADR-002. |
-| THI-106 | OpenRouter tier 0 — intégration modèles gratuits | High | `phase-10`, `ai`, `openrouter` | DeepSeek V3.1, Llama 3.3 70B, Gemini 2.0 Flash, Qwen 2.5 72B. UI onboarding sans carte bancaire. |
-| THI-107 | Prompt system Tuteur Socratique — CEFR A1→C2 | High | `phase-10`, `ai`, `prompt` | Prompts adaptés par niveau CEFR, jamais la réponse directe (maïeutique), OWASP LLM Top 10 2025 defenses. |
-| THI-108 | UI chat Tuteur — drawer latéral contextuel | Medium | `phase-10`, `ai`, `ui` | Drawer shadcn/ui, contexte leçon/commande courante injecté, historique session (pas persistant). |
-
-#### Phase 11 — LTI 1.3 Provider
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-109 | LTI 1.3 — endpoints de base (login, launch, JWK) | High | `phase-11`, `lti`, `b2b` | OIDC login init, LTI launch, JWK rotation endpoint. Ref ADR-001. |
-| THI-110 | LTI AGS — grade passback vers LMS hôte | Medium | `phase-11`, `lti` | Score TTFR + score leçons synchronisés vers Moodle/Canvas grade book. |
-| THI-111 | LTI NRPS — sync rosters | Medium | `phase-11`, `lti` | Récupération liste étudiants/enseignants depuis LMS hôte. |
-| THI-112 | LTI deep linking — sélection module/leçon | Low | `phase-11`, `lti` | Enseignant LMS choisit un module Terminal Learning à embed. |
-
-#### Phase 12 — Classroom Composer UI
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-113 | Composer UI — builder visuel JSON | High | `phase-12`, `classroom`, `ui` | UI drag-drop pour composer un parcours, JSON comme storage invisible. Ref ADR-004. |
-| THI-114 | Templates par défaut — 5 parcours Belgique | High | `phase-12`, `classroom`, `content` | 6ème sec FWB, humanités, CAP CESS, Forem, Bruxelles Formation. |
-| THI-115 | Fork/remix parcours — classroom forking | Medium | `phase-12`, `classroom` | Un enseignant fork un parcours public, l'adapte, le partage. Attribution obligatoire. |
-
-#### Phase 13 — i18n FR/NL/EN
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-116 | i18n — setup react-i18next + routes localisées | High | `phase-13`, `i18n` | `/fr/*`, `/nl/*`, `/en/*`, détection navigateur, switcher UI. |
-| THI-117 | i18n — traduction UI complète NL + EN | High | `phase-13`, `i18n` | Tous les composants UI + landing + dashboard. FR reste source de vérité. |
-| THI-118 | i18n — stratégie curriculum (décision technique) | Medium | `phase-13`, `i18n`, `curriculum` | Trancher : fichiers séparés `curriculum.fr.ts` vs clés i18n inline. Décision → ADR-005. |
-
-#### Crédibilité B2B (transversal)
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-119 | Crédibilité B2B — audit pages publiques | High | `b2b`, `compliance` | Landing + /story + /changelog : retirer tout claim non vérifiable, ajouter phrase "projet bénévole solo en développement". |
-| THI-120 | Demo interactive — try-before-signup | Medium | `b2b`, `onboarding` | Mini terminal playground sur landing, 3 commandes guidées sans auth. Conversion target : +30% signups. |
-
-#### Performance — régression INP prod
-
-| ID attendu | Titre | Priorité | Labels | Description courte |
-|---|---|---|---|---|
-| THI-121 | Speed Insights — investigation approfondie RES=64 / INP=1048ms | **Urgent** | `performance`, `investigation`, `regression` | Malgré THI-90 (startTransition, lab 515→26ms), le RES prod chute à 64 sur 7 jours (10-17 avril). INP P75 = 1048ms (rouge). FCP 2.74s + LCP 2.54s (orange). CLS 0.01 et TTFB 0.21s OK. **Hypothèses** : (1) startTransition insuffisant hors env-switcher (autres handlers lourds ?) ; (2) re-renders massifs sur routes leçons / LessonPage (ProgressContext ?) ; (3) bundle chunks encore trop gros sur routes lentes ; (4) third-party script (Sentry replay ?) ; (5) device low-end / conditions réseau réelles >> lab. **Livrables** : (a) profiling Chrome DevTools sur preview prod (desktop + mobile emulated CPU 4x) ; (b) analyse routes les plus lentes via Speed Insights "Paths" tab ; (c) audit `on*` handlers dans composants chauds (Sidebar, Landing, LessonPage) ; (d) vérifier si Sentry Replay actif en prod (peut ajouter 200-500ms INP) ; (e) rapport avec 3 hypothèses rankées + plan de remédiation chiffré. **Screenshot réf** : RES 64, tendance baissière 10-15 avril puis remontée partielle 16-17 avril. |
-
-### Création des branches
-
-Pour chaque issue créée ci-dessus, créer la branche GitHub correspondante avec `gh` :
-
-```bash
-# Exemple (à faire dans l'ordre des priorités High d'abord)
-gh issue create --title "..." --label "..." --body "..."
-# puis
-git checkout main && git pull
-git checkout -b feature/thi-105-ai-tutor-byok-scaffolding
-git push -u origin feature/thi-105-ai-tutor-byok-scaffolding
-```
-
-**Ne pas créer toutes les branches d'un coup** — créer au fur et à mesure quand on commence à travailler dessus, pour éviter la pollution des orphelines.
+- [ ] Passer THI-109 → Done dans Linear
+- [ ] Mettre à jour `docs/plan.md` Phase 7b step 1 : ✅
+- [ ] Mémoire `project_ai_agent_byok.md` : séquence step 2 marquée "Done"
+- [ ] `CLAUDE.md` projet : THI-109 ajouté en ✅
+- [ ] Demander à Thierry : démarrer THI-110 ou pause ?
 
 ---
 
-## Étape 4 — Vérification finale
+## Chaîne ADR-005 complète (référence)
 
-Après création des issues + docs à jour :
-- [ ] Lancer agent `linear-sync` pour confirmer cohérence
-- [ ] `git status` clean sur `main`
-- [ ] MEMORY.md à jour (ajouter entry si ADR-005 créé pour i18n curriculum)
-- [ ] Résumé oral à Thierry : nombre d'issues créées, phases couvertes, priorités top 3
-
----
-
-## Ordre de priorité si temps limité
-
-Si Thierry a un budget session restreint :
-
-1. **Must-have** (30 min) — Étape 2.1 ROADMAP + Étape 3 issues Phase 10 (4 issues) + THI-119 crédibilité
-2. **Should-have** (+30 min) — Étape 2.2 ARCHITECTURE + Étape 3 issues Phase 11 (4 issues)
-3. **Nice-to-have** (+30 min) — Étape 2.3 GUIDELINES + Étape 2.4 CLAUDE.md + Étape 3 issues Phases 12/13
-4. **Deferred** — Création des branches (attendre le démarrage effectif de chaque feature)
+| ID | Titre | Statut 2026-04-18 | Priorité | Dépend de |
+|---|---|---|---|---|
+| THI-109 | Agent prompt-guardrail-auditor | Backlog | High | — |
+| THI-110 | Key manager V1 | Backlog | High | THI-109 |
+| THI-111 | AiTutorPanel + providers + system prompt + sanitizer | Backlog | High | THI-110 |
+| THI-112 | Onboarding IA — AiKeySetup + AiConsentModal | Backlog | Medium | THI-111 |
+| THI-113 | Audit final Tuteur IA | Backlog | High | THI-112 |
+| THI-114 | V1.5 — Web Worker isolation keyManager | Backlog | Low | THI-113 (post-ship) |
 
 ---
 
-## Mémoires à charger automatiquement
+## Mémoires prioritaires à recharger en début de session
 
-En début de session demain, ces mémoires sont prioritaires :
-- `project_platform_vision_v2.md` — **source de vérité stratégique**
+- `project_ai_agent_byok.md` — **source de vérité** ADR-002 + ADR-005
+- `feedback_doc_alignment.md` — règle doc alignment systématique
 - `user_health_signals.md` — règle slow-down
-- `project_internationalization.md` — priorités i18n
 - `feedback_session_protocol.md` — règles opérationnelles
+- `reference_vercel_bypass.md` — secret bypass pour visual verification previews
 
 ---
 
 ## Trigger d'activation
 
-Thierry dira probablement : **"ok, lance les process habituels"** ou **"début de session"**.
+Thierry dira probablement : **"ok, on démarre THI-109"** ou **"suite de l'AI Tutor"**.
 
-→ Répondre par l'exécution directe des étapes 1 à 4 ci-dessus, sans demander confirmation pour chaque sous-étape. Demander confirmation uniquement avant : création d'une issue Linear, push d'une branche, modification destructive.
+→ Répondre par l'exécution directe des étapes 1-2 ci-dessus. Demander confirmation avant : création de PR, push de branche, modification destructive.


### PR DESCRIPTION
## Summary

Post-merge cleanup after PR #151 (THI-115). Two doc files had drifted vs the current state of the project:

- **CLAUDE.md** — phases section missed several recently merged THIs (91, 105, 107, 96, 115) and the upcoming Phase 7b chain (THI-109 → 114). Now reflects the AI Tutor V1 roadmap.
- **docs/processes/next-session-plan.md** — fully drifted: still described the old LTI/Classroom scope for THI-109-115 instead of the current ADR-005 AI Tutor chain. Rewritten to focus on THI-109 as gate zero (prompt-guardrail-auditor agent) with full chain reference table.
- **.gitignore** — adds `.claude-screenshots/` (local preview verification artifacts land there).

Pure docs sync — no code, no UI changes, no dependencies touched.

## Linear

Closes THI-116

## Test plan
- [x] CI green (type-check + lint + test + build)
- [x] No visual changes (docs-only PR — Vercel preview check not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)