### PR TITLE
docs(security): clarify dual SECURITY.md roles + sync findings post-1May audit

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,8 @@
 # Security Policy
 
+> **Public security policy** — vulnerability disclosure process and threat model for external researchers and users.
+> For internal audit reports, fresh `security-auditor` findings, and developer-facing remediation roadmap, see [`docs/SECURITY.md`](docs/SECURITY.md).
+
 ## Supported Versions
 
 | Version | Supported |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,9 @@
-# Security — Audit Report & Incident Log
+# Security — Audit Report & Internal Roadmap
 
-> **Last Updated:** 2026-05-01  
+> **Internal working doc** — fresh audit findings (`security-auditor` agent), feature-flag inventory, and remediation tracking with Linear issue refs (THI-XXX).
+> For the **public-facing security policy** (vulnerability disclosure process, supported versions, full threat model, public Incident Log including Incidents 006 + 007), see [`SECURITY.md`](../SECURITY.md) at the repo root.
+>
+> **Last Updated:** 2026-05-02
 > **Audited By:** `security-auditor` agent (OWASP Top 10 2021 + API Security Top 10 2023)
 
 ---
@@ -20,36 +23,36 @@
 
 ---
 
-### High Issues (Phase 9 Gates)
-1. **[H1] RLS Policy Drift**
-   - **Root Cause:** Migrations 010 and 011 both modify `institutions` SELECT policy
-   - **Migration 010:** `authenticated to select any institution`
-   - **Migration 011:** `role-based filtering (super_admin sees all, others see own)`
-   - **Issue:** If both policies coexist, 010 takes precedence (permissive), defeating 011's security
-   - **Resolution:** Query `pg_policies` on production to confirm current state; create migration 012 if both policies present
-   - **Phase:** Phase 9 (multi-tenancy hardening)
+### High Issues — Active
 
