### PR TITLE
chore: gitignore .tmp/ session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ playwright-report/
 
 # Internal Claude planning drafts (per-issue tactical plans, not project doc)
 .claude/plans/
+
+# Local CC scratch directory (commit message drafts, validation screenshots,
+# session reprise snapshots, audit reports, handoff files). Persistent local
+# only — never tracked. Cleanup safe à tout moment, contenu reproductible.
+.tmp/


### PR DESCRIPTION
Cleans VS Code Source Control noise — `.tmp/` contient drafts commit-msg + screenshots preview + cc-handoffs internes session, pas pour le repo. Demande @thierry shutdown 9 mai 2026 fin de soirée. 5 lignes au .gitignore.

## Summary by Sourcery

Tâches :
- Ajouter le répertoire `.tmp` au fichier `.gitignore` pour exclure les artefacts de session locaux du dépôt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add .tmp directory to .gitignore to exclude local session artifacts from the repository.

</details>