### PR TITLE
fix(mobile): trigger AI tutor + scroll-to-top respect iOS safe-area (THI-147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 
 ---
 
+## Fix safe-area iPhone PWA — trigger AI tutor + scroll-to-top landing
+*4 mai 2026 soir · Mobile · THI-147 · mini-PR follow-up THI-111*
+
+**Le défi :** Test post-merge THI-111 sur iPhone PWA standalone : le trigger ✨ AI tutor n'est pas accessible. Hypothèse initiale @cowork : « parent overflow-y-auto + transform brisant fixed ». Diagnostic Chrome DevTools MCP a réfuté empiriquement (`breakingAncestorsCount: 0`, aucun ancêtre avec `transform`/`filter`/`contain`/`will-change`). Vraie cause confirmée : `bottom-4` (16px) passe sous le home indicator iPhone (~34px `safe-area-inset-bottom` en PWA standalone) — pattern WebKit classique documenté Apple HIG.
+
+**Ce qui a été livré :**
+- `src/app/components/ai/AiTutorPanel.tsx` — trigger FAB : `bottom-4` → `bottom-[max(1rem,env(safe-area-inset-bottom))]`
+- `src/app/components/Landing.tsx` — bouton scroll-to-top de la landing : même incohérence avec `MarkdownPage` et `PrivacyPolicy` qui avaient déjà le pattern correct → fixé en bonus de cohérence (`bottom-6` → `bottom-[max(1.5rem,env(safe-area-inset-bottom))]`)
+
+**Le `max()` garantit aucune régression :** desktop, Android, Safari mobile non-PWA → 1rem/1.5rem identique au comportement actuel. iPhone PWA standalone → 34px au-dessus du home indicator. Mode landscape Dynamic Island → safe-area-inset-bottom adapté automatiquement.
+
+**Validation :**
+- 1268/1268 tests verts (1 nouveau test `resetRateCounter` post-PR #188)
+- Type-check + lint clean
+- Risque très faible (1 ligne CSS modifiée par fichier, max() préserve comportement existant)
+- Validation empirique @thierry post-merge : réinstaller PWA iPhone → vérifier trigger ✨ visible au-dessus du home indicator
+
+**Convergence cross-projet :** pattern identique au sprint Mobile Recovery Ankora (mêmes patterns iOS WebKit). Audit transversal validé par @cowork.
+
+---
+
 ## Tuteur IA V1 (BYOK) — 4 providers + sanitizer + panel + 287 tests + validation live 3/4
 *4 mai 2026 · Phase 7b · ADR-002 + ADR-005 · PR #188*
 

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -583,7 +583,7 @@ export function Landing() {
           size="icon-round"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           aria-label="Retour en haut"
-          className="fixed bottom-6 right-6 z-50"
+          className="fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-6 z-50"
         >
           <ArrowUp size={18} />
         </Button>

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -167,7 +167,10 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
         aria-label="Ouvrir le tuteur IA (Ctrl+I)"
         aria-expanded={open}
         aria-controls="ai-tutor-panel"
-        className="fixed bottom-4 right-20 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white opacity-80 shadow-md ring-1 ring-black/30 transition hover:opacity-100 hover:bg-[var(--github-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 md:h-12 md:w-12"
+        // bottom uses max(1rem, env(safe-area-inset-bottom)) so the FAB sits
+        // above the iPhone home indicator in PWA standalone mode (THI-147).
+        // The pattern matches MarkdownPage and PrivacyPolicy already-fixed FABs.
+        className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-20 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white opacity-80 shadow-md ring-1 ring-black/30 transition hover:opacity-100 hover:bg-[var(--github-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 md:h-12 md:w-12"
       >
         <Sparkles size={20} strokeWidth={2} aria-hidden="true" />
       </button>


### PR DESCRIPTION
## Summary

Fix safe-area-inset-bottom sur 2 FABs (`fixed bottom-*`) qui étaient invisibles sur **iPhone PWA standalone** parce qu'ils passaient sous le home indicator (~34 px) avec leur position `bottom-4`/`bottom-6` (16/24 px).

## Diagnostic empirique (Chrome DevTools MCP)

Hypothèse initiale @cowork « parent `overflow-y-auto` + `transform` brisant `position: fixed` » → **réfutée** :

```json
{
  "btnPosition": "fixed",
  "btnZIndex": "40",
  "btnRect": {"x":376,"y":792,"w":44,"h":44,"bottom":836,"right":420},
  "btnVisible": true,
  "breakingAncestorsCount": 0,
  "breakers": []
}
```

Aucun ancêtre n'a `transform` / `filter` / `contain` / `will-change`. Le bouton est computed à la bonne position. Le bug n'est PAS dans le DOM web — il est dans le **safe-area-inset-bottom** non honoré.

## Vraie cause — pattern WebKit classique

`bottom-4` = 16 px → sous le home indicator iPhone X+ en mode PWA standalone (`safe-area-inset-bottom` ≈ 34 px). Pattern documenté Apple HIG, présent dans la checklist `mobile-ios-auditor` Ankora (Section 2 point 7 + Section 8 point 31). Convergence cross-projet validée @cowork.

## Changes

### `src/app/components/ai/AiTutorPanel.tsx` — trigger ✨ AI tutor (le bug)

```diff
-className="fixed bottom-4 right-20 z-40 ..."
+className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-20 z-40 ..."
```

### `src/app/components/Landing.tsx` — scroll-to-top de la landing (bonus cohérence)

`MarkdownPage.tsx:214` et `PrivacyPolicy.tsx:184` utilisent déjà ce pattern. Landing était la dernière incohérence du projet.

```diff
-className="fixed bottom-6 right-6 z-50"
+className="fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-6 z-50"
```

## Risque

**Très faible.** `max()` préserve comportement actuel partout :

| Environnement | Avant | Après |
|---|---|---|
| Desktop / Android / Safari non-PWA | 16 / 24 px | **identique** (max(rem, 0px)) |
| iPhone PWA standalone | 16 / 24 px (sous home indicator) | **34 px** (au-dessus) |
| iPhone landscape Dynamic Island | partiellement masqué | adapté auto |

## Test plan

- [x] Tests Vitest verts (1268 / 1268, snapshots inclus)
- [x] Type-check + ESLint clean
- [ ] Validation empirique @thierry post-merge : **réinstaller la PWA iPhone**, ouvrir une page de leçon, vérifier que le trigger ✨ est bien visible au-dessus du home indicator
- [ ] Vercel preview deployment OK

## Note numérotation Linear

[THI-147](https://linear.app/thierryvm/issue/THI-147) — @cowork avait anticipé THI-148 mais la séquence Linear a alloué THI-147 (suivant après les 5 tickets post-analyse THI-142 à THI-146 créés un peu plus tôt). Pas de duplicate à fermer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Ajuster les boutons d’action flottants pour respecter les marges de sécurité (safe-area insets) iOS en mode PWA autonome.

Corrections de bugs :
- S’assurer que le bouton flottant (FAB) déclenchant le tutor IA reste visible au‑dessus de l’indicateur d’accueil iOS en mode PWA autonome sur iPhone en prenant en compte les marges de sécurité (safe-area insets).

Améliorations :
- Aligner le positionnement du bouton « retour en haut » de la page d’accueil avec les modèles existants déjà compatibles avec les marges de sécurité, utilisés ailleurs dans l’application, afin d’assurer un comportement cohérent sur tous les appareils.

Documentation :
- Documenter la correction liée aux marges de sécurité pour la PWA sur iPhone ainsi que le contexte associé dans le changelog.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust floating action buttons to respect iOS safe-area insets in PWA standalone mode.

Bug Fixes:
- Ensure the AI tutor trigger FAB remains visible above the iOS home indicator in iPhone PWA standalone mode by honoring safe-area insets.

Enhancements:
- Align the landing page scroll-to-top button positioning with existing safe-area-aware patterns used elsewhere in the app for consistent behavior across devices.

Documentation:
- Document the iPhone PWA safe-area fix and related context in the changelog.

</details>