-2. **[H2-H6]** Other high-severity findings documented in security-auditor raw report
+1. **[H1] LTI launch endpoint accepts forged JWTs in prod** — ✅ Mitigated 2026-05-01 via `LTI_ENABLED` feature flag (THI-133, PR #169). Phase 7c will add the actual RS256 JWK validation and lift the gate.
+2. **[H2] LTI launch endpoint has no rate limiting** — 🔄 Backlog (extract sliding window from `api/sentry-tunnel.ts` to shared `api/_lib/rateLimit.ts`, apply to both endpoints).
+3. **[H3] Git history credential exposure** (`TerminalLearning2026!`) — 🔄 Accepted residual risk; `git filter-repo` requires force-push validation. Test users rotated via Supabase Admin API. See Incident-006 in [`/SECURITY.md`](../SECURITY.md).
 
----
+### High Issues — Resolved
 
-### Medium Issues (Phase 9 Backlog)
-- Key manager default encryption mode (use encrypted by default for THI-112)
-- CSP `connect-src` coverage for Sentry tunnel rate limiting
-- Session token storage validation
-- SSRF prevention on Sentry tunnel (already mitigated in THI-120)
+- **[H-RLS] RLS Policy Drift on `institutions` SELECT** — ✅ Resolved by migration 012 (drop permissive policy 010, keep restrictive 011). Verified on production.
 
 ---
 
-## Incident-006: Password Exposure in RBAC Test Kit
+### Medium Issues — Active (security-auditor 2026-05-01 findings)
 
-**Date:** 2026-04-21  
-**Discovered By:** security-auditor agent  
-**Impact:** Test users only (no production data)  
-**Response:**
-1. ✅ Rotated 5 test user passwords via Supabase Admin API
-2. ✅ Pre-commit hook strengthened (word boundary regex for password/secret patterns)
-3. 🔜 Git filter-repo (low priority — repo is public, exposure was test credentials)
+| # | Finding | Phase / Issue |
+|---|---------|---------------|
+| M1 | CSP `script-src` may need SHA-256 hashes for Vite inline scripts | Audit needed |
+| M2 | `vercel.live` in CSP applies to prod (preview-only intended) | Split CSP preview vs prod |
+| M3 | CORS LTI launch fixed to `terminallearning.dev` — verify against real LTI 1.3 flow | Phase 7c |
+| M4 | `keyManager.ts` defaults to plain localStorage (`encrypt: false`) | THI-112 (BYOK AiKeySetup) |
+| M5 | Migration 010 `institutions: select by role` — drift risk if 010→011→012 not applied in order | Phase 9 multi-tenancy |
+| M6 | Sentry scrubber only covers `type === 'event'` — `transaction`/`profile`/`check_in` ignored | THI-120 follow-up |
+
+> Full raw report archived in session memory + Linear THI-133/THI-134 issues. Re-run `security-auditor` agent for fresh findings before any release.
+
+---
+
+## Incident Log
+
+Public incident log lives in [`/SECURITY.md`](../SECURITY.md#incident-log) (Incidents 006 password exposure + 007 wrong-model session catastrophe). No duplication here to avoid drift.
 
 ---
 
@@ -67,15 +70,17 @@ Sensitive endpoints can be gated via Vercel environment variables. They default 
 
 ## Roadmap
 
-| Phase | Item | Owner | Status |
-|-------|------|-------|--------|
-| THI-133 | [H1] LTI launch endpoint forged-JWT gate | Security | ✅ 2026-05-01 (feature flag) |
-| Phase 7c | [H1 follow-up] Implement RS256 JWK validation in `verifyJwt()` then enable `LTI_ENABLED` | AI | 🔜 |
-| Phase 9 | [H1] Verify RLS policy state + create migration 012 if needed | Backend | 🔜 |
-| Phase 9 | [H1] Branch protection + code owner review (Vector 1) | Infra | 🔜 |
-| Phase 9 | [H1] Signed commits enforcement (Vector 2) | Infra | 🔜 |
-| THI-112 | [H2] Key manager encryption default (BYOK AiKeySetup) | AI | 🔜 |
-| THI-120 | [H5] Rate limiting test + Vercel KV migration | Infra | ✅ Phase 7b |
+| Phase | Item | Status |
+|-------|------|--------|
+| THI-133 | [H1] LTI forged-JWT gate (`LTI_ENABLED` feature flag) | ✅ 2026-05-01 (PR #169) |
+| THI-134 | LTI handler 500 cold-start fix (unblocks the 503 from the flag) | 🔄 In Progress (PR #170) |
+| Phase 7c | [H1 follow-up] RS256 JWK validation in `verifyJwt()` then enable `LTI_ENABLED` | 🔜 |
+| Backlog H2 | LTI launch endpoint rate limiting (shared module) | 🔜 |
+| Backlog H3 | Git history credential `git filter-repo` (force-push, accepted residual risk for now) | 🔜 |
+| Backlog M1-M6 | 6 medium findings (see table above) | 🔜 |
+| THI-112 | Key manager default encryption (`encrypt: true`) for AiKeySetup | 🔜 |
+| Phase 9 | Branch protection + code owner review + signed commits | 🔜 |
+| THI-120 | Sentry scrubber double-layer (server + client) | ✅ Phase 7b |
 
 ---
 


### PR DESCRIPTION
## Summary

The repo has two `SECURITY.md` files with **distinct roles** that were drifting out of sync. This PR formalizes the boundary, adds cross-links, and updates the internal doc to reflect the fresh `security-auditor` run from 1 May 2026.

## Why two files? Both stay.

| File | Role | Audience |
|------|------|----------|
| `/SECURITY.md` (root) | Public security policy (GitHub convention) | External researchers, vulnerability disclosure, GitHub Security tab |
| `/docs/SECURITY.md` | Internal working doc — fresh findings, env vars, Linear refs | Developers (Thierry, Claude, contributors) |

Cross-links added in both directions to prevent future drift.

## Changes to internal doc

- Replaced stale `[H1] RLS Policy Drift` (resolved via migration 012) with current 3 HIGH findings (H1 LTI gate ✅ THI-133, H2 LTI rate limit, H3 git history)
- Replaced placeholder Medium Issues list with actual 6 M-findings from 1 May audit (M1 CSP hashes, M2 vercel.live, M3 LTI CORS, M4 keyManager, M5 RLS order, M6 Sentry scrubber types)
- Removed duplicate Incident-006 section (now linked to /SECURITY.md — single source of truth)
- Roadmap table updated with current status

## Test plan

- [x] `npx vitest run` — 1002 pass, 0 fail
- [x] `npm run build` — clean
- [ ] Sourcery green
- [ ] Vercel preview SUCCESS
- [ ] No code change so no UI/UX regression expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarifier les rôles distincts de la politique de sécurité publique (`SECURITY`) et du document d’audit de sécurité interne, et synchroniser la documentation de sécurité interne (`SECURITY`) avec les dernières conclusions d’audit du 1er mai 2026.

Documentation :
- Mettre à jour `docs/SECURITY.md` pour le présenter explicitement comme un document de travail interne contenant les dernières conclusions d’audit, les feature flags et le suivi des actions correctives, et le lier au fichier public `SECURITY.md` à la racine.
- Documenter les constats de sécurité actuels de sévérité élevée et moyenne provenant de l’exécution du security-auditor du 1er mai 2026, y compris les statuts et les tâches associées, et supprimer les détails d’incidents dupliqués qui sont désormais gérés par le fichier de politique publique.
- Actualiser le tableau de la feuille de route de sécurité interne pour refléter les tâches de remédiation terminées, en cours et en backlog, liées à des tickets et phases spécifiques.
- Annoter le `SECURITY.md` à la racine comme politique de sécurité publique et ajouter un pointeur vers le `docs/SECURITY.md` interne pour les détails d’audit destinés aux développeurs.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the distinct roles of the public SECURITY policy and the internal security audit doc, and synchronize the internal SECURITY documentation with the latest 1 May 2026 audit findings.

Documentation:
- Update docs/SECURITY.md to explicitly position it as an internal working document with fresh audit findings, feature flags, and remediation tracking, and cross-link it with the public root SECURITY.md.
- Document current high- and medium-severity security findings from the 1 May 2026 security-auditor run, including statuses and associated work items, and remove duplicated incident details now owned by the public policy file.
- Refresh the internal security roadmap table to reflect completed, in-progress, and backlog remediation tasks tied to specific tickets and phases.
- Annotate the root SECURITY.md as the public-facing security policy and add a pointer to the internal docs/SECURITY.md for developer-focused audit details.

</details>