### PR TITLE
security(csp): implement nonce-based style-src with Fluid Compute

### DIFF
--- a/api/csp-nonce.ts
+++ b/api/csp-nonce.ts
@@ -1,6 +1,6 @@
-export const runtime = 'edge';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
-// Generate a cryptographically random nonce (32 hex chars)
 function generateNonce(): string {
   const buffer = crypto.getRandomValues(new Uint8Array(32));
   return Array.from(buffer)
@@ -8,23 +8,14 @@ function generateNonce(): string {
     .join('');
 }
 
-export default async function handler(req: Request) {
-  const nonce = generateNonce();
-  const url = new URL(req.url);
-
-  // Get origin for fetching index.html
-  const origin = url.protocol + '//' + url.host;
-  const indexUrl = new URL('/', origin);
-
+export default function handler(req: Request) {
   try {
-    // Fetch index.html from the static build
-    const indexRes = await fetch(indexUrl.toString(), {
-      headers: { 'Accept': 'text/html' },
-    });
+    const nonce = generateNonce();
 
-    if (!indexRes.ok) throw new Error('Failed to fetch index.html');
-
-    let html = await indexRes.text();
+    // Read the built index.html from the static output directory
+    // Vercel places the build output at .vercel/output/static/
+    const indexPath = join(process.cwd(), '.vercel/output/static/index.html');
+    let html = readFileSync(indexPath, 'utf-8');
 
     // Inject nonce meta tag before </head>
     html = html.replace(
@@ -32,36 +23,37 @@ export default async function handler(req: Request) {
       `<meta name="csp-nonce" content="${nonce}" /></head>`
     );
 
-    // Create response with injected HTML
-    const headers = new Headers({
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'public, max-age=0, must-revalidate',
-      'Content-Security-Policy': [
-        "default-src 'self'",
-        "script-src 'self' https://va.vercel-scripts.com https://vercel.live",
-        `style-src 'self' https://fonts.googleapis.com https://vercel.live 'nonce-${nonce}'`,
-        "img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live",
-        "font-src 'self' data: https://fonts.gstatic.com https://vercel.live",
-        "connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o1234.ingest.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://vercel.live",
-        "frame-src 'self' https://vercel.live",
-        "frame-ancestors 'none'",
-        "base-uri 'self'",
-        "form-action 'self'",
-        "upgrade-insecure-requests"
-      ].join('; '),
-      'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
-      'X-XSS-Protection': '0',
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-      'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=()',
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Resource-Policy': 'same-origin',
-      'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
-    });
+    const csp = [
+      "default-src 'self'",
+      `script-src 'self' https://va.vercel-scripts.com https://vercel.live 'nonce-${nonce}'`,
+      `style-src 'self' https://fonts.googleapis.com https://vercel.live 'nonce-${nonce}'`,
+      "img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live",
+      "font-src 'self' data: https://fonts.gstatic.com https://vercel.live",
+      "connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o1234.ingest.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://vercel.live",
+      "frame-src 'self' https://vercel.live",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "upgrade-insecure-requests"
+    ].join('; ');
 
-    return new Response(html, { headers });
-  } catch {
-    // Fallback: return error response
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Content-Security-Policy': csp,
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'X-XSS-Protection': '0',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+        'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=()',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+      },
+    });
+  } catch (error) {
     return new Response('Internal Server Error', { status: 500 });
   }
 }

