### PR TITLE
fix(ui): FAB Sparkles size + opacity + position propre (THI-152 brick 3/9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@
 
 ---
 
+## FAB Sparkles — taille + opacité + position propre + feedback tactile
+*5 mai 2026 · Phase 7c · THI-152 brick 3/9*
+
+Troisième mini-PR. Ferme le finding **P0 ios-critical** d'audit #1 FINDING-02 (FAB opacity-80 + h-11 floor + hover-only affordance) + fixe la dette technique de position héritée de THI-111.
+
+**Avant** :
+```
+fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-20 z-40
+flex h-11 w-11 items-center justify-center rounded-full
+bg-[var(--github-accent)] text-white opacity-80 shadow-md
+ring-1 ring-black/30 transition
+hover:opacity-100 hover:bg-[var(--github-accent-hover)]
+focus-visible:outline-2 focus-visible:outline-offset-2
+md:h-12 md:w-12
+```
+
+**Après** :
+```
+fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-6 z-40
+flex h-12 w-12 items-center justify-center rounded-full
+bg-[var(--github-accent)] text-white shadow-lg
+ring-1 ring-black/30 transition active:scale-95
+hover:bg-[var(--github-accent-hover)]
+focus-visible:outline-2 focus-visible:outline-offset-2
+md:h-14 md:w-14
+```
+
+### Changements
+
+| Aspect | Avant | Après | Pourquoi |
+|---|---|---|---|
+| Position latérale | `right-20` (80px) | `right-6` (24px) | Coin inférieur droit propre. Le `right-20` était une précaution V1 (THI-111) contre un chevauchement avec scroll-to-top FAB qui n'existe sur aucune des pages où l'AI tutor est rendu (Dashboard, LessonPage, CommandReference) |
+| Taille mobile | `h-11 w-11` (44px) | `h-12 w-12` (48px) | Confort tactile au-dessus du floor Apple HIG |
+| Taille desktop | `md:h-12 md:w-12` (48px) | `md:h-14 md:w-14` (56px) | Standard Material/Apple FAB primary |
+| Opacité | `opacity-80 hover:opacity-100` | (default 100%) | Safari iOS n'a pas de hover state — la FAB était permanently 80% transparente, absorbée dans le chrome du panneau Terminal |
+| Shadow | `shadow-md` | `shadow-lg` | Détachement visuel renforcé sur fond sombre |
+| Feedback tactile | (aucun) | `active:scale-95` | Press feedback sur touch devices (compense l'absence de hover) |
+| Icône Sparkles | `size={20}` | `size={22}` | Cohérent avec le bump conteneur 44→48 |
+
+### Dette technique fixée
+
+Le `right-20` legacy est documenté comme dette V1 dans le commentaire JSDoc inline. Ferme la confusion *"pourquoi le FAB n'est pas dans le coin inférieur droit ?"* (question @thierry, validation empirique 5 mai matin).
+
+### Specs régression
+
+**Étendus** (`e2e/mobile/ai-tutor-fab.webkit.spec.ts`) :
+- Hit area mobile **= 48 px exact** (au lieu de juste ≥44, garde-fou anti-régression vers le floor)
+- Opacité **= 1** (catche un futur retour de l'opacity-80)
+
+**Nouveau** (`e2e/desktop/ai-tutor-fab-desktop.chromium.spec.ts`) — 4 tests × 2 viewports = **8 tests** :
+- Width/height = 56 px sur desktop (md:h-14)
+- Background `rgb(35, 134, 54)` préservé (PR #194 regression guard)
+- Position `fixed` préservée
+- Opacité 100% cohérente avec mobile
+
+### Quality gates
+
+- type-check ✅, lint ✅
+- 1268/1268 vitest
+- **42/42 e2e:mobile** (39+3 nouveaux/étendus, 22.5s)
+- **32/32 e2e:desktop** (24+8 nouveaux, 13.9s)
+
+### Hors scope (= mini-PRs futures)
+
+- ❌ Harmoniser scroll-to-top Landing FAB pattern (variant `icon-round` Button) avec AI tutor FAB pattern (Tailwind direct) — *flag backlog issue, non-bloquant*
+- ❌ PWA apple-touch-icon PNG (= mini-PR 4/9)
+- ❌ Touch targets ≥44×44 boutons restants (= mini-PR 5/9)
+
+---
+
 ## Forms font-size ≥ 16px — anti-zoom Safari iOS
 *5 mai 2026 · Phase 7c · THI-152 brick 2/9*
 

--- a/e2e/desktop/ai-tutor-fab-desktop.chromium.spec.ts
+++ b/e2e/desktop/ai-tutor-fab-desktop.chromium.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * THI-152 brick 3/9 — AI tutor FAB desktop sizing regression specs.
+ *
+ * Desktop counterpart to e2e/mobile/ai-tutor-fab.webkit.spec.ts. The
+ * Tailwind class pattern `h-12 w-12 md:h-14 md:w-14` gives:
+ *  - mobile (<768px) → 48 px (Material/Apple FAB comfort floor)
+ *  - desktop (≥768px) → 56 px (Material/Apple FAB primary standard)
+ *
+ * These specs run on the two desktop preservation viewports
+ * (1280×800, 1920×1080) and assert the upsizing did not break:
+ *  - the computed dimensions on desktop
+ *  - the fixed positioning
+ *  - the emerald background still resolves (PR #194 regression guard)
+ *  - the FAB sits above the home indicator (safe-area pattern still
+ *    collapses to 1rem on desktop where the inset value is 0)
+ */
+
+test.describe('AI tutor FAB desktop — Chromium preserve (THI-152 brick 3/9)', () => {
+  test('FAB is 56×56 px on desktop (md:h-14)', async ({ page }) => {
+    await page.goto('/app');
+
+    const fab = page.getByRole('button', { name: /tuteur IA/i });
+    await expect(fab).toBeVisible();
+
+    const box = await fab.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width, 'FAB desktop width must be 56 px (md:h-14)').toBe(56);
+    expect(box!.height, 'FAB desktop height must be 56 px (md:h-14)').toBe(56);
+  });
+
+  test('FAB still renders emerald background on desktop (PR #194 guard)', async ({ page }) => {
+    await page.goto('/app');
+
+    const fab = page.getByRole('button', { name: /tuteur IA/i });
+    await expect(fab).toBeVisible();
+
+    const bg = await fab.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe('rgb(35, 134, 54)');
+  });
+
+  test('FAB is fixed-positioned on desktop (not absolute or sticky)', async ({ page }) => {
+    await page.goto('/app');
+
+    const fab = page.getByRole('button', { name: /tuteur IA/i });
+    await expect(fab).toBeVisible();
+
+    const position = await fab.evaluate((el) => getComputedStyle(el).position);
+    expect(position).toBe('fixed');
+  });
+
+  test('FAB opacity is 100% on desktop (consistent with mobile)', async ({ page }) => {
+    await page.goto('/app');
+
+    const fab = page.getByRole('button', { name: /tuteur IA/i });
+    await expect(fab).toBeVisible();
+
+    const opacity = await fab.evaluate((el) => parseFloat(getComputedStyle(el).opacity));
+    expect(opacity).toBe(1);
+  });
+});

--- a/e2e/mobile/ai-tutor-fab.webkit.spec.ts
+++ b/e2e/mobile/ai-tutor-fab.webkit.spec.ts
@@ -57,7 +57,7 @@ test.describe('AI tutor FAB — Safari iOS WebKit regression (THI-151)', () => {
     expect(bg).not.toBe('transparent');
   });
 
-  test('FAB hit area is at least 44×44 px (Apple HIG floor)', async ({ page }) => {
+  test('FAB hit area is 48×48 px on mobile (h-12, comfort over Apple HIG floor)', async ({ page }) => {
     await page.goto('/app');
 
     const fab = page.getByRole('button', { name: /tuteur IA/i });
@@ -65,8 +65,25 @@ test.describe('AI tutor FAB — Safari iOS WebKit regression (THI-151)', () => {
 
     const box = await fab.boundingBox();
     expect(box).not.toBeNull();
-    expect(box!.width, 'FAB width must be ≥ 44 px').toBeGreaterThanOrEqual(44);
-    expect(box!.height, 'FAB height must be ≥ 44 px').toBeGreaterThanOrEqual(44);
+    // Tightened from "≥ 44" to "= 48" after THI-152 brick 3/9 bumped the
+    // mobile FAB to h-12 w-12 (48 px). Catches a future regression that
+    // would silently shrink it back to 44 px (the Apple HIG floor with
+    // no comfort margin).
+    expect(box!.width, 'FAB mobile width must be 48 px (h-12)').toBe(48);
+    expect(box!.height, 'FAB mobile height must be 48 px (h-12)').toBe(48);
+  });
+
+  test('FAB opacity is 100% (no hover-dependent visibility on touch)', async ({ page }) => {
+    await page.goto('/app');
+
+    const fab = page.getByRole('button', { name: /tuteur IA/i });
+    await expect(fab).toBeVisible();
+
+    const opacity = await fab.evaluate((el) => parseFloat(getComputedStyle(el).opacity));
+    // THI-152 brick 3/9 dropped opacity-80 + hover:opacity-100 because
+    // Safari iOS has no hover state — the FAB was permanently 80%
+    // transparent and visually absorbed into the terminal panel chrome.
+    expect(opacity, 'FAB opacity must be 1 (always full visibility)').toBe(1);
   });
 
   test('FAB is rendered as a fixed positioned element', async ({ page }) => {

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -170,9 +170,24 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
         // bottom uses max(1rem, env(safe-area-inset-bottom)) so the FAB sits
         // above the iPhone home indicator in PWA standalone mode (THI-147).
         // The pattern matches MarkdownPage and PrivacyPolicy already-fixed FABs.
-        className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-20 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white opacity-80 shadow-md ring-1 ring-black/30 transition hover:opacity-100 hover:bg-[var(--github-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 md:h-12 md:w-12"
+        //
+        // Position (THI-152 brick 3/9): right-6 (24px) anchors the FAB in the
+        // bottom-right corner cleanly. The legacy right-20 (80px) was a
+        // V1 (THI-111) precaution against overlapping the Landing
+        // scroll-to-top FAB, but the AI tutor is only rendered on
+        // Dashboard / LessonPage / CommandReference — none of which carry
+        // a scroll-to-top FAB. So the precaution was dead weight that
+        // pushed the icon awkwardly off the corner.
+        //
+        // Sizing: mobile 48px (h-12, comfort over the 44px Apple HIG floor),
+        // desktop 56px (md:h-14, Material/Apple FAB primary standard).
+        // Always-100% opacity so the Sparkles is unambiguously visible on
+        // every background; active:scale-95 gives a tactile press feedback
+        // on touch devices that the previous hover-only affordance could
+        // not deliver on Safari iOS (no hover state).
+        className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-6 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--github-accent)] text-white shadow-lg ring-1 ring-black/30 transition active:scale-95 hover:bg-[var(--github-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 md:h-14 md:w-14"
       >
-        <Sparkles size={20} strokeWidth={2} aria-hidden="true" />
+        <Sparkles size={22} strokeWidth={2} aria-hidden="true" />
       </button>
 
       {open && (


### PR DESCRIPTION
## Mini-PR 3/9 — FAB Sparkles size + opacity + position + tactile feedback (P0)

Troisième mini-PR. Ferme audit #1 **FINDING-02 ios-critical** (FAB opacity-80 + h-11 floor + hover-only affordance) ET fixe la dette technique de position héritée de THI-111 (constat empirique @thierry sur preview PR #197).

## Linear

**[THI-152](https://linear.app/thierryvm/issue/THI-152)** — fix: mobile responsive bugs sequential mini-PRs (epic-parent THI-149 Done)

## Changements

### Diff sur le className du `<button>` AI tutor trigger (AiTutorPanel.tsx)

| Aspect | Avant | Après | Pourquoi |
|---|---|---|---|
| Position latérale | `right-20` (80px) | `right-6` (24px) | **Coin inférieur droit propre.** Le `right-20` était une précaution V1 (THI-111) contre un chevauchement avec le scroll-to-top Landing FAB qui n'existe sur **aucune** des pages où l'AI tutor est rendu (Dashboard, LessonPage, CommandReference). Dette V1 documentée dans le commentaire JSDoc inline. |
| Taille mobile | `h-11 w-11` (44px floor Apple HIG) | `h-12 w-12` (48px) | Confort tactile au-dessus du minimum |
| Taille desktop | `md:h-12 md:w-12` (48px) | `md:h-14 md:w-14` (56px) | Standard Material/Apple FAB primary |
| Opacité | `opacity-80 hover:opacity-100` | (default 100%) | Safari iOS n'a pas de hover state — la FAB était permanently 80% transparente, absorbée dans le chrome du panneau Terminal |
| Shadow | `shadow-md` | `shadow-lg` | Détachement visuel renforcé sur fond sombre |
| Feedback tactile | (aucun) | `active:scale-95` | Press feedback sur touch devices (compense l'absence de hover Safari iOS) |
| Icône Sparkles | `size={20}` | `size={22}` | Proportion icône/conteneur cohérente après le bump |

### Question @thierry sur preview PR #197

> *"les 2 ne coexistent jamais sur la même page alors pourquoi l'icône IA tutor n'est pas placée dans le coin inférieur droit proprement ?"*

Vérification empirique :
- **Dashboard `/app`** : pas de scroll-to-top FAB → AI tutor seul → `right-6` OK
- **LessonPage `/app/learn/X/Y`** : pas de scroll-to-top FAB → AI tutor seul → `right-6` OK
- **CommandReference `/app/reference`** : pas de scroll-to-top FAB → AI tutor seul → `right-6` OK
- **Landing `/`, /story, /changelog, /privacy** : scroll-to-top FAB oui, AI tutor **NON** → pas de conflit

→ Le `right-20` était de la dette V1 sans justification empirique. Fix in scope mini-PR 3/9 (FAB position).

## Specs régression

### Étendus — `e2e/mobile/ai-tutor-fab.webkit.spec.ts`
- Hit area mobile **= 48 px exact** (au lieu de juste ≥44, garde-fou anti-régression)
- **Opacité = 1** (catche un futur retour de l'opacity-80)

### Nouveau — `e2e/desktop/ai-tutor-fab-desktop.chromium.spec.ts`
4 tests × 2 viewports = **8 tests** :
- Width/height = **56 px** sur desktop (md:h-14)
- Background `rgb(35, 134, 54)` préservé (PR #194 regression guard)
- Position `fixed` préservée
- Opacité 100% cohérente avec mobile

## Quality gates ✅

| Suite | Résultat |
|---|---|
| Type-check | ✅ |
| Lint | ✅ |
| Vitest | **1268/1268 PASS** |
| `npm run e2e:mobile` | **42/42 PASS** (39+3 nouveaux/étendus, 22.5s) |
| `npm run e2e:desktop` | **32/32 PASS** (24+8 nouveaux, 13.9s) |
| Pre-commit credential scan | ✅ Clean |

## Diff scope strict

```
4 files changed, 169 insertions(+), 5 deletions(-)
```
- `src/app/components/ai/AiTutorPanel.tsx` (+10 -3 className + JSDoc dette V1 documentée)
- `e2e/mobile/ai-tutor-fab.webkit.spec.ts` (+22 -2 tightened tests + opacity test)
- `e2e/desktop/ai-tutor-fab-desktop.chromium.spec.ts` (+62 NEW)
- `CHANGELOG.md` (+72)

**Aucune nouvelle dépendance npm. Aucun changement sur d'autres composants.**

## Test plan empirique @thierry

### Safari iPhone 14 (mobile)
- [ ] Aller sur `/app` → FAB Sparkles **dans le coin inférieur droit** (right-6 = 24px depuis bord)
- [ ] FAB visiblement plus grand (48px vs 44px avant)
- [ ] FAB **pleinement opaque** (plus de dilution sur fond terminal noir)
- [ ] Tap FAB → animation `scale-95` pendant le press
- [ ] Tap relâché → FAB revient à scale-100 + drawer s'ouvre

### Desktop preserve (1280×800 + 1920×1080)
- [ ] FAB Sparkles 56×56 px sur `/app` (visiblement plus grand qu'avant)
- [ ] Aucun chevauchement avec d'autres éléments (puisque l'AI tutor n'est pas sur les pages avec scroll-to-top)
- [ ] LessonPage split 44%/42% inchangé (Section 11 Desktop Preservation)
- [ ] Hover desktop → background `--github-accent-hover` actif (feedback visuel)

## Hors scope (= mini-PRs futures + backlog)

- ❌ Harmoniser pattern scroll-to-top Landing FAB (variant `icon-round` Button) avec AI tutor FAB (Tailwind direct) — *flag backlog, non-bloquant*
- ❌ PWA apple-touch-icon PNG 180×180 (= mini-PR 4/9)
- ❌ Touch targets ≥44×44 boutons restants (= mini-PR 5/9)
- ❌ Chat bubble word-break + drawer header truncation (= mini-PR 6/9)
- ❌ Focus rings emerald harmonization (= mini-PR 7/9)
- ❌ Safe-area top bar + autoFocus terminal (= mini-PR 8/9)
- ❌ Theme-color media + tap-highlight + font-display (= mini-PR 9/9)

Push done ≠ task done. Validation empirique @thierry obligatoire (Safari iPhone 14 + desktop preserve) avant merge + GO mini-PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)