### PR TITLE
feat(ai): add keyManager V1 (THI-110, ADR-005 step 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
+        "fake-indexeddb": "^6.2.5",
         "gif-encoder-2": "^1.0.5",
         "jsdom": "^29.0.1",
         "pngjs": "^7.0.0",
@@ -7087,6 +7088,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "fake-indexeddb": "^6.2.5",
     "gif-encoder-2": "^1.0.5",
     "jsdom": "^29.0.1",
     "pngjs": "^7.0.0",

--- a/src/lib/ai/keyManager.ts
+++ b/src/lib/ai/keyManager.ts
@@ -1,0 +1,288 @@
+/**
+ * Key manager V1 — ADR-005, THI-110.
+ *
+ * Client-side only. No key ever leaves the browser.
+ * - Plain mode (default): localStorage.
+ * - Encrypted mode (opt-in): IndexedDB + Web Crypto AES-GCM + PBKDF2 ≥ 210k iter.
+ *
+ * Web Worker isolation → V1.5 (THI-114).
+ */
+
+export type Provider = 'openrouter' | 'anthropic' | 'openai' | 'gemini';
+
+export interface KeySaveOpts {
+  encrypt?: boolean;
+  passphrase?: string;
+}
+
+const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
+
+const LS_PREFIX = 'ai_key_';
+const DB_NAME = 'ai_keys_encrypted';
+const DB_VERSION = 1;
+const STORE_NAME = 'keys';
+
+const PBKDF2_ITERATIONS = 210_000;
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+
+interface EncryptedRecord {
+  provider: Provider;
+  ciphertext: ArrayBuffer;
+  salt: ArrayBuffer;
+  iv: ArrayBuffer;
+}
+
+function assertProvider(p: Provider): void {
+  if (!PROVIDERS.includes(p)) {
+    throw new Error('Unknown provider');
+  }
+}
+
+function getLocalStorage(): Storage {
+  const ls = (globalThis as { localStorage?: Storage }).localStorage;
+  if (!ls) {
+    throw new Error('localStorage unavailable');
+  }
+  return ls;
+}
+
+function getIndexedDB(): IDBFactory {
+  const idb = (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+  if (!idb) {
+    throw new Error('indexedDB unavailable');
+  }
+  return idb;
+}
+
+function getSubtle(): SubtleCrypto {
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (!c?.subtle) {
+    throw new Error('Web Crypto unavailable');
+  }
+  return c.subtle;
+}
+
+function randomBytes(n: number): Uint8Array<ArrayBuffer> {
+  // Explicitly back the Uint8Array with a plain ArrayBuffer so TS does not infer
+  // ArrayBufferLike (which would admit SharedArrayBuffer and fail BufferSource).
+  const buf = new Uint8Array(new ArrayBuffer(n));
+  globalThis.crypto.getRandomValues(buf);
+  return buf;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = getIndexedDB().open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'provider' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'));
+  });
+}
+
+async function withDb<T>(fn: (db: IDBDatabase) => Promise<T>): Promise<T> {
+  // Open one short-lived connection per operation so a subsequent deleteDatabase
+  // never blocks on a lingering handle (tests rely on this for teardown).
+  const db = await openDb();
+  try {
+    return await fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function dbGet(provider: Provider): Promise<EncryptedRecord | undefined> {
+  return withDb(
+    (db) =>
+      new Promise<EncryptedRecord | undefined>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const req = tx.objectStore(STORE_NAME).get(provider);
+        req.onsuccess = () => resolve(req.result as EncryptedRecord | undefined);
+        req.onerror = () => reject(req.error ?? new Error('IndexedDB get failed'));
+      }),
+  );
+}
+
+function dbPut(record: EncryptedRecord): Promise<void> {
+  return withDb(
+    (db) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const req = tx.objectStore(STORE_NAME).put(record);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error ?? new Error('IndexedDB put failed'));
+      }),
+  );
+}
+
+function dbDelete(provider: Provider): Promise<void> {
+  return withDb(
+    (db) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const req = tx.objectStore(STORE_NAME).delete(provider);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error ?? new Error('IndexedDB delete failed'));
+      }),
+  );
+}
+
+async function deriveKey(passphrase: string, salt: BufferSource): Promise<CryptoKey> {
+  const subtle = getSubtle();
+  const passKey = await subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey'],
+  );
+  return subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+    passKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+async function encryptKey(
+  key: string,
+  passphrase: string,
+): Promise<Pick<EncryptedRecord, 'ciphertext' | 'salt' | 'iv'>> {
+  const salt = randomBytes(SALT_BYTES);
+  const iv = randomBytes(IV_BYTES);
+  const cryptoKey = await deriveKey(passphrase, salt);
+  const ciphertext = await getSubtle().encrypt(
+    { name: 'AES-GCM', iv },
+    cryptoKey,
+    new TextEncoder().encode(key),
+  );
+  // Clone bytes into fresh ArrayBuffers so the stored record cannot reference
+  // the caller's mutable Uint8Array backing stores.
+  return {
+    ciphertext,
+    salt: salt.slice().buffer,
+    iv: iv.slice().buffer,
+  };
+}
+
+async function decryptKey(record: EncryptedRecord, passphrase: string): Promise<string> {
+  const cryptoKey = await deriveKey(passphrase, record.salt);
+  const plainBuf = await getSubtle().decrypt(
+    { name: 'AES-GCM', iv: record.iv },
+    cryptoKey,
+    record.ciphertext,
+  );
+  return new TextDecoder().decode(plainBuf);
+}
+
+/** Detects a provider from a key's prefix. Returns null if unknown. */
+export function detectProvider(key: string): Provider | null {
+  if (typeof key !== 'string') return null;
+  const k = key.trim();
+  if (k.startsWith('sk-or-v1-')) return 'openrouter';
+  if (k.startsWith('sk-ant-')) return 'anthropic';
+  if (k.startsWith('sk-')) return 'openai';
+  if (k.startsWith('AIza')) return 'gemini';
+  return null;
+}
+
+/**
+ * Stores an API key for the given provider.
+ * - Plain by default (localStorage).
+ * - Encrypted when `opts.encrypt === true` (IndexedDB + AES-GCM + PBKDF2).
+ *   Requires a non-empty `opts.passphrase`.
+ * Migration: switching mode for a provider removes the previous store entry.
+ */
+export async function saveKey(
+  provider: Provider,
+  key: string,
+  opts: KeySaveOpts = {},
+): Promise<void> {
+  assertProvider(provider);
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('Key must be a non-empty string');
+  }
+
+  if (opts.encrypt) {
+    if (typeof opts.passphrase !== 'string' || opts.passphrase.length === 0) {
+      throw new Error('Passphrase required for encrypted mode');
+    }
+    const { ciphertext, salt, iv } = await encryptKey(key, opts.passphrase);
+    await dbPut({ provider, ciphertext, salt, iv });
+    // Migration: erase any pre-existing plain entry.
+    getLocalStorage().removeItem(LS_PREFIX + provider);
+    return;
+  }
+
+  getLocalStorage().setItem(LS_PREFIX + provider, key);
+  // Migration: erase any pre-existing encrypted entry.
+  try {
+    await dbDelete(provider);
+  } catch {
+    // Best-effort — if IDB is unavailable or empty, the plain write still succeeded.
+  }
+}
+
+/**
+ * Reads an API key for the given provider.
+ * - Plain entry returned as-is.
+ * - Encrypted entry: requires `passphrase`. Wrong passphrase or decryption
+ *   failure returns `null` (never throws, never logs the key).
+ * - No entry → `null`.
+ */
+export async function getKey(provider: Provider, passphrase?: string): Promise<string | null> {
+  assertProvider(provider);
+
+  const plain = getLocalStorage().getItem(LS_PREFIX + provider);
+  if (plain !== null) return plain;
+
+  try {
+    const record = await dbGet(provider);
+    if (!record) return null;
+    if (typeof passphrase !== 'string' || passphrase.length === 0) return null;
+    return await decryptKey(record, passphrase);
+  } catch {
+    return null;
+  }
+}
+
+/** Removes both plain and encrypted entries for the given provider. */
+export async function forgetKey(provider: Provider): Promise<void> {
+  assertProvider(provider);
+  getLocalStorage().removeItem(LS_PREFIX + provider);
+  try {
+    await dbDelete(provider);
+  } catch {
+    // Idempotent — nothing to do if IDB unavailable or entry absent.
+  }
+}
+
+/** True iff an encrypted entry exists for the provider and no plain entry shadows it. */
+export async function isEncrypted(provider: Provider): Promise<boolean> {
+  assertProvider(provider);
+  if (getLocalStorage().getItem(LS_PREFIX + provider) !== null) return false;
+  try {
+    const record = await dbGet(provider);
+    return !!record;
+  } catch {
+    return false;
+  }
+}
+
+/** True iff any entry (plain or encrypted) exists for the provider. */
+export async function hasKey(provider: Provider): Promise<boolean> {
+  assertProvider(provider);
+  if (getLocalStorage().getItem(LS_PREFIX + provider) !== null) return true;
+  try {
+    const record = await dbGet(provider);
+    return !!record;
+  } catch {
+    return false;
+  }
+}

