### PR TITLE
chore: address Sourcery review on PR #185 (agents README)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -2,6 +2,7 @@
 
 > Index et guide d'usage des agents internes du projet.
 > **Dernière mise à jour** : 2 mai 2026
+> ⚠️ **Maintenance** : ce champ "Dernière mise à jour" doit être bumpé à chaque ajout/modification d'agent (cf. section "Convention — ajouter un nouvel agent").
 
 Cet index liste les **11 agents** spécialisés du projet, **quand les invoquer**, et **pourquoi ils ont été créés**. Il complète le frontmatter individuel de chaque fichier `.md` en apportant une vue d'ensemble que les frontmatters ne peuvent pas donner.
 
@@ -22,8 +23,8 @@ Cet index liste les **11 agents** spécialisés du projet, **quand les invoquer*
 | [`prompt-guardrail-auditor`](prompt-guardrail-auditor.md) | Haiku | ❌ | Avant PR `src/lib/ai/*` ou `src/app/components/ai/*` | ✅ CRITICAL |
 | [`route-attack-auditor`](route-attack-auditor.md) | Sonnet | ❌ | Avant PR `api/*` ou nouvel endpoint | ✅ verdict release-ready |
 | [`vercel-firewall-auditor`](vercel-firewall-auditor.md) | Sonnet | ❌ | Avant release majeure ou modif firewall | ⚠️ WARN si rules cassées |
-| [`rbac-flow-tester`](rbac-flow-tester.md) | (default) | ❌ | Avant chaque release Phase 9+ | ✅ pass/fail |
-| [`sustain-auditor-spec`](sustain-auditor-spec.md) | (spec) | ❌ scheduled trimestriel | À la demande | ⚠️ score 1-10 |
+| [`rbac-flow-tester`](rbac-flow-tester.md) | Haiku | ❌ | Avant chaque release Phase 9+ | ✅ pass/fail |
+| [`sustain-auditor-spec`](sustain-auditor-spec.md) | Haiku (spec, non instanciée) | ❌ scheduled trimestriel (à instancier) | À la demande (manuel) | ⚠️ score 1-10 |
 
 ---
 
@@ -60,7 +61,10 @@ rbac-flow-tester  # Si Phase 9+ activée
 ### 4. Trimestriellement (santé du projet long-terme)
 
 ```bash
-sustain-auditor  # Manuel ou scheduled — voir spec
+# ⚠️ NOTE: sustain-auditor est actuellement une spec (sustain-auditor-spec.md),
+# pas un agent invocable. Voir fiche détaillée plus bas pour le statut.
+# Tant que pas instancié → audit manuel par lecture de la spec.
+sustain-auditor  # Quand l'agent sera instancié à partir de la spec
 ```
 
 ---
@@ -89,7 +93,7 @@ sustain-auditor  # Manuel ou scheduled — voir spec
 ### `content-auditor` — Audit pédagogique global
 
 **Modèle** : Haiku
-**Créé** : avril 2026 (THI-45) — coverage env, cohérence curriculum↔terminalEngine↔tests, validité liens externes (WebFetch), cohérence prérequis, qualité `validate()`. Long à exécuter (~5 min).
+**Créé** : avril 2026 (THI-45) — coverage env, cohérence curriculum↔terminalEngine↔tests, validité des liens externes (WebFetch), cohérence prérequis, qualité `validate()`. Long à exécuter (~5 min).
 **Quand l'invoquer** : avant releases majeures uniquement, pas à chaque PR.
 
 ### `security-auditor` — OWASP black-hat
@@ -125,8 +129,8 @@ sustain-auditor  # Manuel ou scheduled — voir spec
 
 ### `rbac-flow-tester` — Vérification flow RBAC
 
