### PR TITLE
fix(scripts): em-dash in X-Title header breaks eval-tutor.ts fetch

### DIFF
--- a/scripts/eval-tutor.ts
+++ b/scripts/eval-tutor.ts
@@ -157,7 +157,7 @@ async function callOpenRouter(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
       'HTTP-Referer': 'https://terminallearning.dev',
-      'X-Title': 'Terminal Learning — eval-tutor.ts',
+      'X-Title': 'Terminal Learning - eval-tutor.ts',
     },
     body: JSON.stringify({
       model,


### PR DESCRIPTION
## Summary

Empirical reproduction by `@cowork` :
`npx tsx --env-file=.env.local scripts/eval-tutor.ts`
produced 14/14 `ERROR: Cannot convert argument to a ByteString because the character at index 18 has a value of 8212 which is greater than 255`.

## Root cause

Ligne 160 `scripts/eval-tutor.ts` : header `X-Title` value contained an em-dash `—` (U+2014). HTTP header values must be ByteString (chars 0-255 only) per fetch spec. Em-dash 8212 > 255 → fetch refuses.

## Fix

Replace em-dash with ASCII hyphen `-`. Header value is now ByteString-compatible.

## Test plan
- [x] Reproduction confirmed before fix (14/14 ERROR)
- [ ] Re-run `@cowork` post-merge → expected : 14/14 successful API calls + report markdown with PASS/WARN/FAIL heuristics
- [ ] No regression : script signature unchanged, only string literal modified

## Closes
Validation empirique eval (b) gate ADR-008 ship pour v1.1.0 — bloque depuis hier soir.

## Résumé par Sourcery

Corrections de bugs :
- Normaliser la valeur de l’en-tête `X-Title` dans `eval-tutor.ts` en remplaçant un tiret cadratin par un tiret ASCII afin d’éviter les erreurs de validation `ByteString` lors de l’appel à `fetch`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Normalize the X-Title header value in eval-tutor.ts by replacing an em-dash with an ASCII hyphen to prevent ByteString validation errors in fetch.

</details>