### PR TITLE
chore: address Sourcery typo on PR #186 — long-terme → long terme

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -58,7 +58,7 @@ route-attack-auditor
 rbac-flow-tester  # Si Phase 9+ activée
 ```
 
-### 4. Trimestriellement (santé du projet long-terme)
+### 4. Trimestriellement (santé du projet long terme)
 
 ```bash
 # ⚠️ NOTE: sustain-auditor est actuellement une spec (sustain-auditor-spec.md),


### PR DESCRIPTION
Single typo fix flagged by Sourcery on PR #186: 'long-terme' → 'long terme' (usage standard sans trait d'union).

1 ligne changée, doc only, no risk.

Cohérent avec la discipline Sourcery établie aujourd'hui — on traite tous les commentaires avant de fermer la session.

## Summary by Sourcery

Documentation :
- Corriger une faute de formulation en français dans le titre de la section README des agents concernant la santé des projets à long terme.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct a French wording typo in the agents README section title regarding long-term project health.

</details>