-**Modèle** : (default — non spécifié)
-**Créé** : avril 2026 — vérifie le flow complet RBAC pour les 5 test users via Supabase REST API. Invoke avant chaque release Phase 9+. Confirme login + role assignment + RLS isolation intacts.
+**Modèle** : Haiku (pass/fail structuré, pas de judgment — frontmatter complété PR #186)
+**Créé** : avril 2026 — vérifie le flow complet RBAC pour les 5 test users via Supabase REST API. À invoquer avant chaque release Phase 9+. Confirme login + role assignment + RLS isolation intacts.
 **Lié** : THI-37 (RBAC complet, PR #92).
 
 ### `sustain-auditor-spec` — Santé du mainteneur solo
@@ -153,6 +157,7 @@ sustain-auditor  # Manuel ou scheduled — voir spec
 3. **Ajouter une fiche détaillée** dans la section "Fiches détaillées" (modèle, créé, contexte, lié)
 4. Si auto-trigger : mettre à jour `CLAUDE.md` projet section "Protocole de session"
 5. Si bloquant merge : mettre à jour `feedback_session_protocol.md` (mémoire) section "Avant toute PR ..."
+6. **Bumper le champ "Dernière mise à jour"** au tout début de ce README (ligne 4) avec la date du jour (format `JJ mois AAAA`)
 
 ## Convention — modèle Haiku vs Sonnet
 

--- a/.claude/agents/rbac-flow-tester.md
+++ b/.claude/agents/rbac-flow-tester.md
@@ -2,6 +2,7 @@
 name: rbac-flow-tester
 description: Verifies the complete RBAC role flow for all 5 test users via Supabase REST API. Invoke before each Phase 9+ release to confirm login, role assignment, and RLS isolation are intact. Returns a structured pass/fail report.
 tools: Bash, Read
+model: haiku
 ---
 
 You are the **RBAC Flow Tester** for Terminal Learning.


### PR DESCRIPTION
## Summary

Adresse les **5 commentaires Sourcery** post-merge sur PR #185 (3 overall + 2 individual).

### Overall 1 — `sustain-auditor` confusing
Section "Trimestriellement" + matrice clarifiées : `sustain-auditor` est actuellement une **spec non instanciée** (`sustain-auditor-spec.md`), pas un agent invocable. Tant que pas instancié → audit manuel par lecture de la spec.

### Overall 2 — `rbac-flow-tester` modèle `(default)` flou
- `rbac-flow-tester.md` frontmatter : ajout `model: haiku` (cause root)
- README matrice + fiche : `(default — non spécifié)` → `Haiku` (cohérent convention pass/fail structuré → Haiku)

### Overall 3 — date hard-codée risque drift
- Note ⚠️ **Maintenance** ajoutée dans l'en-tête
- Convention "ajouter un nouvel agent" : étape 6 explicite "Bumper le champ Dernière mise à jour"

### Individual 1 — typo
"validité liens externes" → "validité des liens externes"

### Individual 2 — anglais en français
"Invoke avant chaque release" → "À invoquer avant chaque release"

## Test plan
- [x] `git diff --stat` = 2 fichiers (README + rbac-flow-tester frontmatter), +12/-6
- [x] Pas de code applicatif touché
- [ ] CI verte (uniquement docs/agents)
- [ ] Sourcery clean

## Note méta

Cohérent avec la discipline Sourcery établie aujourd'hui (PR #184 follow-up sur PRs #182/#183). 5 PRs Sourcery follow-up traitées dans la même session = zéro dette technique en sortant.

## Summary by Sourcery

Clarifier la documentation pour les agents internes, en particulier `rbac-flow-tester` et `sustain-auditor`, et mettre à jour les conventions de maintenance dans le README des agents.

Documentation :
- Documenter `rbac-flow-tester` comme utilisant le modèle Haiku à la fois dans la matrice et dans la section détaillée, et aligner le champ `model` du frontmatter.
- Préciser que `sustain-auditor` est actuellement une spécification non instanciée nécessitant des audits manuels tant qu’il n’est pas instancié, et ajuster en conséquence sa matrice et ses notes d’utilisation.
- Corriger de légers problèmes de formulation en français dans le README des agents, notamment le libellé concernant la validité des liens externes et la phrase d’invocation de release.
- Ajouter une note de maintenance et une convention explicite pour mettre à jour la date « Dernière mise à jour » du README à chaque ajout ou modification d’agents.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation for internal agents, particularly rbac-flow-tester and sustain-auditor, and update maintenance conventions in the agents README.

Documentation:
- Document rbac-flow-tester as using the Haiku model in both the matrix and detailed section, and align its frontmatter model field.
- Clarify that sustain-auditor is currently an uninstantiated spec requiring manual audits until instantiated, and adjust its matrix and usage notes accordingly.
- Fix minor French phrasing issues in the agents README, including external link validity wording and the release invocation sentence.
- Add a maintenance note and explicit convention to bump the README "Dernière mise à jour" date whenever agents are added or modified.

</details>