### PR TITLE
chore(agents): add YAML frontmatter to sustain-auditor agent

### DIFF
--- a/.claude/agents/sustain-auditor-spec.md
+++ b/.claude/agents/sustain-auditor-spec.md
@@ -1,3 +1,8 @@
+---
+name: sustain-auditor
+description: Quarterly sustainability health check for solo maintainer — document freshness, git pattern analysis (weekend/night commits, streaks), Sentry alert load, memory drift. Outputs 1-10 health score + warnings + recommendations. Trigger manual (comment) or scheduled quarterly.
+---
+
 # sustain-auditor Agent Specification
 
 **Version** : 1.0 (Phase THI-129)


### PR DESCRIPTION
## Problem

The agent file `.claude/agents/sustain-auditor-spec.md` was missing the YAML frontmatter required for Claude Code to load it as an invocable agent. Without `name` and `description` fields, Claude Code cannot list or invoke the agent — it was effectively a static spec file rather than a callable agent.

## Discovery

Found during the post-Haiku catastrophe agent quality audit (24-25 April 2026) when verifying that all 10 agents had proper frontmatter.

## Fix

Added the standard frontmatter:

```yaml
---
name: sustain-auditor
description: Quarterly sustainability health check for solo maintainer — document freshness, git pattern analysis (weekend/night commits, streaks), Sentry alert load, memory drift. Outputs 1-10 health score + warnings + recommendations. Trigger manual (comment) or scheduled quarterly.
---
```

## Test plan
- [x] No code/test impact (agent definition file only)
- [ ] CI verte
- [ ] After merge: sustain-auditor agent should be invocable from Claude Code session

## Summary by Sourcery

Nouvelles fonctionnalités :
- Définir les métadonnées de l’agent sustain-auditor avec un nom et une description dans le frontmatter YAML afin de le rendre appelable depuis Claude Code.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Define the sustain-auditor agent metadata with name and description in YAML frontmatter to make it callable from Claude Code.

</details>