### PR TITLE
security(csp): remove vercel.live from CSP (THI-137)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -50,7 +50,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'sha256-DBnj1gBulFTJpTRw4pojS1qphQFPUqgyWUYoeimJiog=' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o4511149685080064.ingest.de.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors https://*.instructure.com https://*.moodlecloud.com https://*.smartschool.be; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'sha256-DBnj1gBulFTJpTRw4pojS1qphQFPUqgyWUYoeimJiog=' https://fonts.googleapis.com; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o4511149685080064.ingest.de.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com; frame-src 'self'; frame-ancestors https://*.instructure.com https://*.moodlecloud.com https://*.smartschool.be; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",
@@ -71,7 +71,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vercel.live; style-src 'self' 'sha256-DBnj1gBulFTJpTRw4pojS1qphQFPUqgyWUYoeimJiog=' https://fonts.googleapis.com https://vercel.live; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://vercel.live; font-src 'self' data: https://fonts.gstatic.com https://vercel.live; connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o4511149685080064.ingest.de.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://vercel.live; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'sha256-DBnj1gBulFTJpTRw4pojS1qphQFPUqgyWUYoeimJiog=' https://fonts.googleapis.com; img-src 'self' data: https://avatars.githubusercontent.com https://lh3.googleusercontent.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://vitals.vercel-insights.com https://jdnukbpkjyyyjpuwgxhv.supabase.co https://o4511149685080064.ingest.de.sentry.io https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com; frame-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Closes [THI-137](https://linear.app/thierryvm/issue/THI-137). Resolves M2 from the 1 May `security-auditor` audit.

## Problem
`vercel.live` was allowed in 5 CSP directives (`script-src`, `style-src`, `font-src`, `connect-src`, `frame-src`) on **every route, including production**. The domain only serves the Vercel Live Feedback widget on previews — verified that prod (`terminallearning.dev`) has 0 console errors and never loads it. The inclusion was therefore an unused permission unnecessarily widening the production attack surface (a compromise of vercel.live infra → script injection into prod).

## Trade-off
The Vercel Comments widget on previews will no longer load. Accepted because:
1. The widget already produces 6 unfixable CSP errors on preview (its inline styles aren't covered by our SHA-256 hash policy)
2. Thierry's preview validation = Brave + Lighthouse autonome, the widget isn't part of the loop
3. PR comments work fine on GitHub

If the widget becomes needed: migrate `vercel.json` → `vercel.ts` and gate `vercel.live` behind `deploymentEnv === 'preview'`. Deferred to a dedicated session post-deadline.

## Test plan
- [x] 1029 tests / 0 fail
- [x] Build clean
- [x] No test was checking vercel.live presence
- [ ] CI green
- [ ] Vercel preview SUCCESS
- [ ] Brave preview: no CSP errors from feedback.js (those should disappear)
- [ ] Prod after merge: no behavior change (widget wasn't loaded there anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorations :
- Supprimer `vercel.live` des directives CSP dans `vercel.json` afin de réduire la surface d’attaque en production.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove vercel.live from CSP directives in vercel.json to reduce production attack surface.

</details>