--- a/api/csp-nonce.ts
+++ b/api/csp-nonce.ts
@@ -1,21 +1,31 @@
+import { randomBytes } from 'crypto';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
 function generateNonce(): string {
-  const buffer = crypto.getRandomValues(new Uint8Array(32));
+  const buffer = randomBytes(32);
   return Array.from(buffer)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
+}
+
+// Cache HTML template at module scope — read once at startup, reuse for all requests
+const indexPath = join(process.cwd(), '.vercel/output/static/index.html');
+let indexHtmlTemplate: string;
+
+try {
+  indexHtmlTemplate = readFileSync(indexPath, 'utf-8');
+} catch (err) {
+  console.error('CSP handler: failed to read index.html template at module load:', err instanceof Error ? err.message : String(err));
+  indexHtmlTemplate = '<!DOCTYPE html><html><head></head><body>Service Unavailable</body></html>';
 }
 
 export default function handler(req: Request) {
   try {
     const nonce = generateNonce();
 
-    // Read the built index.html from the static output directory
-    // Vercel places the build output at .vercel/output/static/
-    const indexPath = join(process.cwd(), '.vercel/output/static/index.html');
-    let html = readFileSync(indexPath, 'utf-8');
+    // Start from the cached template and inject nonce per-request
+    let html = indexHtmlTemplate;
 
     // Inject nonce meta tag before </head>
     html = html.replace(
@@ -54,6 +64,7 @@ export default function handler(req: Request) {
       },
     });
   } catch (error) {
+    console.error('CSP handler: request failed:', error instanceof Error ? error.message : String(error));
     return new Response('Internal Server Error', { status: 500 });
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,12 @@
 {
   "buildCommand": "npm install --legacy-peer-deps && npm run build",
-  "rewrites": [
-    { "source": "/((?!api|assets|manifest|favicon).*)", "destination": "/index.html" }
+  "routes": [
+    { "src": "/api/.*", "dest": "/api/$1", "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"] },
+    { "src": "/assets/.*", "dest": "/assets/$1" },
+    { "src": "/manifest.webmanifest", "dest": "/manifest.webmanifest" },
+    { "src": "/favicon.ico", "dest": "/favicon.ico" },
+    { "src": "/robots.txt", "dest": "/robots.txt" },
+    { "src": "/.*", "dest": "/api/csp-nonce" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary
- Replaces deferred approach with working Fluid Compute implementation
- Injects nonce into HTML meta tag and CSP header
- Avoids infinite loop by reading static index.html directly
- Routes all non-API/non-asset requests through csp-nonce handler
- CSP now includes nonces for both style-src and script-src

## Fixes
- THI-120/THI-123: CSP nonce injection was deferred, now implemented
- Removes problematic rewrite rule that caused infinite fetch loops

## Testing
- Build passes (npm run build)
- No credentials exposed
- CSP headers include nonce-based style protection

## Summary by Sourcery

Implémentation d’une gestion CSP basée sur un nonce pour les réponses HTML à l’aide d’une fonction Fluid Compute et durcissement de la CSP pour les scripts et les styles.

Nouvelles fonctionnalités :
- Ajout d’une politique Content-Security-Policy basée sur un nonce pour `script-src` et `style-src` sur les réponses HTML servies via le gestionnaire `csp-nonce`.

Corrections de bugs :
- Éviter les boucles de requêtes infinies en servant directement le `index.html` généré plutôt qu’en le récupérant de nouveau via les règles de routage.

Améliorations :
- Servir le fichier `index.html` statique précompilé depuis le répertoire de sortie Vercel dans le gestionnaire `csp-nonce` au lieu de dépendre d’une requête en edge runtime.
- Centraliser la construction de l’en-tête CSP dans le gestionnaire `csp-nonce` avec des en-têtes de sécurité cohérents pour les réponses HTML.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement nonce-based CSP handling for HTML responses using a Fluid Compute function and tighten CSP for scripts and styles.

New Features:
- Add nonce-based Content-Security-Policy for both script-src and style-src on HTML responses served via the csp-nonce handler.

Bug Fixes:
- Avoid infinite fetch loops by serving the built index.html directly instead of refetching it through routing rules.

Enhancements:
- Serve the prebuilt static index.html from the Vercel output directory in the csp-nonce handler instead of relying on an edge runtime fetch.
- Centralize CSP header construction in the csp-nonce handler with consistent security headers for HTML responses.

</details>