### PR TITLE
docs: sync post-THI-110 (next = THI-120 scrubber Sentry)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,8 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - THI-96 🔄 Web 2026 compliance — 6/8 sub-issues shipped (THI-97 à 102), reste desktop a11y + CSS moderne 2026
 - THI-115 ✅ Doc alignment ADR-002 + ADR-005 (AI Tutor V1) — plan.md Phase 7b réécrit, 4 décisions figées (PR #151, 18 avril 2026)
 - THI-109 ✅ Agent `prompt-guardrail-auditor` — gate zéro ADR-005, OWASP LLM Top 10, créé AVANT implémentation (PR #153, 18 avril 2026)
-- **Phase 7b 🔄 AI Tutor V1 (chaîne ADR-005)** — ✅ THI-109 · 🔜 THI-110 (key manager V1) → THI-111 (AiTutorPanel + providers + sanitizer) → THI-112 (onboarding AiKeySetup/AiConsentModal) → THI-113 (audit final) · THI-114 (Web Worker isolation V1.5 post-ship)
+- THI-110 ✅ Key manager V1 — `src/lib/ai/keyManager.ts` + 32 tests, localStorage plain + IndexedDB AES-GCM + PBKDF2 210k iter, premier audit `prompt-guardrail-auditor` PASS (PR #155, 18 avril 2026)
+- **Phase 7b 🔄 AI Tutor V1 (chaîne ADR-005)** — ✅ THI-109 · ✅ THI-110 · 🔜 THI-120 (scrubber Sentry, gate avant THI-111) → THI-111 (AiTutorPanel + providers + sanitizer) → THI-112 (onboarding AiKeySetup/AiConsentModal) → THI-113 (audit final) · THI-114 (Web Worker isolation V1.5 post-ship)
 
 ## Contenus narratifs — règle d'enrichissement
 - `CHANGELOG.md` et `STORY.md` à la racine : mettre à jour à chaque release majeure ou décision significative

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,7 @@
 # Terminal Learning — Plan de lancement public
 
 > Dernière mise à jour : 18 avril 2026
-> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 11 modules ✅, 65 leçons, 923 tests unitaires (903 pass + 20 RBAC skipped Phase 9) + 176 E2E — **Vision consolidée** : LTI-first (ADR-001), BYOK OpenRouter 4-tiers (ADR-002), TTFR KPI central (ADR-003), Classroom Composer UI (ADR-004), AI Tutor V1 décisions gelées (ADR-005 — stockage, rate-limit, guardrails), tuteur IA socratique dès A1, i18n FR/NL/EN — Architecture stratégique précédente (THI-35) : Terminal Sentinel (Phase 5.5) ✅, RBAC complet (Phase 7) ✅, Admin Panel (Phase 9), PWA avancée (Phase finale) — **Epic Web 2026 Compliance** (THI-96) : 6/8 sub-issues livrées (THI-97 → THI-102), reste Desktop a11y + CSS moderne 2026
+> Statut global : **Phase 5 EN COURS** — Curriculum Expansion : 11 modules ✅, 65 leçons, 955 tests unitaires (935 pass + 20 RBAC skipped Phase 9) + 176 E2E — **Vision consolidée** : LTI-first (ADR-001), BYOK OpenRouter 4-tiers (ADR-002), TTFR KPI central (ADR-003), Classroom Composer UI (ADR-004), AI Tutor V1 décisions gelées (ADR-005 — stockage, rate-limit, guardrails), tuteur IA socratique dès A1, i18n FR/NL/EN — Architecture stratégique précédente (THI-35) : Terminal Sentinel (Phase 5.5) ✅, RBAC complet (Phase 7) ✅, Admin Panel (Phase 9), PWA avancée (Phase finale) — **Epic Web 2026 Compliance** (THI-96) : 6/8 sub-issues livrées (THI-97 → THI-102), reste Desktop a11y + CSS moderne 2026 — **Phase 7b (AI Tutor V1)** : THI-115 ✅, THI-109 ✅, THI-110 ✅, 🔜 THI-120 (scrubber Sentry) avant THI-111
 
 ---
 
@@ -690,12 +690,13 @@ src/lib/ai/
 #### Séquence d'implémentation (ADR-005)
 
 1. ✅ Doc alignment + ADR-005 (PR #151 mergée — THI-115)
-2. ✅ Agent `prompt-guardrail-auditor` (THI-109 — cette PR)
-3. Key manager V1 — THI-110
-4. `AiTutorPanel` + fetch OpenRouter + system prompt + sanitizer/post-filter — THI-111
-5. Onboarding UX + Consent modal — THI-112
-6. Audit final security-auditor + prompt-guardrail-auditor → merge Phase 7b — THI-113
-7. 🔮 Web Worker isolation V1.5 post-ship — THI-114
+2. ✅ Agent `prompt-guardrail-auditor` (PR #153 mergée — THI-109)
+3. ✅ Key manager V1 — `src/lib/ai/keyManager.ts`, localStorage plain + IndexedDB AES-GCM + PBKDF2 210k iter, 32 tests, premier audit `prompt-guardrail-auditor` PASS (PR #155 mergée — THI-110)
+4. 🔜 Scrubber Sentry `beforeSend` (Authorization + champs `key`/`token`/`secret`/`auth`) — gate avant THI-111 — THI-120
+5. `AiTutorPanel` + fetch OpenRouter + system prompt + sanitizer/post-filter — THI-111
+6. Onboarding UX + Consent modal — THI-112
+7. Audit final security-auditor + prompt-guardrail-auditor → merge Phase 7b — THI-113
+8. 🔮 Web Worker isolation V1.5 post-ship — THI-114
 
 ---
 

--- a/docs/processes/next-session-plan.md
+++ b/docs/processes/next-session-plan.md
@@ -1,8 +1,8 @@
-# Next Session Plan — 19 avril 2026 (chaîne ADR-005 AI Tutor V1, step 3)
+# Next Session Plan — 20 avril 2026 (chaîne ADR-005 AI Tutor V1, gate avant THI-111)
 
 > Fichier lu automatiquement par `session-kickoff.md` étape 5.
 > À supprimer ou archiver une fois la chaîne ADR-005 close (post-merge THI-113).
-> Mis à jour : 18 avril 2026 après merge PR #153 (THI-109 Done).
+> Mis à jour : 18 avril 2026 après merge PR #155 (THI-110 Done).
 
 ---
 
@@ -11,9 +11,18 @@
 Session précédente (18 avril 2026) :
 - PR #151 mergée, THI-115 Done (doc alignment ADR-002 + ADR-005)
 - PR #152 mergée, THI-116 Done (sync CLAUDE.md + next-session-plan.md)
-- PR #153 mergée, **THI-109 Done** (agent `prompt-guardrail-auditor`, gate zéro ADR-005 — OWASP LLM Top 10, batterie injections, test à blanc ✅)
+- PR #153 mergée, THI-109 Done (agent `prompt-guardrail-auditor`)
+- PR #154 mergée, THI-117 Done (sync doc post-THI-109)
+- PR #155 mergée, **THI-110 Done** (key manager V1 — localStorage plain + IndexedDB AES-GCM + PBKDF2 210k, 32 tests, premier audit `prompt-guardrail-auditor` PASS)
 
-**Scope prochaine session** : démarrer **THI-110** (Key manager V1 — localStorage plain + opt-in IndexedDB Web Crypto). C'est la première ligne de code fonctionnel du Tuteur IA — l'agent `prompt-guardrail-auditor` est prêt à auditer dès ce step.
+**Findings ouverts en Backlog à partir de la session du 18 avril** :
+- **THI-118** (High) — perf regression LCP sur `/` (3.87s → 9.31s, ×2.4) — investigation à tête reposée
+- **THI-119** (Medium) — filtre Sentry `text/html` MIME type variant — quick win
+- **THI-120** (High) — scrubber Sentry `beforeSend` — **gate avant THI-111**
+
+**Scope prochaine session** : démarrer **THI-120** (scrubber Sentry), ensuite **THI-111** (AiTutorPanel + providers + sanitizer). Logique : THI-120 est léger, bloque THI-111, et doit être mergé avant pour qu'aucun fetch LLM ne fuite la clé via Sentry.
+
+Possibilité d'intercaler **THI-119** (quick win complémentaire, même zone de code `src/lib/sentry.ts`) — Thierry décide.
 
 ---
 
@@ -23,56 +32,60 @@ Exécuter `session-kickoff.md` étapes 1 à 7. Si signal rouge santé → **stop
 
 ---
 
-## Étape 2 — Démarrer THI-110 (key manager V1)
+## Étape 2 — Démarrer THI-120 (scrubber Sentry)
 
-**Issue** : [THI-110 — Key manager V1 (localStorage plain + opt-in Web Crypto)](https://linear.app/thierryvm/issue/THI-110)
+**Issue** : [THI-120 — Sentry — durcir beforeSend (scrubber Authorization + champs *key*/*token*/*auth*)](https://linear.app/thierryvm/issue/THI-120)
 
 ### Livrables
 
-- `src/lib/ai/keyManager.ts` avec API stable :
-  - `getApiKey(): Promise<string | null>` — lecture à la demande, jamais de cache global long-lived
-  - `setApiKey(key: string, opts?: { encrypt?: boolean; passphrase?: string }): Promise<void>`
-  - `forgetApiKey(): Promise<void>` — efface localStorage + IndexedDB + variables RAM
-  - `hasEncryptedKey(): Promise<boolean>` — true si l'utilisateur a opt-in au chiffrement
-- Implémentation V1 :
-  - **Défaut** : `localStorage` plain, warning visible à configurer côté UI (pas dans ce ticket)
-  - **Opt-in** : IndexedDB + Web Crypto AES-GCM, PBKDF2 ≥ 210 000 itérations, sel aléatoire par user, IV unique par opération
-- Détection auto du provider via préfixe de clé (`sk-or-v1-*`, `sk-ant-*`, `sk-*`, custom base URL) — exposée via `detectProvider(key: string)`
-- Tests unitaires Vitest :
-  - Round-trip set/get en mode plain
-  - Round-trip set/get en mode chiffré avec passphrase correcte
-  - Échec de get avec mauvaise passphrase (pas de crash, retourne null + log sanitisé)
-  - `forgetApiKey()` efface réellement les deux stores
-  - `detectProvider()` renvoie le bon tier pour chaque format
+- `src/lib/sentry.ts` `beforeSend` : scrubber générique avant le `return event` :
+  - `event.request.headers.Authorization` / `authorization` → `[REDACTED]`
+  - `event.extra` / `event.contexts` : tout champ dont le nom matche `/key|token|secret|auth/i` → `[REDACTED]`
+  - `event.breadcrumbs[].data` : idem
+
+- Test unitaire Vitest dans `src/test/sentry.test.ts` (nouveau fichier) :
+  - Mock d'un event Sentry avec `extra.apiKey = 'sk-ant-test'` → vérifie `'[REDACTED]'` après `beforeSend`
+  - Mock d'un event avec `request.headers.Authorization = 'Bearer sk-or-v1-test'` → vérifie `'[REDACTED]'`
+  - Mock d'un breadcrumb avec `data.token = '...'` → vérifie `'[REDACTED]'`
+  - Cas safe : un champ `userId` ne doit PAS être scrubé
 
 ### Critères de merge
 
 - CI verte (type-check + lint + test + build)
 - Sourcery OK (ou SKIPPED rate limit)
-- **Agent `prompt-guardrail-auditor` lancé** → doit maintenant détecter `keyManager.ts` et auditer les leakage surfaces (console.log, Sentry `beforeSend`, etc.)
-- Agent `security-auditor` complémentaire pour PBKDF2 iter count + CSP `connect-src` inchangé (pas de fetch dans ce ticket)
-- Branche : `feature/thi-110-key-manager-v1`
-- Passer THI-110 en **In Review** dès PR push, puis **Done** au merge
+- Agent `prompt-guardrail-auditor` clean sur `src/lib/sentry.ts` (scope étape 7 de l'agent)
+- Branche : `feature/thi-120-sentry-scrubber`
+- Passer THI-120 en **In Review** dès PR push, puis **Done** au merge
 
 ### Dépendances
 
-- THI-109 ✅ (prompt-guardrail-auditor créé)
+- THI-109 ✅ (agent guardrail existe)
+- THI-110 ✅ (premier audit a identifié ce gap)
 
 ### Débloque
 
-- THI-111 (AiTutorPanel + providers + system prompt + sanitizer)
-- THI-112 → THI-113 → merge Phase 7b
+- **THI-111** — AiTutorPanel + providers + system prompt + sanitizer (ne peut pas merger sans ce scrubber)
 
 ---
 
-## Étape 3 — Vérification finale
+## Étape 3 (optionnelle, si contexte frais) — Démarrer THI-119
 
-Après merge THI-110 :
+**Issue** : [THI-119 — Sentry filtrer text/html is not a valid JavaScript MIME type](https://linear.app/thierryvm/issue/THI-119)
 
-- [ ] THI-110 → Done dans Linear
-- [ ] `docs/plan.md` Phase 7b step 3 : ✅
-- [ ] Mémoire `project_ai_agent_byok.md` : séquence step 3 marquée "Done"
-- [ ] `CLAUDE.md` projet : THI-110 ajouté en ✅
+Quick win ~30 min — même fichier `src/lib/sentry.ts`, étendre le filtre stale chunk existant à 3 variants : `'text/html' is not a valid JavaScript MIME type`, `Failed to load module script`, `Expected a JavaScript module script but the server responded with a MIME type`.
+
+Intéressant d'enchaîner avec THI-120 (même zone de code, gain de contexte).
+
+---
+
+## Étape 4 — Vérification finale
+
+Après merge THI-120 (et éventuellement THI-119) :
+
+- [ ] THI-120 → Done dans Linear
+- [ ] `docs/plan.md` Phase 7b step 4 : ✅
+- [ ] Mémoire `project_ai_agent_byok.md` : ajouter note « scrubber Sentry en place »
+- [ ] `CLAUDE.md` projet : ajouter THI-120 en ✅
 - [ ] Mettre à jour ce fichier pour pointer sur THI-111
 - [ ] Demander à Thierry : démarrer THI-111 (plus gros ticket — AiTutorPanel + providers + sanitizer) ou pause ?
 
@@ -83,26 +96,34 @@ Après merge THI-110 :
 | ID | Titre | Statut 2026-04-18 | Priorité | Dépend de |
 |---|---|---|---|---|
 | THI-109 | Agent prompt-guardrail-auditor | ✅ Done (PR #153) | High | — |
-| THI-110 | Key manager V1 | 🔜 Next | High | THI-109 |
-| THI-111 | AiTutorPanel + providers + system prompt + sanitizer | Backlog | High | THI-110 |
+| THI-110 | Key manager V1 | ✅ Done (PR #155) | High | THI-109 |
+| THI-120 | Scrubber Sentry beforeSend | 🔜 Next | High | THI-110 (finding d'audit) |
+| THI-111 | AiTutorPanel + providers + system prompt + sanitizer | Backlog | High | THI-120 |
 | THI-112 | Onboarding IA — AiKeySetup + AiConsentModal | Backlog | Medium | THI-111 |
 | THI-113 | Audit final Tuteur IA | Backlog | High | THI-112 |
 | THI-114 | V1.5 — Web Worker isolation keyManager | Backlog | Low | THI-113 (post-ship) |
+
+### Tickets perf/ops ouverts en parallèle
+
+| ID | Titre | Statut | Priorité |
+|---|---|---|---|
+| THI-118 | Perf regression LCP sur `/` (3.87s → 9.31s) | Backlog | High |
+| THI-119 | Filtre Sentry `text/html` MIME type variant | Backlog | Medium |
 
 ---
 
 ## Mémoires prioritaires à recharger en début de session
 
-- `project_ai_agent_byok.md` — **source de vérité** ADR-002 + ADR-005 (séquence step 3 = THI-110)
+- `project_ai_agent_byok.md` — **source de vérité** ADR-002 + ADR-005 (séquence step 4 = THI-120)
 - `feedback_doc_alignment.md` — règle doc alignment systématique
 - `user_health_signals.md` — règle slow-down
 - `feedback_session_protocol.md` — règles opérationnelles
-- `reference_vercel_bypass.md` — secret bypass pour visual verification previews (pas nécessaire pour THI-110 — pas de changement UI)
+- `reference_vercel_bypass.md` — secret bypass pour visual verification previews (pas nécessaire pour THI-120 — pas de changement UI)
 
 ---
 
 ## Trigger d'activation
 
-Thierry dira probablement : **"ok, on démarre THI-110"**, **"suite du tuteur IA"**, ou **"enchaîne"**.
+Thierry dira probablement : **"ok, on démarre THI-120"**, **"suite du tuteur IA"**, ou **"enchaîne"**.
 
 → Répondre par l'exécution directe des étapes 1-2 ci-dessus. Demander confirmation avant : création de PR, push de branche, modification destructive.


### PR DESCRIPTION
## Summary

Doc-sync standard post-merge THI-110 (PR #155) — aligne plan.md / CLAUDE.md / next-session-plan.md avec l'état réel de la chaîne ADR-005.

- **CLAUDE.md** : THI-110 ✅ ajoutée + ligne Phase 7b réordonnée pour insérer THI-120 avant THI-111
- **docs/plan.md** : séquence d'implémentation passe à 8 étapes (step 3 ✅ THI-110 mergé, step 4 🔜 THI-120 scrubber Sentry, THI-111 devient step 5)
- **docs/processes/next-session-plan.md** : réécriture complète pointant sur THI-120 comme prochain gate avant THI-111 (spec complète scrubber `beforeSend` + cas de test), THI-119 en option step 3 (quick win même zone)

## Contexte

L'audit `prompt-guardrail-auditor` du premier PR THI-110 = **PASS**, mais finding W1 identifié : absence de scrubber générique dans `src/lib/sentry.ts` `beforeSend` → risque de fuite clé API via Sentry dès que THI-111 ajoute les fetch LLM. THI-120 créé (High priority) pour gate cette zone avant d'ouvrir THI-111.

## Test plan

- [ ] CI verte (type-check + lint + test + build)
- [ ] Aucun impact fonctionnel (doc uniquement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)