### PR TITLE
chore(claude.md): mandatory `gh pr list` at session shutdown (lesson from 2 May incident)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 2. `git status` + `git log --oneline -5` → état de la branche courante
 3. Lire l'issue Linear active avant d'écrire la moindre ligne
 
+### Fin de chaque session — récap obligatoire avant "stop"
+1. ✅ `git status` clean (rien d'uncommit ou stagé sans raison documentée)
+2. ✅ `gh pr list --state open` → **lister TOUTES les PRs ouvertes**, pas seulement celles de la session
+3. Pour chaque PR ouverte > 7 jours : la mentionner explicitement avec date + statut CI/Sourcery/Vercel + action attendue (validation utilisateur, merge, etc.)
+4. Distinguer dans le récap : "PRs livrées cette session" / "PRs externes en attente" / "Branches orphelines"
+5. **Mot interdit** : "rien d'orphelin" sans `gh pr list` au préalable. Le scope d'un récap shutdown est le **projet entier**, pas la session courante. (Incident 2 mai 2026 — #149/#150 oubliées 14 jours, leçon documentée dans `memory/feedback_pr_inventory_blind_spot.md`.)
+
 ### Avant toute modification de `curriculum.ts`
 - Invoquer l'agent **`curriculum-validator`** → analyser le rapport, corriger les CRITICAL avant de continuer
 


### PR DESCRIPTION
## Why

On 2 May 2026, after a productive 11-PR security sprint, the session shutdown recap declared "rien d'orphelin" — but PRs #149 (THI-108 curriculum merge-strategies) and #150 (chore agents) had been open for **14 days** awaiting visual validation, with green CI/Sourcery/Vercel. The next session caught this via `linear-sync`, but a shutdown filet shouldn't depend on the next session catching the previous session's miss.

Thierry's feedback: "tu dois en tirer des leçons et améliorer tes process de fin de session et ta mémoire, ainsi que tout fichiers qui auraient pû t'éviter ces erreurs".

## Change

New rule in `CLAUDE.md` — "Fin de chaque session — récap obligatoire avant 'stop'":
1. `git status` clean
2. **`gh pr list --state open`** mandatory (covers ALL open PRs, not session-scoped)
3. PRs > 7 days → explicit mention with date + CI/Sourcery/Vercel verdict + expected action
4. Recap distinguishes: "PRs livrées cette session" / "PRs externes en attente" / "Branches orphelines"
5. The phrase "rien d'orphelin" is forbidden without a prior `gh pr list`

## Companion memory updates (in ~/.claude, not tracked by Git)
- `session_shutdown_process.md` — new "Phase 1 bis: Inventaire PRs ouvertes"
- `feedback_pr_inventory_blind_spot.md` — incident + lesson
- `MEMORY.md` — index updated

## Test plan
- [x] CLAUDE.md updated (+7 lines, only addition)
- [ ] CI green
- [ ] Sourcery green
- [ ] Future shutdown recaps explicitly list all open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)