### PR TITLE
docs: sync CLAUDE.md + next-session-plan post-THI-109

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - THI-107 ✅ A11y focus-visible + 11 native `<button>` migrés (PRs #140/142, 17 avril 2026)
 - THI-96 🔄 Web 2026 compliance — 6/8 sub-issues shipped (THI-97 à 102), reste desktop a11y + CSS moderne 2026
 - THI-115 ✅ Doc alignment ADR-002 + ADR-005 (AI Tutor V1) — plan.md Phase 7b réécrit, 4 décisions figées (PR #151, 18 avril 2026)
-- **Phase 7b 🔄 AI Tutor V1 (chaîne ADR-005)** — THI-109 (prompt-guardrail-auditor agent) → THI-110 (key manager V1) → THI-111 (AiTutorPanel + providers + sanitizer) → THI-112 (onboarding AiKeySetup/AiConsentModal) → THI-113 (audit final) · THI-114 (Web Worker isolation V1.5 post-ship)
+- THI-109 ✅ Agent `prompt-guardrail-auditor` — gate zéro ADR-005, OWASP LLM Top 10, créé AVANT implémentation (PR #153, 18 avril 2026)
+- **Phase 7b 🔄 AI Tutor V1 (chaîne ADR-005)** — ✅ THI-109 · 🔜 THI-110 (key manager V1) → THI-111 (AiTutorPanel + providers + sanitizer) → THI-112 (onboarding AiKeySetup/AiConsentModal) → THI-113 (audit final) · THI-114 (Web Worker isolation V1.5 post-ship)
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative

--- a/docs/processes/next-session-plan.md
+++ b/docs/processes/next-session-plan.md
@@ -1,16 +1,19 @@
-# Next Session Plan — 18-19 avril 2026 (chaîne ADR-005 AI Tutor V1)
+# Next Session Plan — 19 avril 2026 (chaîne ADR-005 AI Tutor V1, step 3)
 
 > Fichier lu automatiquement par `session-kickoff.md` étape 5.
 > À supprimer ou archiver une fois la chaîne ADR-005 close (post-merge THI-113).
-> Créé : 18 avril 2026 après merge PR #151 (THI-115 Done).
+> Mis à jour : 18 avril 2026 après merge PR #153 (THI-109 Done).
 
 ---
 
 ## Contexte d'entrée
 
-Session précédente (18 avril 2026) : PR #151 mergée, THI-115 Done. `docs/plan.md` Phase 7b + ADR-005 alignés sur la nouvelle architecture BYOK 4-tiers OpenRouter (ADR-002). La chaîne d'implémentation AI Tutor V1 est débloquée — le gate zéro est **THI-109** (aucune dépendance entrante).
+Session précédente (18 avril 2026) :
+- PR #151 mergée, THI-115 Done (doc alignment ADR-002 + ADR-005)
+- PR #152 mergée, THI-116 Done (sync CLAUDE.md + next-session-plan.md)
+- PR #153 mergée, **THI-109 Done** (agent `prompt-guardrail-auditor`, gate zéro ADR-005 — OWASP LLM Top 10, batterie injections, test à blanc ✅)
 
-**Scope prochaine session** : démarrer THI-109 (agent `prompt-guardrail-auditor`) pour poser le test harness AVANT la première ligne de code fonctionnel.
+**Scope prochaine session** : démarrer **THI-110** (Key manager V1 — localStorage plain + opt-in IndexedDB Web Crypto). C'est la première ligne de code fonctionnel du Tuteur IA — l'agent `prompt-guardrail-auditor` est prêt à auditer dès ce step.
 
 ---
 
@@ -20,50 +23,58 @@ Exécuter `session-kickoff.md` étapes 1 à 7. Si signal rouge santé → **stop
 
 ---
 
-## Étape 2 — Démarrer THI-109 (gate zéro ADR-005)
+## Étape 2 — Démarrer THI-110 (key manager V1)
 
-**Issue** : [THI-109 — Agent prompt-guardrail-auditor (pre-implementation gate)](https://linear.app/thierryvm/issue/THI-109/agent-prompt-guardrail-auditor-pre-implementation-gate)
+**Issue** : [THI-110 — Key manager V1 (localStorage plain + opt-in Web Crypto)](https://linear.app/thierryvm/issue/THI-110)
 
 ### Livrables
 
-- Nouveau fichier `.claude/agents/prompt-guardrail-auditor.md` avec :
-  - Frontmatter : `model: haiku`, `tools: Read, Grep, Glob`
-  - Batterie de patterns d'injection connus (jailbreaks, prompt leaks, system prompt overrides, "ignore previous instructions", base64/unicode, role-play subversif)
-  - Analyse future `src/lib/ai/systemPrompt.ts` → détecte instructions faibles, absence de role enforcement
-  - Analyse future `src/lib/ai/sanitizer.ts` → détecte bypass triviaux
-  - Analyse future `AiTutorPanel.tsx`, `AiHintBubble.tsx` → rendu réponse LLM (anti-XSS)
-  - Rapport : CRITICAL (bloque merge) / WARNINGS / RECOMMENDATIONS
-- Mention dans `CLAUDE.md` projet (section Agents disponibles)
-- Test à blanc sur le repo actuel (aucun composant AI encore) → l'agent doit retourner "No AI components found, ready to audit once implementation starts"
+- `src/lib/ai/keyManager.ts` avec API stable :
+  - `getApiKey(): Promise<string | null>` — lecture à la demande, jamais de cache global long-lived
+  - `setApiKey(key: string, opts?: { encrypt?: boolean; passphrase?: string }): Promise<void>`
+  - `forgetApiKey(): Promise<void>` — efface localStorage + IndexedDB + variables RAM
+  - `hasEncryptedKey(): Promise<boolean>` — true si l'utilisateur a opt-in au chiffrement
+- Implémentation V1 :
+  - **Défaut** : `localStorage` plain, warning visible à configurer côté UI (pas dans ce ticket)
+  - **Opt-in** : IndexedDB + Web Crypto AES-GCM, PBKDF2 ≥ 210 000 itérations, sel aléatoire par user, IV unique par opération
+- Détection auto du provider via préfixe de clé (`sk-or-v1-*`, `sk-ant-*`, `sk-*`, custom base URL) — exposée via `detectProvider(key: string)`
+- Tests unitaires Vitest :
+  - Round-trip set/get en mode plain
+  - Round-trip set/get en mode chiffré avec passphrase correcte
+  - Échec de get avec mauvaise passphrase (pas de crash, retourne null + log sanitisé)
+  - `forgetApiKey()` efface réellement les deux stores
+  - `detectProvider()` renvoie le bon tier pour chaque format
 
 ### Critères de merge
 
 - CI verte (type-check + lint + test + build)
-- Sourcery OK (ou SKIPPED rate limit acceptable)
-- **Preview Vercel pas nécessaire** (agent = fichier markdown, zéro changement visuel)
-- Branche : `feature/thi-109-prompt-guardrail-auditor`
-- Passer THI-109 en **In Review** dès PR push, puis **Done** au merge
+- Sourcery OK (ou SKIPPED rate limit)
+- **Agent `prompt-guardrail-auditor` lancé** → doit maintenant détecter `keyManager.ts` et auditer les leakage surfaces (console.log, Sentry `beforeSend`, etc.)
+- Agent `security-auditor` complémentaire pour PBKDF2 iter count + CSP `connect-src` inchangé (pas de fetch dans ce ticket)
+- Branche : `feature/thi-110-key-manager-v1`
+- Passer THI-110 en **In Review** dès PR push, puis **Done** au merge
 
 ### Dépendances
 
-- Aucune — c'est le gate zéro.
+- THI-109 ✅ (prompt-guardrail-auditor créé)
 
 ### Débloque
 
-- THI-110 (key manager V1) → THI-111 (AiTutorPanel) → THI-112 (onboarding) → THI-113 (audit final) → merge Phase 7b
-- THI-114 (Web Worker isolation V1.5) — post-ship
+- THI-111 (AiTutorPanel + providers + system prompt + sanitizer)
+- THI-112 → THI-113 → merge Phase 7b
 
 ---
 
 ## Étape 3 — Vérification finale
 
-Après merge THI-109 :
+Après merge THI-110 :
 
-- [ ] Passer THI-109 → Done dans Linear
-- [ ] Mettre à jour `docs/plan.md` Phase 7b step 1 : ✅
-- [ ] Mémoire `project_ai_agent_byok.md` : séquence step 2 marquée "Done"
-- [ ] `CLAUDE.md` projet : THI-109 ajouté en ✅
-- [ ] Demander à Thierry : démarrer THI-110 ou pause ?
+- [ ] THI-110 → Done dans Linear
+- [ ] `docs/plan.md` Phase 7b step 3 : ✅
+- [ ] Mémoire `project_ai_agent_byok.md` : séquence step 3 marquée "Done"
+- [ ] `CLAUDE.md` projet : THI-110 ajouté en ✅
+- [ ] Mettre à jour ce fichier pour pointer sur THI-111
+- [ ] Demander à Thierry : démarrer THI-111 (plus gros ticket — AiTutorPanel + providers + sanitizer) ou pause ?
 
 ---
 
@@ -71,8 +82,8 @@ Après merge THI-109 :
 
 | ID | Titre | Statut 2026-04-18 | Priorité | Dépend de |
 |---|---|---|---|---|
-| THI-109 | Agent prompt-guardrail-auditor | Backlog | High | — |
-| THI-110 | Key manager V1 | Backlog | High | THI-109 |
+| THI-109 | Agent prompt-guardrail-auditor | ✅ Done (PR #153) | High | — |
+| THI-110 | Key manager V1 | 🔜 Next | High | THI-109 |
 | THI-111 | AiTutorPanel + providers + system prompt + sanitizer | Backlog | High | THI-110 |
 | THI-112 | Onboarding IA — AiKeySetup + AiConsentModal | Backlog | Medium | THI-111 |
 | THI-113 | Audit final Tuteur IA | Backlog | High | THI-112 |
@@ -82,16 +93,16 @@ Après merge THI-109 :
 
 ## Mémoires prioritaires à recharger en début de session
 
-- `project_ai_agent_byok.md` — **source de vérité** ADR-002 + ADR-005
+- `project_ai_agent_byok.md` — **source de vérité** ADR-002 + ADR-005 (séquence step 3 = THI-110)
 - `feedback_doc_alignment.md` — règle doc alignment systématique
 - `user_health_signals.md` — règle slow-down
 - `feedback_session_protocol.md` — règles opérationnelles
-- `reference_vercel_bypass.md` — secret bypass pour visual verification previews
+- `reference_vercel_bypass.md` — secret bypass pour visual verification previews (pas nécessaire pour THI-110 — pas de changement UI)
 
 ---
 
 ## Trigger d'activation
 
-Thierry dira probablement : **"ok, on démarre THI-109"** ou **"suite de l'AI Tutor"**.
+Thierry dira probablement : **"ok, on démarre THI-110"**, **"suite du tuteur IA"**, ou **"enchaîne"**.
 
 → Répondre par l'exécution directe des étapes 1-2 ci-dessus. Demander confirmation avant : création de PR, push de branche, modification destructive.


### PR DESCRIPTION
## Summary

- `CLAUDE.md` : ligne phase THI-109 ✅ ajoutée + annotation Phase 7b (`✅ THI-109 · 🔜 THI-110 ...`).
- `docs/processes/next-session-plan.md` : réécrit pour pointer sur **THI-110** (Key manager V1) en step 3 de la chaîne ADR-005. Livrables, critères, débloque.

Même pattern que PR #152 (doc sync post-THI-115) — mini-PR isolée pour séparer doc de l'implémentation.

## Linear

Closes THI-117

## Test plan

- [x] CI verte (type-check + lint + test + build)
- [x] Sourcery OK ou SKIPPED (rate limit acceptable)
- [ ] Pas de preview Vercel nécessaire (markdown uniquement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)