--- a/src/test/keyManager.test.ts
+++ b/src/test/keyManager.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for src/lib/ai/keyManager.ts — THI-110.
+ *
+ * Covers plain + encrypted round-trip, migration between modes, isEncrypted/hasKey,
+ * forgetKey, detectProvider, and defensive throws (invalid provider, empty key,
+ * encrypt without passphrase, wrong passphrase → null).
+ */
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  detectProvider,
+  forgetKey,
+  getKey,
+  hasKey,
+  isEncrypted,
+  saveKey,
+  type Provider,
+} from '@/lib/ai/keyManager';
+
+const DB_NAME = 'ai_keys_encrypted';
+
+function resetIdb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    const done = () => resolve();
+    req.onsuccess = done;
+    req.onerror = done;
+    req.onblocked = done;
+  });
+}
+
+beforeEach(async () => {
+  localStorage.clear();
+  await resetIdb();
+});
+
+describe('detectProvider', () => {
+  it('detects OpenRouter', () => {
+    expect(detectProvider('sk-or-v1-abc123')).toBe('openrouter');
+  });
+
+  it('detects Anthropic', () => {
+    expect(detectProvider('sk-ant-api03-abc')).toBe('anthropic');
+  });
+
+  it('detects OpenAI (sk- without narrower prefix)', () => {
+    expect(detectProvider('sk-proj-abc123')).toBe('openai');
+  });
+
+  it('detects Gemini', () => {
+    expect(detectProvider('AIzaSyABC123')).toBe('gemini');
+  });
+
+  it('returns null for unknown prefix', () => {
+    expect(detectProvider('unknown-key')).toBeNull();
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(detectProvider('   sk-or-v1-abc   ')).toBe('openrouter');
+  });
+
+  it('returns null for non-string input', () => {
+    expect(detectProvider(null as unknown as string)).toBeNull();
+    expect(detectProvider(undefined as unknown as string)).toBeNull();
+    expect(detectProvider(42 as unknown as string)).toBeNull();
+  });
+});
+
+describe('saveKey / getKey — plain mode', () => {
+  it('round-trips a plain key', async () => {
+    await saveKey('openrouter', 'sk-or-v1-test');
+    expect(await getKey('openrouter')).toBe('sk-or-v1-test');
+  });
+
+  it('stores under a namespaced localStorage key', async () => {
+    await saveKey('anthropic', 'sk-ant-test');
+    expect(localStorage.getItem('ai_key_anthropic')).toBe('sk-ant-test');
+  });
+
+  it('returns null when no key is stored', async () => {
+    expect(await getKey('openai')).toBeNull();
+  });
+
+  it('overwrites an existing plain key', async () => {
+    await saveKey('openai', 'first');
+    await saveKey('openai', 'second');
+    expect(await getKey('openai')).toBe('second');
+  });
+});
+
+describe('saveKey / getKey — encrypted mode', () => {
+  it('round-trips an encrypted key with correct passphrase', async () => {
+    await saveKey('anthropic', 'sk-ant-secret', { encrypt: true, passphrase: 'correct horse' });
+    expect(await getKey('anthropic', 'correct horse')).toBe('sk-ant-secret');
+  });
+
+  it('never leaves the plaintext key in localStorage when encrypted', async () => {
+    await saveKey('anthropic', 'sk-ant-secret', { encrypt: true, passphrase: 'pw' });
+    expect(localStorage.getItem('ai_key_anthropic')).toBeNull();
+  });
+
+  it('returns null for a wrong passphrase (does not throw)', async () => {
+    await saveKey('anthropic', 'sk-ant-secret', { encrypt: true, passphrase: 'right' });
+    expect(await getKey('anthropic', 'wrong')).toBeNull();
+  });
+
+  it('returns null when an encrypted entry exists but no passphrase is provided', async () => {
+    await saveKey('anthropic', 'sk-ant-secret', { encrypt: true, passphrase: 'pw' });
+    expect(await getKey('anthropic')).toBeNull();
+  });
+
+  it('throws when encrypt: true but no passphrase is provided', async () => {
+    await expect(saveKey('openrouter', 'k', { encrypt: true })).rejects.toThrow(/passphrase/i);
+  });
+
+  it('throws when encrypt: true and passphrase is empty', async () => {
+    await expect(
+      saveKey('openrouter', 'k', { encrypt: true, passphrase: '' }),
+    ).rejects.toThrow(/passphrase/i);
+  });
+});
+
+describe('saveKey — input validation', () => {
+  it('throws on unknown provider', async () => {
+    await expect(
+      saveKey('ghost' as unknown as Provider, 'sk-test'),
+    ).rejects.toThrow(/provider/i);
+  });
+
+  it('throws on empty key', async () => {
+    await expect(saveKey('openai', '')).rejects.toThrow(/non-empty/i);
+  });
+});
+
+describe('migration between modes', () => {
+  it('erases plain entry when switching to encrypted', async () => {
+    await saveKey('openai', 'plain-key');
+    expect(localStorage.getItem('ai_key_openai')).toBe('plain-key');
+
+    await saveKey('openai', 'encrypted-key', { encrypt: true, passphrase: 'pw' });
+    expect(localStorage.getItem('ai_key_openai')).toBeNull();
+    expect(await getKey('openai', 'pw')).toBe('encrypted-key');
+  });
+
+  it('erases encrypted entry when switching to plain', async () => {
+    await saveKey('openai', 'encrypted-key', { encrypt: true, passphrase: 'pw' });
+    expect(await isEncrypted('openai')).toBe(true);
+
+    await saveKey('openai', 'plain-key');
+    expect(await isEncrypted('openai')).toBe(false);
+    expect(await getKey('openai')).toBe('plain-key');
+  });
+});
+
+describe('forgetKey', () => {
+  it('removes a plain key', async () => {
+    await saveKey('gemini', 'AIza-test');
+    await forgetKey('gemini');
+    expect(await hasKey('gemini')).toBe(false);
+    expect(await getKey('gemini')).toBeNull();
+  });
+
+  it('removes an encrypted key', async () => {
+    await saveKey('gemini', 'AIza-test', { encrypt: true, passphrase: 'pw' });
+    await forgetKey('gemini');
+    expect(await hasKey('gemini')).toBe(false);
+    expect(await getKey('gemini', 'pw')).toBeNull();
+  });
+
+  it('is a no-op when no key exists', async () => {
+    await expect(forgetKey('openrouter')).resolves.toBeUndefined();
+    expect(await hasKey('openrouter')).toBe(false);
+  });
+
+  it('throws on unknown provider', async () => {
+    await expect(forgetKey('ghost' as unknown as Provider)).rejects.toThrow(/provider/i);
+  });
+});
+
+describe('hasKey / isEncrypted', () => {
+  it('hasKey reflects plain storage', async () => {
+    expect(await hasKey('openai')).toBe(false);
+    await saveKey('openai', 'k');
+    expect(await hasKey('openai')).toBe(true);
+  });
+
+  it('hasKey reflects encrypted storage', async () => {
+    expect(await hasKey('anthropic')).toBe(false);
+    await saveKey('anthropic', 'k', { encrypt: true, passphrase: 'pw' });
+    expect(await hasKey('anthropic')).toBe(true);
+  });
+
+  it('isEncrypted is false for plain keys', async () => {
+    await saveKey('openai', 'k');
+    expect(await isEncrypted('openai')).toBe(false);
+  });
+
+  it('isEncrypted is true only for encrypted keys', async () => {
+    await saveKey('anthropic', 'k', { encrypt: true, passphrase: 'pw' });
+    expect(await isEncrypted('anthropic')).toBe(true);
+  });
+
+  it('isEncrypted is false when no key is stored', async () => {
+    expect(await isEncrypted('gemini')).toBe(false);
+  });
+});
+
+describe('providers are isolated from one another', () => {
+  it('saving one provider does not affect another', async () => {
+    await saveKey('openrouter', 'or-key');
+    await saveKey('anthropic', 'ant-key', { encrypt: true, passphrase: 'pw' });
+
+    expect(await getKey('openrouter')).toBe('or-key');
+    expect(await getKey('anthropic', 'pw')).toBe('ant-key');
+    expect(await getKey('openai')).toBeNull();
+    expect(await getKey('gemini')).toBeNull();
+  });
+
+  it('forgetting one provider leaves others intact', async () => {
+    await saveKey('openrouter', 'or-key');
+    await saveKey('openai', 'oa-key');
+
+    await forgetKey('openrouter');
+
+    expect(await hasKey('openrouter')).toBe(false);
+    expect(await getKey('openai')).toBe('oa-key');
+  });
+});


