### PR TITLE
chore(security-auditor): add Vercel posture audit section

### DIFF
--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -307,6 +307,48 @@ WARNING si des actions utilisent des tags mutables sans SHA pin.
 
 ---
 
+## Vercel posture audit (ajouté 2 mai 2026 — incident bypass forensic)
+
+**Contexte** : le 2 mai 2026, un event Vercel `project-automation-bypass` est apparu à 16:53 UTC sans action explicite de Thierry. Investigation a révélé 8+ tokens "An MCP client" actifs/révoqués sur le compte ces derniers jours, sans tracabilité claire. Hypothèse retenue : MCP Vercel client (autre session Claude ou Cowork) génère des tokens éphémères qui peuvent toucher au bypass via side-effect d'autres opérations.
+
+### Audit a effectuer (necessite VERCEL_TOKEN en variable d'environnement de session)
+
+```bash
+TOKEN="$VERCEL_TOKEN"  # provided by user, never hardcoded
+PROJECT_ID="prj_mfBbwmor5DhN57SEasB1RtYAFE5m"
+```
+
+### Tokens actifs sur le compte
+- `GET /v3/user/tokens` → liste complete des access tokens
+- Pour chaque token : verifier `name`, `createdAt`, `activeAt`, `lastUsedAt`
+- WARNING si > 3 tokens "An MCP client" actifs simultanement
+- WARNING si un token "Never expires" n'a pas de label clair (ex: "Vercel Dashboard from X" est legitime, mais un token sans nom = drift)
+- CRITICAL si un token ancien > 30 jours est encore actif sans usage tracable
+
+### Project events
+- `GET /v3/events?projectId=$PROJECT_ID&limit=30` → audit log
+- Filtrer sur `type=project-automation-bypass`, `type=token-created`, `type=token-revoked`
+- WARNING si un event `project-automation-bypass` n'est pas correle a une session Claude tracee (memoire `reference_vercel_bypass.md`)
+
+### Bypass Deployment Protection
+- `GET /v9/projects/$PROJECT_ID` → champ `protectionBypass`
+- WARNING si > 1 entree active simultanement (rotation incomplete)
+- WARNING si l'entree active n'est pas la meme que celle stockee dans `.secrets/vercel-bypass.txt`
+- CRITICAL si le secret stocke en local fait HTTP 401 alors que la liste API montre une entree active (drift confirme)
+
+### Procedure stricte navigation Chrome DevTools (memoire `reference_vercel_bypass.md`)
+- Toute navigation Chrome MCP avec `?x-vercel-protection-bypass=` = max 1 par session par hostname
+- Tout token API Vercel cree via UI Web (Chrome MCP) = consider "potentiellement expose" (capture DOM dans accessibility tree) → 2eme rotation manuelle a planifier
+- WARNING si la session courante a fait > 1 navigation avec query param bypass
+- INFO si un token a ete cree via UI Web pendant la session sans 2eme rotation programmee
+
+### Recommendations
+- [R1] Routine `schedule` hebdomadaire : regeneration du bypass via API REST (seulement si on identifie un mecanisme propre — aujourd'hui le secret reste expose en URL au moins une fois)
+- [R2] Audit MCP clients : si plus de 5 tokens "An MCP client" sur 30j → investiguer quelle integration les genere (probablement plugin Vercel MCP officiel)
+- [R3] Renommer `.secrets/vercel-bypass.txt` (qui contient l'access token) en `.secrets/vercel-token.txt` pour distinguer du bypass Deployment Protection
+
+---
+
 ## Format de rapport obligatoire
 
 SECURITY AUDIT REPORT — Terminal Learning


### PR DESCRIPTION
## Summary

Renforce l'agent `security-auditor` avec une section "Vercel posture audit" suite à l'investigation forensic du 2 mai après-midi.

## Contexte — incident bypass

Pendant la session de validation visuelle PR #149, le bypass Deployment Protection avait été noté comme exposé en URL (mémoire `reference_vercel_bypass.md`, discipline acceptée le 25 avril). En investiguant les rotations, découverte :

1. **Un event Vercel `project-automation-bypass` à 16:53 UTC** (2 mai) sans action explicite de Thierry → bypass `ItNg…LW4Q` révoqué automatiquement, nouveau `ICuS…p4bO` créé.
2. **8+ tokens "An MCP client"** actifs/révoqués sur le compte ces derniers jours, sans traçabilité claire.
3. **Hypothèse retenue** : un MCP Vercel client (autre session Claude Code ou Cowork active sur Ankora/SynapseHub) génère des tokens éphémères qui peuvent toucher au bypass via side-effect d'autres opérations.

L'agent `security-auditor` n'avait pas de section dédiée à cet aspect du compte Vercel — il auditait l'app mais pas l'infra de gestion. Cette PR comble le gap.

## Couverture ajoutée

- **Tokens actifs** : `GET /v3/user/tokens` → flag les MCP non répertoriés, les "Never expires" sans label, les > 30 jours sans usage
- **Project events** : `GET /v3/events` → détecte les `project-automation-bypass` non corrélés à une session Claude tracée
- **Bypass Deployment Protection** : drift détection entre entrée API active et secret stocké en local
- **Procédure stricte navigation Chrome DevTools** : max 1 navigation avec query param bypass par session
- **WARN explicite** : token API créé via UI Web pendant session MCP = capture DOM possible → 2ème rotation manuelle obligatoire
- **3 recommandations structurelles** : schedule régénération bypass, audit MCP clients, renommage `.secrets/vercel-bypass.txt` (mal nommé)

## Test plan

- [x] Diff = 1 fichier (`.claude/agents/security-auditor.md`) +42 lignes
- [x] Pas de code applicatif touché
- [ ] CI verte (uniquement doc agent, pas de risque)
- [ ] Au prochain `security-auditor` invocation, l'agent vérifie la section Vercel posture

## Hors scope

- Implémentation d'une routine `schedule` hebdo régénération bypass → à voir la prochaine session si Thierry valide
- Renommage `.secrets/vercel-bypass.txt` → `.secrets/vercel-token.txt` → ticket Linear à créer
- 2ème rotation manuelle du token vcp_3zDw…oq2 (exposé dans la conversation Claude pendant la création via UI) → à faire par Thierry, sans Claude/MCP actif sur la page

## Résumé par Sourcery

Étendre la spécification de l’agent security-auditor avec une nouvelle section d’audit de posture Vercel couvrant les contrôles de sécurité au niveau du compte et du projet à la suite d’un incident de contournement.

Documentation :
- Documenter les étapes de revue des jetons de compte Vercel et des journaux d’audit, y compris la détection de jetons générés via MCP suspects et d’événements de contournement.
- Décrire les vérifications de dérive de configuration de contournement de Deployment Protection entre l’API Vercel et les secrets locaux.
- Ajouter des consignes procédurales pour l’utilisation sécurisée de Chrome DevTools avec des URL de contournement Vercel et des recommandations structurelles pour la rotation des jetons et l’audit des clients MCP.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the security-auditor agent specification with a new Vercel posture audit section covering account- and project-level security checks following a bypass incident.

Documentation:
- Document Vercel account token and audit-log review steps, including detection of suspicious MCP-generated tokens and bypass events.
- Describe checks for Deployment Protection bypass configuration drift between Vercel API and local secrets.
- Add procedural guidance for safe use of Chrome DevTools with Vercel bypass URLs and structural recommendations for token rotation and MCP client auditing.

</details>