### PR TITLE
fix(css): define 4 missing GitHub theme vars (BUG-FAB-001 root cause)

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -39,19 +39,6 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* GitHub Dark Theme Colors */
-  --github-bg: #0d1117;
-  --github-bg-primary: #0d1117;
-  --github-bg-secondary: #010409;
-  --github-bg-tertiary: #161b22;
-  --github-border-primary: #30363d;
-  --github-border-secondary: #21262d;
-  --github-text-primary: #c9d1d9;
-  --github-text-secondary: #8b949e;
-  --github-text-tertiary: #6e7681;
-  --github-subtle: #484f58;
-  --github-accent: #238636;
-  --github-accent-hover: #2ea043;
 }
 
 .dark {
@@ -89,9 +76,18 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
-  /* GitHub Dark Theme Colors (same as light mode) */
+}
+
+/* GitHub Dark Theme Colors — shared by :root and .dark (TL uses the
+ * same dark-canonical palette in both modes; centralized here to
+ * prevent drift between the two scopes).
+ * --github-bg-primary is aliased to --github-bg so a future bump of
+ * the canonical bg value propagates automatically (Sourcery review
+ * on PR #194). */
+:root,
+.dark {
   --github-bg: #0d1117;
-  --github-bg-primary: #0d1117;
+  --github-bg-primary: var(--github-bg);
   --github-bg-secondary: #010409;
   --github-bg-tertiary: #161b22;
   --github-border-primary: #30363d;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -41,13 +41,17 @@
   --sidebar-ring: oklch(0.708 0 0);
   /* GitHub Dark Theme Colors */
   --github-bg: #0d1117;
+  --github-bg-primary: #0d1117;
   --github-bg-secondary: #010409;
+  --github-bg-tertiary: #161b22;
   --github-border-primary: #30363d;
   --github-border-secondary: #21262d;
   --github-text-primary: #c9d1d9;
   --github-text-secondary: #8b949e;
   --github-text-tertiary: #6e7681;
   --github-subtle: #484f58;
+  --github-accent: #238636;
+  --github-accent-hover: #2ea043;
 }
 
 .dark {
@@ -87,13 +91,17 @@
   --sidebar-ring: oklch(0.439 0 0);
   /* GitHub Dark Theme Colors (same as light mode) */
   --github-bg: #0d1117;
+  --github-bg-primary: #0d1117;
   --github-bg-secondary: #010409;
+  --github-bg-tertiary: #161b22;
   --github-border-primary: #30363d;
   --github-border-secondary: #21262d;
   --github-text-primary: #c9d1d9;
   --github-text-secondary: #8b949e;
   --github-text-tertiary: #6e7681;
   --github-subtle: #484f58;
+  --github-accent: #238636;
+  --github-accent-hover: #2ea043;
 }
 
 @theme inline {


### PR DESCRIPTION
## 🔥 Hot fix P0 — root cause BUG-FAB-001

L'audit `mobile-responsive-auditor` (12ᵉ agent, première invocation post-THI-150) a révélé que **4 CSS variables sont utilisées 13+ fois dans le code AI tutor mais jamais définies dans aucun fichier `.css` du projet**.

Confirmé par cross-audit `ui-auditor` (Chromium discipline) — même finding flagué C1 CRITICAL.
Cross-audit `mobile-responsive-auditor #2` (autres pages) — confirme que le bug NE SE PROPAGE PAS hors AI tutor.

## Vars manquantes (utilisées dans 4 fichiers)

| Variable | Utilisée dans | Effet pré-fix |
|---|---|---|
| `--github-accent` | `AiTutorPanel.tsx:173,297,339,361,483` + `MessageInput.tsx:64,77` + `MessageList.tsx:103` | FAB Sparkles ✨ background → transparent |
| `--github-accent-hover` | `MessageInput.tsx:77` + 7 instances AiTutorPanel | Hover state buttons → no color change (WCAG 2.1 SC 2.4.7 fail) |
| `--github-bg-primary` | `AiTutorPanel.tsx:200` | Drawer surface → transparent |
| `--github-bg-tertiary` | `AiTutorPanel.tsx:297,451` + `MessageList.tsx` (code blocks) + `RateLimitBadge.tsx:26` | Code bg + inactive pills + badge bg → undefined |

**Effet** : `var(--undefined-var)` → empty string → `background: ;` → transparent.

**Le Sparkles ✨ AI tutor FAB était LITTÉRALEMENT INVISIBLE sur Safari iPhone 14**, pas juste petit ou peu contrasté. Le drawer panel aussi. Ce que @thierry observait empiriquement comme *"absorbé dans le chrome du panneau Terminal"* était de la **transparence réelle** laissant le panneau derrière transparaître.

## Valeurs choisies (cohérence GitHub Dark canonique)

```css
--github-accent: #238636;        /* GitHub Dark accent green */
--github-accent-hover: #2ea043;  /* One shade lighter pour hover state */
--github-bg-primary: #0d1117;    /* Alias de --github-bg (drawer surface) */
--github-bg-tertiary: #161b22;   /* One shade lighter (code blocks + inactive states) */
```

**Pourquoi ces valeurs** : alignement avec `--github-bg: #0d1117` déjà défini (ligne 43 theme.css). Cohérence canonique GitHub Dark theme. Si design intent diverge (ex: brand TL emerald au lieu de GitHub green), c'est un follow-up ticket — l'objectif immédiat est de **rendre le FAB visible**.

**Note** : `ui-auditor` proposait `#58a6ff` (blue) pour `--github-accent-hover` — divergence avec `mobile-responsive-auditor`. J'ai retenu la proposition green emerald car `--github-accent` (le base) est green, et un hover qui changerait de teinte (green → blue) serait incohérent.

## Diff scope strict

**1 fichier modifié, 8 lignes ajoutées** (4 vars × 2 blocs `:root` + `.dark`).

```
 src/styles/theme.css | 8 ++++++++
 1 file changed, 8 insertions(+)
```

- ✅ Aucune autre modif
- ✅ Aucun composant consumer touché
- ✅ Aucun fichier doc/CHANGELOG modifié (sera bundlé THI-152)
- ✅ Pre-commit credential scan clean
- ✅ Pattern identique aux 8 autres GitHub vars existantes

## Quality gates

- ✅ Type-check (`tsc --noEmit`)
- ✅ Lint (`eslint src`)
- ⏳ Vitest CI — devrait passer trivialement (CSS-only change)

## Test plan empirique @thierry post-merge

### iPhone Safari (test P0)
- [ ] Naviguer sur `/app/learn/<module>/<lesson>` en preview
- [ ] Vérifier que le bouton ✨ Sparkles AI tutor est **visiblement vert** (pas transparent)
- [ ] Vérifier le contraste sur fond noir terminal vs sur fond `bg-card`
- [ ] Ouvrir le drawer AI tutor — vérifier surface drawer **opaque** (pas transparent)
- [ ] Vérifier hover state buttons (sur desktop preview puis croiser iPhone)

### Desktop preserve (critère absolu @cowork)
- [ ] Screenshot LessonPage 1280×800 avant/après — vérifier aucune régression visuelle
- [ ] Screenshot Landing 1440×900 — vérifier scroll-to-top + nav inchangés
- [ ] Vérifier theme.css `:root` charge correctement (pas de conflit cascade)

## Lien Linear

Pas de ticket explicite — hot fix sprint pattern (cf. PR #191 hot fix overflow body THI-149). Sera attaché à **THI-152** (mini-PRs fix séquentielles ex-brick 3c) ou nouveau ticket BUG-FAB-001 selon arbitrage @thierry.

## Co-déploiement

Cette PR fait partie d'un **trio d'audits** lancés ce matin 5 mai :
- ✅ Audit #1 (`mobile-responsive-auditor` AI tutor + Landing + Lesson + theme + index.html) — 13 findings, BLOCK, root cause CSS vars révélée
- ✅ Audit #2 (`mobile-responsive-auditor` Dashboard + sidebar + CommandReference + MarkdownPage + LoginModal + UserMenu + PrivacyPolicy + NotFound + TerminalEmulator) — 13 findings supplémentaires, BLOCK
- ✅ Audit #3 (`ui-auditor` Chromium cross-check) — 1 CRITICAL (confirme C1) + 1 HIGH focus ring inconsistency, autres OK

Rapports complets dans `.tmp/cc-handoffs/2026-05-05-audit{1,2,3}-*.md` (handoffs locaux pour @cowork → Obsidian Athenaeum).

Push done ≠ task done. Validation empirique @thierry obligatoire (FAB visible iPhone Safari + desktop préservé) avant merge.

Bypass admin acceptable si Sourcery rate limit hebdo (low risk : 8 lignes CSS, scope strict, root cause confirmée par 3 agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Définir les variables CSS de thème GitHub manquantes afin de rétablir le style prévu du bouton flottant (FAB) et du panneau du tuteur IA dans les modes clair et sombre.

Corrections de bugs :
- Ajouter des définitions pour les variables CSS d’accentuation et d’arrière-plan de GitHub afin que le FAB du tuteur IA, les tiroirs et les éléments associés s’affichent avec un style visible et cohérent au lieu d’arrières-plans transparents.

Améliorations :
- Aligner les nouvelles variables de thème GitHub sur la palette de couleurs existante de GitHub Dark pour assurer une apparence cohérente dans les thèmes :root et .dark.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define missing GitHub theme CSS variables to restore intended AI tutor FAB and panel styling across light and dark modes.

Bug Fixes:
- Add definitions for GitHub accent and background CSS variables so AI tutor FAB, drawers, and related elements render with visible, consistent styling instead of transparent backgrounds.

Enhancements:
- Align new GitHub theme variables with existing GitHub Dark color palette for consistent appearance in both :root and .dark themes.

</details>