### PR DESCRIPTION
## Summary

- **THI-110** — step 3 of the ADR-005 AI Tutor V1 chain. Client-side key manager for BYOK (zero server-side key, ADR-002).
- Plain mode (default) = `localStorage`. Encrypted mode (opt-in) = IndexedDB + Web Crypto AES-GCM + PBKDF2 (210k iter SHA-256, 16B salt, 12B IV per op, deriveKey non-extractible).
- Migration between modes erases the previous store entry. Wrong passphrase → `null` (never throws, no timing oracle).
- API: `saveKey`, `getKey`, `forgetKey`, `isEncrypted`, `hasKey`, `detectProvider` — providers `openrouter | anthropic | openai | gemini`.
- 32 new tests (935 total suite, all green). `fake-indexeddb@6.2.5` added as devDep for jsdom IDB polyfill.

## Audit

`prompt-guardrail-auditor` — **first real audit**, gate zero of ADR-005 — ran on this branch:

- **VERDICT: ✅ PASS** — 0 CRITICAL · 1 WARN (non-blocking) · 5 recommendations
- WARN [W1] = Sentry `beforeSend` doesn't scrub `Authorization` headers or `key/token/secret/auth` fields in `extra`/`contexts`. **Risk today = NULL** (no AI code touches Sentry yet). Tracked as THI-120, must ship before THI-111 wires fetch.
- Cryptography clean: PBKDF2 at the exact ADR value, salt/IV random per op, deriveKey non-extractible, buffers cloned before store, no console.*, no Authorization header anywhere, no real key in repo/history.

## Hors scope (reportés)

- Web Worker isolation → **THI-114** (V1.5 post-ship, decided in ADR-005)
- Rate limiting → handled in THI-111 (AiTutorPanel layer)
- Cross-device sync → not in scope (client-side only)

## Follow-up tickets opened in this session

- **THI-118** (High) — perf regression LCP on `/` (3.87s → 9.31s, ×2.4)
- **THI-119** (Medium) — Sentry filter for `text/html` MIME type variant
- **THI-120** (High) — Sentry `beforeSend` scrubber before THI-111

## Test plan

- [x] `npm run test` — 935 passed / 20 skipped (955 total) — +32 from keyManager
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `prompt-guardrail-auditor` — PASS (0 CRITICAL)
- [ ] CI green (type-check + lint + test + build)
- [ ] Sourcery OK (or SKIPPED rate limit)
- [ ] Visual verification not needed — no UI changes in this PR

Closes THI-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)