### PR TITLE
chore(docs): bump README freshness table post-Sprint Mobile Recovery TL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Index — Terminal Learning
 
-> Last updated: 2 May 2026  
+> Last updated: 5 May 2026  
 > This directory contains active project documentation. For historical/stale docs, see `.archive/`.
 
 ---
@@ -91,17 +91,18 @@ These files remain in `.archive/` for historical reference. Current session prot
 
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| ROADMAP.md | 21 April 2026 | 🟢 Active |
+| ROADMAP.md | 5 May 2026 (Sprint Mobile Recovery TL THI-152 🏁 COMPLETE — 9 mini-PRs + hotfix 7bis) | 🟢 Active |
 | ARCHITECTURE.md | 14 April 2026 | 🟢 Active |
 | SECURITY.md | 1 May 2026 | 🟢 Active |
 | CONVENTIONS.md | 13 April 2026 | 🟢 Active |
-| plan.md | 2 May 2026 (sprint sécurité clos + session PM cleanup THI-108 + gate-zero THI-111) | 🟢 Active |
+| plan.md | 5 May 2026 (Sprint Mobile Recovery TL clos + lien narration v1.5) | 🟢 Active |
 | security-audit-log.md | 2 May 2026 (audit run 1 May logged) | 🟢 Active |
 | GUIDELINES.md | 11 April 2026 | 🟡 Stable |
 | vercel-firewall.md | 14 April 2026 | 🟢 Active |
 | ATTRIBUTIONS.md | 2 April 2026 | 🟡 Stable |
 | adr/ | 18 April 2026 | 🟢 Active |
 | guides/ | 15 April 2026 | 🟢 Active |
+| story/v1-5-mobile-recovery-narrative.md | 5 May 2026 (NEW — narration thématique sprint THI-152) | 🟢 Active |
 
 ---
 


### PR DESCRIPTION
## Summary

Maintenance docs après clôture Sprint Mobile Recovery TL (THI-152). La freshness table de `docs/README.md` était stale (plan.md référencé au 2 May, ROADMAP.md au 21 April).

**1 fichier, 4 modifs** (bumps de date + 1 nouvelle ligne).

## Changements

- "Last updated" en tête : 2 May → **5 May 2026**
- `ROADMAP.md` row : 21 April → 5 May 2026 (Sprint THI-152 🏁 COMPLETE)
- `plan.md` row : 2 May → 5 May 2026 (Sprint THI-152 clos + lien narration v1.5)
- Nouvelle ligne : `story/v1-5-mobile-recovery-narrative.md` (NEW — narration thématique sprint THI-152)

## Justification

Le memo `feedback_docs_freshness_check.md` exige de vérifier la freshness table à chaque PR pertinente. Sans ce bump, drift latent dans 2 mois.

## Test plan

- [ ] CI verte (lint + type-check + vitest — pas de modif code, pas de risque)
- [ ] Squash merge

🏁 PR de maintenance docs post-clôture sprint THI-152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Mettre à jour les métadonnées de fraîcheur de la documentation après le sprint Mobile Recovery TL.

Documentation :
- Actualiser les dates du tableau de fraîcheur dans `docs/README.md` pour `ROADMAP.md` et `plan.md` au 5 mai 2026.
- Ajouter une nouvelle entrée pour le document de récit d’histoire de récupération mobile du sprint `THI-152` dans l’index de la documentation.
- Mettre à jour l’horodatage « Dernière mise à jour » de l’index global de la documentation au 5 mai 2026.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation freshness metadata after the Mobile Recovery TL sprint.

Documentation:
- Refresh docs/README.md freshness table dates for ROADMAP.md and plan.md to 5 May 2026.
- Add a new entry for the sprint THI-152 mobile recovery narrative story document to the docs index.
- Update the overall docs index "Last updated" timestamp to 5 May 2026.

</details>