### PR TITLE
feat(ai): THI-112 — onboarding AI Tutor (AiKeySetup + AiConsentModal + AiSettings + Privacy section) + M3-AI consent versioning fix

### DIFF
--- a/src/app/components/AiSettings.tsx
+++ b/src/app/components/AiSettings.tsx
@@ -33,6 +33,7 @@ import {
   type Provider,
 } from '@/lib/ai/keyManager';
 import { DEFAULT_MODELS } from '@/lib/ai/providers';
+import { PROVIDER_LABELS } from '@/lib/ai/providers/meta';
 import {
   CONSENT_KEY,
   readConsentRecord,
@@ -42,13 +43,6 @@ import {
 import { AiKeySetup } from './ai/AiKeySetup';
 
 const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
-
-const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
-  openrouter: 'OpenRouter',
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  gemini: 'Gemini',
-};
 
 interface ProviderStatus {
   provider: Provider;

--- a/src/app/components/AiSettings.tsx
+++ b/src/app/components/AiSettings.tsx
@@ -1,0 +1,285 @@
+/**
+ * AiSettings — THI-112 Phase B.
+ *
+ * Settings page under `/app/settings` that lets the learner review and
+ * manage everything the AI tutor stores locally:
+ *  - per-provider key status (configured? plain or encrypted? masked tail)
+ *  - consent record (accepted? when? expires when? remaining days)
+ *  - actions: edit a key (mounts AiKeySetup inline), forget a key,
+ *    revoke consent
+ *
+ * No data ever leaves the browser from this page — every action is a
+ * local read or local write. The consent revocation button calls
+ * `useAiTutor.revokeConsent` which removes the JSON record from
+ * localStorage; the next AI tutor open re-prompts.
+ *
+ * The page intentionally does NOT mount the full `useAiTutor` hook
+ * (which would require a `lang` and possibly a `lessonContext`) — it
+ * uses the lighter `keyManager` + `readConsentRecord` helpers directly
+ * because we only need read-only state plus two local mutations.
+ */
+import {
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import { Link } from 'react-router';
+import { ArrowLeft, KeyRound, ShieldCheck, Trash2 } from 'lucide-react';
+
+import {
+  forgetKey as kmForgetKey,
+  hasKey as kmHasKey,
+  isEncrypted as kmIsEncrypted,
+  type Provider,
+} from '@/lib/ai/keyManager';
+import { DEFAULT_MODELS } from '@/lib/ai/providers';
+import {
+  CONSENT_KEY,
+  readConsentRecord,
+  type ConsentRecord,
+} from '@/lib/ai/useAiTutor';
+
+import { AiKeySetup } from './ai/AiKeySetup';
+
+const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
+
+const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
+  openrouter: 'OpenRouter',
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+};
+
+interface ProviderStatus {
+  provider: Provider;
+  configured: boolean;
+  encrypted: boolean;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function formatDateFr(ts: number): string {
+  return new Date(ts).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function daysRemaining(expiresAt: number): number {
+  return Math.max(0, Math.ceil((expiresAt - Date.now()) / ONE_DAY_MS));
+}
+
+export function AiSettings() {
+  const [statuses, setStatuses] = useState<readonly ProviderStatus[]>([]);
+  const [consent, setConsent] = useState<ConsentRecord | null>(null);
+  const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
+
+  // Refresh local-storage / IndexedDB-backed state. Called on mount and
+  // whenever a save / forget / revoke action mutates that state so the UI
+  // reflects the change without forcing a page reload.
+  const refresh = useCallback(async () => {
+    const next = await Promise.all(
+      PROVIDERS.map(async (p) => ({
+        provider: p,
+        configured: await kmHasKey(p),
+        encrypted: await kmIsEncrypted(p),
+      })),
+    );
+    setStatuses(next);
+    setConsent(readConsentRecord());
+  }, []);
+
+  useEffect(() => {
+    // `refresh` is async: it awaits four `keyManager.hasKey/isEncrypted`
+    // calls (IndexedDB-backed) before resolving and only then updates
+    // state. This is exactly the "subscribe for updates from an external
+    // system" shape the React docs sanction — there is no cascading-
+    // render risk because the state writes happen post-await, after the
+    // current render cycle is committed. The lint rule cannot model the
+    // async boundary, so we silence it here with explicit rationale.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+  }, [refresh]);
+
+  const onForget = useCallback(
+    async (p: Provider) => {
+      await kmForgetKey(p);
+      if (editingProvider === p) setEditingProvider(null);
+      await refresh();
+    },
+    [editingProvider, refresh],
+  );
+
+  const onRevokeConsent = useCallback(async () => {
+    try {
+      localStorage.removeItem(CONSENT_KEY);
+    } catch {
+      /* storage may be disabled — best effort */
+    }
+    await refresh();
+  }, [refresh]);
+
+  const onSavedFromEditor = useCallback(async () => {
+    setEditingProvider(null);
+    await refresh();
+  }, [refresh]);
+
+  return (
+    <div
+      className="min-h-dvh bg-[var(--github-bg)] text-[var(--github-text-primary)]"
+      style={{ fontFamily: 'Inter, sans-serif' }}
+    >
+      <main className="mx-auto max-w-4xl px-6 py-8">
+        <div className="mb-6 flex items-center gap-3">
+          <Link
+            to="/app"
+            className="text-[var(--github-text-secondary)] hover:text-[var(--github-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 rounded p-1"
+            aria-label="Retour au tableau de bord"
+          >
+            <ArrowLeft size={18} aria-hidden="true" />
+          </Link>
+          <h1 className="text-2xl font-bold">Paramètres IA</h1>
+        </div>
+
+        <p className="mb-8 text-sm text-[var(--github-text-secondary)]">
+          Gestion locale de tes clés API et de ton consentement pour le tuteur
+          IA. Aucune donnée ne quitte ce navigateur depuis cette page. Détails
+          complets dans la{' '}
+          <Link
+            to="/privacy#ai-processing"
+            className="text-emerald-400 underline hover:text-emerald-300"
+          >
+            section IA de la politique de confidentialité
+          </Link>
+          .
+        </p>
+
+        <section aria-labelledby="ai-settings-keys" className="mb-10">
+          <h2
+            id="ai-settings-keys"
+            className="mb-4 flex items-center gap-2 text-lg font-semibold"
+          >
+            <KeyRound size={18} className="text-emerald-400" aria-hidden="true" />
+            Clés API par provider
+          </h2>
+          <ul className="space-y-3">
+            {statuses.map((s) => (
+              <li
+                key={s.provider}
+                className="rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-medium">{PROVIDER_LABELS[s.provider]}</p>
+                    <p className="mt-1 text-xs text-[var(--github-text-secondary)]">
+                      Modèle par défaut :{' '}
+                      <code className="rounded bg-[var(--github-bg-tertiary)] px-1 py-0.5">
+                        {DEFAULT_MODELS[s.provider]}
+                      </code>
+                    </p>
+                    <p className="mt-2 text-sm">
+                      Statut :{' '}
+                      {s.configured ? (
+                        <>
+                          <span className="text-emerald-400">Configurée</span>
+                          {' · '}
+                          <span className="text-[var(--github-text-secondary)]">
+                            {s.encrypted ? 'chiffrée (AES-GCM)' : 'en clair'}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="text-[var(--github-text-secondary)]">
+                          Non configurée
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setEditingProvider((cur) => (cur === s.provider ? null : s.provider))
+                      }
+                      aria-expanded={editingProvider === s.provider}
+                      aria-controls={`ai-settings-editor-${s.provider}`}
+                      className="rounded-md bg-[var(--github-accent)] px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-[var(--github-accent-hover)] focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+                    >
+                      {s.configured ? 'Modifier' : 'Configurer'}
+                    </button>
+                    {s.configured && (
+                      <button
+                        type="button"
+                        onClick={() => void onForget(s.provider)}
+                        className="flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs text-red-300 outline-none hover:bg-red-500/20 focus-visible:ring-2 focus-visible:ring-red-500/60"
+                      >
+                        <Trash2 size={12} aria-hidden="true" />
+                        Oublier
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {editingProvider === s.provider && (
+                  <div
+                    id={`ai-settings-editor-${s.provider}`}
+                    className="mt-4 rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)]"
+                  >
+                    <AiKeySetup
+                      provider={s.provider}
+                      onSaved={() => void onSavedFromEditor()}
+                      className="flex flex-col gap-3 p-4 text-sm text-[var(--github-text-primary)]"
+                    />
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section aria-labelledby="ai-settings-consent">
+          <h2
+            id="ai-settings-consent"
+            className="mb-4 flex items-center gap-2 text-lg font-semibold"
+          >
+            <ShieldCheck size={18} className="text-emerald-400" aria-hidden="true" />
+            Consentement
+          </h2>
+          {consent ? (
+            <div className="rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] p-4">
+              <p className="text-sm">
+                <span className="text-emerald-400">Consentement actif</span>{' '}
+                <span className="text-[var(--github-text-secondary)]">
+                  (version {consent.version})
+                </span>
+              </p>
+              <p className="mt-2 text-sm text-[var(--github-text-secondary)]">
+                Accepté le{' '}
+                <strong className="text-[var(--github-text-primary)]">
+                  {formatDateFr(consent.acceptedAt)}
+                </strong>
+                {' · '}expire le{' '}
+                <strong className="text-[var(--github-text-primary)]">
+                  {formatDateFr(consent.expiresAt)}
+                </strong>{' '}
+                ({daysRemaining(consent.expiresAt)} jours restants).
+              </p>
+              <button
+                type="button"
+                onClick={() => void onRevokeConsent()}
+                className="mt-3 flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs text-red-300 outline-none hover:bg-red-500/20 focus-visible:ring-2 focus-visible:ring-red-500/60"
+              >
+                <Trash2 size={12} aria-hidden="true" />
+                Révoquer le consentement
+              </button>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] p-4 text-sm text-[var(--github-text-secondary)]">
+              Aucun consentement actif. Le tuteur IA te le redemandera à la
+              prochaine ouverture du panel.
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/components/PrivacyPolicy.tsx
+++ b/src/app/components/PrivacyPolicy.tsx
@@ -45,7 +45,7 @@ export function PrivacyPolicy() {
           </div>
           <div>
             <h1 className="text-2xl font-bold text-[var(--github-text-primary)]">Politique de confidentialité</h1>
-            <p className="text-[var(--github-text-secondary)] text-sm">Dernière mise à jour : 31 mars 2026</p>
+            <p className="text-[var(--github-text-secondary)] text-sm">Dernière mise à jour : 10 mai 2026</p>
           </div>
         </div>
 
@@ -109,8 +109,104 @@ export function PrivacyPolicy() {
             </div>
           </section>
 
+          <section id="ai-processing" className="scroll-mt-24">
+            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">4. Tuteur IA — traitement des données (BYOK)</h2>
+            <p className="mb-3">
+              Le tuteur IA est <strong className="text-[var(--github-text-primary)]">optionnel</strong>{' '}
+              et désactivé par défaut. Il fonctionne en mode <strong>BYOK</strong>{' '}
+              (Bring Your Own Key) — tu apportes ta propre clé API du provider de
+              ton choix. Cette section décrit précisément quelles données circulent,
+              qui les voit, et combien de temps elles sont conservées.
+            </p>
+
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Architecture sans serveur</h3>
+                <p className="text-sm">
+                  <strong className="text-[var(--github-text-primary)]">Aucun serveur Terminal Learning ne voit ta clé ni tes questions.</strong>{' '}
+                  Quand tu poses une question au tuteur, ton navigateur appelle
+                  directement l'API du provider que tu as choisi (OpenRouter,
+                  Anthropic, OpenAI ou Gemini). Terminal Learning n'a pas
+                  d'intermédiaire dans la chaîne — ce choix est figé dans
+                  l'architecture (cf.{' '}
+                  <a
+                    href="https://github.com/thierryvm/TerminalLearning/blob/main/docs/adr/ADR-002-openrouter-byok-tiers.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-emerald-400 hover:text-emerald-300 underline"
+                  >
+                    ADR-002
+                  </a>
+                  ).
+                </p>
+              </div>
+
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Données envoyées au provider à chaque question</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm ml-2">
+                  <li>Une consigne système expliquant que l'IA est ton tuteur shell (frozen, identique à chaque appel).</li>
+                  <li>Un contexte statique de la plateforme (nombre de modules, environnements supportés — pas de progression personnelle).</li>
+                  <li>Le contexte de la leçon en cours si tu poses la question depuis une leçon (slug + objectif pédagogique public).</li>
+                  <li>La question que tu tapes.</li>
+                </ul>
+              </div>
+
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Données <em>non</em> envoyées</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm ml-2">
+                  <li>Ton historique de saisie dans le terminal d'entraînement.</li>
+                  <li>Tes données de progression (leçons réussies, scores).</li>
+                  <li>Ton email, ton identifiant Supabase, ton profil OAuth.</li>
+                  <li>Les questions précédentes hors fenêtre courte de conversation (transcript in-memory uniquement, jamais persistant).</li>
+                </ul>
+              </div>
+
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Conservation locale de ta clé</h3>
+                <p className="text-sm mb-2">
+                  Ta clé API est stockée <strong className="text-[var(--github-text-primary)]">uniquement sur ce navigateur</strong> :
+                </p>
+                <ul className="list-disc list-inside space-y-1 text-sm ml-2">
+                  <li><strong className="text-[var(--github-text-primary)]">Mode par défaut</strong> : localStorage en clair (suffisant pour les clés `:free` sans risque financier).</li>
+                  <li><strong className="text-[var(--github-text-primary)]">Mode chiffré opt-in</strong> : IndexedDB + AES-GCM 256 bits + PBKDF2 ≥ 210 000 itérations dérivées d'une passphrase que tu choisis. Recommandé pour les clés payantes.</li>
+                  <li>Tu peux supprimer ta clé à tout moment via le bouton « Oublier ma clé » dans le panel ou la page <code className="text-emerald-400 text-sm">/app/settings</code>.</li>
+                </ul>
+              </div>
+
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Consentement et durée</h3>
+                <p className="text-sm">
+                  Avant la première utilisation du tuteur, un encart de consentement
+                  liste les trois points ci-dessus. Ton consentement est tracé
+                  localement (date d'acceptation + version + date d'expiration) et{' '}
+                  <strong className="text-[var(--github-text-primary)]">valable 12 mois</strong>.
+                  Au-delà, le tuteur te re-demandera ton consentement. Tu peux le
+                  révoquer à tout moment depuis la page paramètres.
+                </p>
+              </div>
+
+              <div className="p-4 rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+                <h3 className="text-[var(--github-text-primary)] font-medium mb-2">Politiques des providers tiers</h3>
+                <p className="text-sm mb-2">
+                  Une fois la requête envoyée, les données sont traitées par le
+                  provider que tu as choisi selon <em>sa</em> politique de
+                  confidentialité :
+                </p>
+                <ul className="list-disc list-inside space-y-1 text-sm ml-2">
+                  <li><a href="https://openrouter.ai/privacy" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline">OpenRouter</a> (recommandé pour débuter — modèles `:free` gratuits)</li>
+                  <li><a href="https://www.anthropic.com/legal/privacy" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline">Anthropic (Claude)</a></li>
+                  <li><a href="https://openai.com/policies/privacy-policy/" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline">OpenAI</a></li>
+                  <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline">Google (Gemini)</a></li>
+                </ul>
+                <p className="text-sm mt-3">
+                  <strong className="text-[var(--github-text-primary)]">Conseil</strong> : si tu utilises une clé partagée (compte d'école, organisation), vérifie aussi la politique du provider sur la conservation des prompts pour usage entraînement modèle. La plupart proposent un opt-out, OpenRouter le fait par défaut sur les modèles non-`:free`.
+                </p>
+              </div>
+            </div>
+          </section>
+
           <section>
-            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">4. Cookies</h2>
+            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">5. Cookies</h2>
             <p>
               Terminal Learning n'utilise pas de cookies de tracking, publicitaires ou analytiques.
               Seul le <code className="text-emerald-400 text-sm">localStorage</code> du navigateur
@@ -119,7 +215,7 @@ export function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">5. Tes droits (RGPD)</h2>
+            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">6. Tes droits (RGPD)</h2>
             <p className="mb-3">
               Conformément au Règlement Général sur la Protection des Données (RGPD —
               Règlement UE 2016/679) et à la loi belge du 30 juillet 2018 relative à la
@@ -143,7 +239,7 @@ export function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">6. Autorité de contrôle</h2>
+            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">7. Autorité de contrôle</h2>
             <p>
               En Belgique, l'autorité de protection des données est l'
               <strong className="text-[var(--github-text-primary)]">Autorité de Protection des Données (APD)</strong> —
@@ -157,7 +253,7 @@ export function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">7. Modifications</h2>
+            <h2 className="text-lg font-semibold text-[var(--github-text-primary)] mb-3">8. Modifications</h2>
             <p>
               Cette politique peut être mise à jour. La date de dernière modification est
               indiquée en haut de cette page. Les modifications importantes seront annoncées

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router';
 import { useFocusTrap } from '../../lib/hooks/useFocusTrap';
 import {
-  Terminal, LayoutDashboard, BookOpen,
+  Terminal, LayoutDashboard, BookOpen, Settings,
   ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock,
 } from 'lucide-react';
 import { UserMenu } from './auth/UserMenu';
@@ -155,6 +155,20 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           >
             <BookOpen size={16} />
             Référence
+          </NavLink>
+          <NavLink
+            to="/app/settings"
+            onClick={onClose}
+            className={({ isActive }) =>
+              `flex items-center gap-2.5 min-h-11 px-3 py-2 rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 ${
+                isActive
+                  ? 'bg-[#21262d] text-[var(--github-text-primary)]'
+                  : 'text-[var(--github-text-secondary)] hover:bg-[var(--github-border-secondary)] hover:text-[var(--github-text-primary)]'
+              }`
+            }
+          >
+            <Settings size={16} />
+            Paramètres IA
           </NavLink>
         </nav>
 

--- a/src/app/components/ai/AiConsentModal.tsx
+++ b/src/app/components/ai/AiConsentModal.tsx
@@ -1,0 +1,126 @@
+/**
+ * AiConsentModal — THI-112 Phase A commit 2.
+ *
+ * Standalone consent block, extracted from the previously inline
+ * `ConsentBlock` inside `AiTutorPanel`. Same UX (in-panel disclosure with
+ * a checkbox + accept button), now reusable so the upcoming `AiSettings`
+ * page (Phase B) can surface the same disclosure when the learner reviews
+ * or revokes consent.
+ *
+ * Storage contract is owned by `useAiTutor.ts`:
+ *  - `tutor.giveConsent()` writes a versioned `ConsentRecord` payload
+ *    `{ version, acceptedAt, expiresAt }` to localStorage (M3-AI fix from
+ *    the llm-security-auditor 9.0/10 re-baseline; previously a bare
+ *    `'true'` literal with no timestamp, no expiry, no version)
+ *  - `tutor.consentGiven` is `false` again when the record expires or its
+ *    version no longer matches `CONSENT_VERSION`, so this component
+ *    re-renders and the learner is prompted again
+ *
+ * Despite the historical name "Modal" (kept to match Linear THI-112), the
+ * component is rendered inline inside the panel's flex column rather than
+ * a Dialog popup — the panel's own drawer container already serves as the
+ * modal surface. The standalone export lets us reuse the disclosure body
+ * elsewhere (e.g. a review banner under /app/settings).
+ */
+import {
+  useId,
+  useState,
+  type ChangeEvent,
+} from 'react';
+import { Link } from 'react-router';
+
+export interface AiConsentModalProps {
+  /** Called when the learner ticks the checkbox and confirms. */
+  onAccept: () => void;
+  /** Optional: CSS class overrides for embedding contexts. */
+  className?: string;
+}
+
+export function AiConsentModal({ onAccept, className }: AiConsentModalProps) {
+  const [checked, setChecked] = useState(false);
+  const checkboxId = useId();
+
+  const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
+  };
+
+  return (
+    <div
+      role="region"
+      aria-labelledby="ai-consent-title"
+      className={
+        className ??
+        'flex flex-1 flex-col gap-3 overflow-y-auto p-4 text-sm text-[var(--github-text-primary)]'
+      }
+    >
+      <h3 id="ai-consent-title" className="sr-only">
+        Consentement Tuteur IA
+      </h3>
+      <p>
+        Avant d'utiliser le tuteur IA, j'ai besoin que tu confirmes trois
+        points importants :
+      </p>
+      <ul className="list-disc space-y-1 pl-5 text-[var(--github-text-secondary)]">
+        <li>
+          Ta clé API reste stockée sur <strong>ce navigateur uniquement</strong>.
+          Aucun serveur Terminal Learning ne la voit.
+        </li>
+        <li>
+          Tes questions sont envoyées <strong>directement au provider choisi</strong>{' '}
+          (OpenRouter, Anthropic, OpenAI ou Gemini). Ton historique terminal,
+          ton profil et tes données de leçon ne sont pas partagés.
+        </li>
+        <li>
+          Tu peux supprimer ta clé à tout moment via le bouton « Oublier ma clé ».
+        </li>
+      </ul>
+      <p className="text-xs text-[var(--github-text-secondary)]">
+        Détails complets dans la{' '}
+        <Link
+          to="/privacy#ai-processing"
+          className="text-[var(--github-accent)] underline hover:text-[var(--github-accent-hover)]"
+        >
+          section IA de la politique de confidentialité
+        </Link>
+        . Pas sûr·e du provider à choisir ?{' '}
+        <a
+          href="https://github.com/thierryvm/TerminalLearning/blob/main/docs/guides/ai-tutor-quickstart.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[var(--github-accent)] underline hover:text-[var(--github-accent-hover)]"
+        >
+          Lire le guide démarrage (5 min) →
+        </a>
+      </p>
+      <label
+        htmlFor={checkboxId}
+        className="mt-2 flex cursor-pointer items-start gap-2 rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] p-3"
+      >
+        <input
+          id={checkboxId}
+          type="checkbox"
+          checked={checked}
+          onChange={handleCheckboxChange}
+          className="mt-0.5 h-4 w-4 cursor-pointer accent-[var(--github-accent)]"
+          aria-describedby="ai-consent-summary"
+        />
+        <span id="ai-consent-summary" className="text-[var(--github-text-primary)]">
+          <strong>J'ai lu et compris</strong> les trois points ci-dessus.
+        </span>
+      </label>
+      <button
+        type="button"
+        onClick={onAccept}
+        disabled={!checked}
+        className="mt-2 self-start rounded-md bg-[var(--github-accent)] px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-[var(--github-accent-hover)] focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Accepter et utiliser le tuteur IA
+      </button>
+      <p className="text-xs text-[var(--github-text-secondary)]">
+        Ton consentement est valable 12 mois et peut être révoqué à tout
+        moment depuis les paramètres ou en cliquant « Oublier ma clé »
+        ci-dessous.
+      </p>
+    </div>
+  );
+}

--- a/src/app/components/ai/AiConsentModal.tsx
+++ b/src/app/components/ai/AiConsentModal.tsx
@@ -44,6 +44,15 @@ export function AiConsentModal({ onAccept, className }: AiConsentModalProps) {
     setChecked(e.target.checked);
   };
 
+  // Defence-in-depth: do not rely on the button's `disabled` attribute alone.
+  // If the attribute is stripped (devtools, automation, theme override), the
+  // handler must still refuse to fire unless the in-component state confirms
+  // the learner has ticked the checkbox. Sourcery review on PR #228.
+  const handleAccept = () => {
+    if (!checked) return;
+    onAccept();
+  };
+
   return (
     <div
       role="region"
@@ -110,16 +119,22 @@ export function AiConsentModal({ onAccept, className }: AiConsentModalProps) {
       </label>
       <button
         type="button"
-        onClick={onAccept}
+        onClick={handleAccept}
         disabled={!checked}
         className="mt-2 self-start rounded-md bg-[var(--github-accent)] px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-[var(--github-accent-hover)] focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Accepter et utiliser le tuteur IA
       </button>
       <p className="text-xs text-[var(--github-text-secondary)]">
-        Ton consentement est valable 12 mois et peut être révoqué à tout
-        moment depuis les paramètres ou en cliquant « Oublier ma clé »
-        ci-dessous.
+        Ton consentement est valable <strong>12 mois</strong> et peut être
+        <strong>révoqué à tout moment</strong> depuis la page{' '}
+        <code className="rounded bg-[var(--github-bg-tertiary)] px-1 py-0.5">
+          /app/settings
+        </code>
+        . Le bouton « Oublier ma clé » ci-dessous ne fait que{' '}
+        <strong>supprimer la clé API</strong> ; il ne révoque pas
+        l'enregistrement du consentement (utilise la page paramètres pour
+        ça).
       </p>
     </div>
   );

--- a/src/app/components/ai/AiKeySetup.tsx
+++ b/src/app/components/ai/AiKeySetup.tsx
@@ -36,31 +36,11 @@ import {
   saveKey as kmSaveKey,
   type Provider,
 } from '@/lib/ai/keyManager';
-
-const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
-  openrouter: 'OpenRouter',
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  gemini: 'Gemini',
-};
-
-const PROVIDER_PREFIX_HINT: Readonly<Record<Provider, string>> = {
-  openrouter: 'sk-or-v1-…',
-  anthropic: 'sk-ant-…',
-  openai: 'sk-…',
-  gemini: 'AIza…',
-};
-
-const PROVIDER_QUICK_HELP: Readonly<Record<Provider, string>> = {
-  openrouter:
-    '🔄 Hub multi-providers — modèles `:free` gratuits (Llama 3.3 70B par défaut, GPT-OSS 20B…). Recommandé pour débuter.',
-  anthropic:
-    '🧠 Claude (Anthropic) — raisonnement haute qualité, excellent en code. Crédit Anthropic requis.',
-  openai:
-    '⚠️ OpenAI direct refuse les requêtes navigateur (CORS). Préfère OpenRouter pour accéder à GPT-4o-mini & co.',
-  gemini:
-    '✨ Gemini (Google) — quota gratuit généreux (Gemini 2.0 Flash). Crédit Google AI Studio requis.',
-};
+import {
+  PROVIDER_LABELS,
+  PROVIDER_PREFIX_HINT,
+  PROVIDER_QUICK_HELP,
+} from '@/lib/ai/providers/meta';
 
 export interface AiKeySetupProps {
   provider: Provider;

--- a/src/app/components/ai/AiKeySetup.tsx
+++ b/src/app/components/ai/AiKeySetup.tsx
@@ -1,0 +1,295 @@
+/**
+ * AiKeySetup — THI-112 Phase A commit 1.
+ *
+ * Standalone, reusable key-entry component. Two consumers:
+ *  - `AiTutorPanel` (in-panel first-time UX): replaces the previous inline
+ *    `KeyEntryBlock` so panel + settings share one source of truth.
+ *  - `AiSettings` (THI-112 Phase B): edit-key flow under `/app/settings`.
+ *
+ * V1 keeps the BYOK guarantees from THI-110 + ADR-005:
+ *  - validates the prefix client-side via `detectProvider` so a wrong key
+ *    is rejected before it ever leaves the form
+ *  - persists via `keyManager.saveKey` — plain by default, encrypted opt-in
+ *    (AES-GCM + PBKDF2 ≥ 210k iter via Web Crypto, IndexedDB-backed)
+ *  - never sends the key to a Terminal Learning server (no server in V1)
+ *  - links the "AI processing" privacy section so the learner can read
+ *    what data flows through which provider before pasting a key
+ *
+ * V1 deliberately omits the live "test the key" call:
+ *  - cross-provider CORS surfaces (OpenAI blocks browser fetches outright)
+ *  - rate-limited probe endpoints would burn the learner's quota
+ *  - structural prefix validation already catches the most common mistake
+ *  - the very next message in the panel exercises the key for real
+ *  Live testing is parked for THI-114 (V1.5 model picker + curated probe).
+ */
+import {
+  useId,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
+import { Link } from 'react-router';
+
+import {
+  detectProvider,
+  saveKey as kmSaveKey,
+  type Provider,
+} from '@/lib/ai/keyManager';
+
+const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
+  openrouter: 'OpenRouter',
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+};
+
+const PROVIDER_PREFIX_HINT: Readonly<Record<Provider, string>> = {
+  openrouter: 'sk-or-v1-…',
+  anthropic: 'sk-ant-…',
+  openai: 'sk-…',
+  gemini: 'AIza…',
+};
+
+const PROVIDER_QUICK_HELP: Readonly<Record<Provider, string>> = {
+  openrouter:
+    '🔄 Hub multi-providers — modèles `:free` gratuits (Llama 3.3 70B par défaut, GPT-OSS 20B…). Recommandé pour débuter.',
+  anthropic:
+    '🧠 Claude (Anthropic) — raisonnement haute qualité, excellent en code. Crédit Anthropic requis.',
+  openai:
+    '⚠️ OpenAI direct refuse les requêtes navigateur (CORS). Préfère OpenRouter pour accéder à GPT-4o-mini & co.',
+  gemini:
+    '✨ Gemini (Google) — quota gratuit généreux (Gemini 2.0 Flash). Crédit Google AI Studio requis.',
+};
+
+export interface AiKeySetupProps {
+  provider: Provider;
+  /** Called after the key has been saved successfully via `keyManager`. */
+  onSaved: () => void;
+  /** Optional: CSS class overrides for embedding contexts (panel vs settings page). */
+  className?: string;
+}
+
+const MIN_PASSPHRASE = 8;
+
+export function AiKeySetup({ provider, onSaved, className }: AiKeySetupProps) {
+  const [value, setValue] = useState('');
+  const [encryptOpt, setEncryptOpt] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+  const [passphraseConfirm, setPassphraseConfirm] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const keyInputId = useId();
+  const passphraseId = useId();
+  const passphraseConfirmId = useId();
+
+  const expectedPrefix = PROVIDER_PREFIX_HINT[provider];
+  const providerHint = PROVIDER_QUICK_HELP[provider];
+  const openaiNeedsProxy = provider === 'openai';
+
+  // Reset transient encrypt-mode state when the user switches off the toggle so
+  // a previously typed passphrase is not silently held in memory while the
+  // checkbox says "plain mode". Defence-in-depth on the in-memory surface.
+  const handleEncryptChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.checked;
+    setEncryptOpt(next);
+    if (!next) {
+      setPassphrase('');
+      setPassphraseConfirm('');
+    }
+  };
+
+  const passphraseProblem = useMemo<string | null>(() => {
+    if (!encryptOpt) return null;
+    if (passphrase.length === 0) return null; // not yet typed → no error
+    if (passphrase.length < MIN_PASSPHRASE) {
+      return `La passphrase doit faire au moins ${MIN_PASSPHRASE} caractères.`;
+    }
+    if (passphraseConfirm.length > 0 && passphrase !== passphraseConfirm) {
+      return 'Les deux passphrases ne correspondent pas.';
+    }
+    return null;
+  }, [encryptOpt, passphrase, passphraseConfirm]);
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      setError('La clé est vide.');
+      return;
+    }
+    const detected = detectProvider(trimmed);
+    if (detected !== provider) {
+      setError(
+        `Cette clé ne correspond pas au provider ${PROVIDER_LABELS[provider]} (préfixe attendu : ${expectedPrefix}).`,
+      );
+      return;
+    }
+    if (encryptOpt) {
+      if (passphrase.length < MIN_PASSPHRASE) {
+        setError(`La passphrase doit faire au moins ${MIN_PASSPHRASE} caractères.`);
+        return;
+      }
+      if (passphrase !== passphraseConfirm) {
+        setError('Les deux passphrases ne correspondent pas.');
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      await kmSaveKey(provider, trimmed, encryptOpt ? { encrypt: true, passphrase } : {});
+      // Wipe the typed secret material from React state so it does not linger
+      // in memory waiting for GC. The persisted copy lives in keyManager.
+      setValue('');
+      setPassphrase('');
+      setPassphraseConfirm('');
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur lors de la sauvegarde.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={
+        className ??
+        'flex flex-1 flex-col gap-3 overflow-y-auto p-4 text-sm text-[var(--github-text-primary)]'
+      }
+      aria-label={`Configuration de la clé ${PROVIDER_LABELS[provider]}`}
+    >
+      <p className="rounded-md bg-[var(--github-bg-secondary)] p-2 text-xs text-[var(--github-text-secondary)]">
+        {providerHint}
+      </p>
+
+      <p>
+        Colle ta clé <strong>{PROVIDER_LABELS[provider]}</strong> ci-dessous.
+        Préfixe attendu :{' '}
+        <code className="rounded bg-[var(--github-bg-tertiary)] px-1 py-0.5 text-xs">
+          {expectedPrefix}
+        </code>
+      </p>
+
+      {openaiNeedsProxy && (
+        <div
+          role="alert"
+          className="rounded border border-yellow-500/30 bg-yellow-500/10 p-2 text-xs text-yellow-300"
+        >
+          ⚠️ <strong>OpenAI</strong> bloque les appels directs depuis le
+          navigateur (politique CORS officielle d'OpenAI). Ta clé sera
+          enregistrée mais l'envoi échouera avec une erreur réseau.{' '}
+          <strong>Solution V1</strong> : utilise <strong>OpenRouter</strong> à
+          la place — il propose les mêmes modèles GPT (
+          <code>openai/gpt-4o-mini</code>, <code>openai/gpt-oss-20b:free</code>
+          …) sans cette limitation. Le proxy OpenAI direct arrivera en V2.
+        </div>
+      )}
+
+      <label htmlFor={keyInputId} className="sr-only">
+        Clé API {PROVIDER_LABELS[provider]}
+      </label>
+      <input
+        id={keyInputId}
+        name="ai-tutor-api-key"
+        type="password"
+        autoComplete="off"
+        spellCheck={false}
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+        placeholder={expectedPrefix}
+        className="w-full rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] p-2 text-base outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 md:text-sm"
+      />
+
+      <fieldset className="flex flex-col gap-2 rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] p-3">
+        <label className="flex cursor-pointer items-start gap-2 text-xs text-[var(--github-text-primary)]">
+          <input
+            type="checkbox"
+            checked={encryptOpt}
+            onChange={handleEncryptChange}
+            className="mt-0.5 h-4 w-4 cursor-pointer accent-[var(--github-accent)]"
+          />
+          <span>
+            <strong>Chiffrer cette clé avec une passphrase</strong>{' '}
+            <span className="text-[var(--github-text-secondary)]">
+              (recommandé pour les clés payantes — Anthropic / OpenAI / Gemini)
+            </span>
+          </span>
+        </label>
+        {encryptOpt && (
+          <div className="flex flex-col gap-2 pl-6">
+            <label htmlFor={passphraseId} className="text-xs text-[var(--github-text-secondary)]">
+              Passphrase (≥ {MIN_PASSPHRASE} caractères)
+            </label>
+            <input
+              id={passphraseId}
+              type="password"
+              autoComplete="new-password"
+              spellCheck={false}
+              value={passphrase}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassphrase(e.target.value)}
+              className="w-full rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-tertiary)] p-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+            />
+            <label
+              htmlFor={passphraseConfirmId}
+              className="text-xs text-[var(--github-text-secondary)]"
+            >
+              Confirme la passphrase
+            </label>
+            <input
+              id={passphraseConfirmId}
+              type="password"
+              autoComplete="new-password"
+              spellCheck={false}
+              value={passphraseConfirm}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassphraseConfirm(e.target.value)}
+              className="w-full rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-tertiary)] p-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+            />
+            <p className="text-xs text-[var(--github-text-secondary)]">
+              ⚠️ La passphrase ne peut <strong>pas</strong> être récupérée. Si tu
+              la perds, tu devras supprimer la clé chiffrée et en saisir une
+              nouvelle.
+            </p>
+            {passphraseProblem && (
+              <p className="text-xs text-yellow-300" role="status">
+                {passphraseProblem}
+              </p>
+            )}
+          </div>
+        )}
+      </fieldset>
+
+      {error && (
+        <p className="text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="self-start rounded-md bg-[var(--github-accent)] px-4 py-2 text-sm font-medium text-white outline-none hover:bg-[var(--github-accent-hover)] focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 disabled:opacity-50"
+      >
+        {saving ? 'Sauvegarde…' : 'Enregistrer'}
+      </button>
+
+      <p className="text-xs text-[var(--github-text-secondary)]">
+        Ta clé reste sur ce navigateur uniquement. Aucun serveur Terminal
+        Learning ne la voit. Les questions sont envoyées <strong>directement</strong>
+        {' '}au provider choisi. Plus de détails dans la{' '}
+        <Link
+          to="/privacy#ai-processing"
+          className="text-[var(--github-accent)] underline hover:text-[var(--github-accent-hover)]"
+        >
+          section IA de la politique de confidentialité
+        </Link>
+        .
+      </p>
+    </form>
+  );
+}

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -26,6 +26,7 @@ import {
   type Provider,
 } from '@/lib/ai/keyManager';
 import { DEFAULT_MODELS } from '@/lib/ai/providers';
+import { PROVIDER_LABELS } from '@/lib/ai/providers/meta';
 import type { TutorLang } from '@/lib/ai/systemPrompt';
 import { useAiTutor } from '@/lib/ai/useAiTutor';
 
@@ -36,12 +37,6 @@ import { MessageList } from './parts/MessageList';
 import { RateLimitBadge } from './parts/RateLimitBadge';
 
 const PROVIDER_STORAGE_KEY = 'ai_tutor_provider';
-const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
-  openrouter: 'OpenRouter',
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  gemini: 'Gemini',
-};
 
 interface Props {
   lang?: TutorLang;

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -29,6 +29,7 @@ import { DEFAULT_MODELS } from '@/lib/ai/providers';
 import type { TutorLang } from '@/lib/ai/systemPrompt';
 import { useAiTutor } from '@/lib/ai/useAiTutor';
 
+import { AiConsentModal } from './AiConsentModal';
 import { AiKeySetup } from './AiKeySetup';
 import { MessageInput } from './parts/MessageInput';
 import { MessageList } from './parts/MessageList';
@@ -271,7 +272,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
             <ProviderPicker value={provider} onChange={setProvider} />
 
             {!tutor.consentGiven ? (
-              <ConsentBlock onAccept={tutor.giveConsent} />
+              <AiConsentModal onAccept={tutor.giveConsent} />
             ) : !hasStoredKey ? (
               <AiKeySetup
                 provider={provider}
@@ -347,67 +348,6 @@ function ProviderPicker({ value, onChange }: PickerProps) {
           {PROVIDER_LABELS[p]}
         </button>
       ))}
-    </div>
-  );
-}
-
-interface ConsentProps {
-  onAccept: () => void;
-}
-
-function ConsentBlock({ onAccept }: ConsentProps) {
-  const [checked, setChecked] = useState(false);
-  return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4 text-sm text-[var(--github-text-primary)]">
-      <p>
-        Avant d'utiliser le tuteur IA, j'ai besoin que tu confirmes deux points
-        importants :
-      </p>
-      <ul className="list-disc space-y-1 pl-5 text-[var(--github-text-secondary)]">
-        <li>
-          Ta clé API reste stockée sur <strong>ce navigateur uniquement</strong>.
-          Aucun serveur Terminal Learning ne la voit.
-        </li>
-        <li>
-          Tes questions sont envoyées <strong>directement au provider choisi</strong>{' '}
-          (OpenRouter, Anthropic, OpenAI ou Gemini). Ton historique terminal,
-          ton profil et tes données de leçon ne sont pas partagés.
-        </li>
-        <li>
-          Tu peux supprimer ta clé à tout moment via le bouton « Oublier ma clé ».
-        </li>
-      </ul>
-      <p className="text-xs text-[var(--github-text-secondary)]">
-        Pas sûr·e du provider à choisir ?{' '}
-        <a
-          href="https://github.com/thierryvm/TerminalLearning/blob/main/docs/guides/ai-tutor-quickstart.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-[var(--github-accent)] underline hover:text-[var(--github-accent-hover)]"
-        >
-          Lire le guide démarrage (5 min) →
-        </a>
-      </p>
-      <label className="mt-2 flex cursor-pointer items-start gap-2 rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] p-3">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(e) => setChecked(e.target.checked)}
-          className="mt-0.5 h-4 w-4 cursor-pointer accent-[var(--github-accent)]"
-          aria-describedby="ai-consent-summary"
-        />
-        <span id="ai-consent-summary" className="text-[var(--github-text-primary)]">
-          <strong>J'ai lu et compris</strong> les trois points ci-dessus.
-        </span>
-      </label>
-      <button
-        type="button"
-        onClick={onAccept}
-        disabled={!checked}
-        className="mt-2 self-start rounded-md bg-[var(--github-accent)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        Accepter et utiliser le tuteur IA
-      </button>
     </div>
   );
 }

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -16,21 +16,20 @@
  *  - the key input uses `type="password"` + `autocomplete="off"` so browser
  *    form-fillers / extensions don't see it
  */
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Sparkles } from 'lucide-react';
 
 import { buildPlatformContext } from '@/app/data/platformContext';
 import {
-  detectProvider,
   forgetKey as kmForgetKey,
   hasKey as kmHasKey,
-  saveKey as kmSaveKey,
   type Provider,
 } from '@/lib/ai/keyManager';
 import { DEFAULT_MODELS } from '@/lib/ai/providers';
 import type { TutorLang } from '@/lib/ai/systemPrompt';
 import { useAiTutor } from '@/lib/ai/useAiTutor';
 
+import { AiKeySetup } from './AiKeySetup';
 import { MessageInput } from './parts/MessageInput';
 import { MessageList } from './parts/MessageList';
 import { RateLimitBadge } from './parts/RateLimitBadge';
@@ -274,7 +273,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
             {!tutor.consentGiven ? (
               <ConsentBlock onAccept={tutor.giveConsent} />
             ) : !hasStoredKey ? (
-              <KeyEntryBlock
+              <AiKeySetup
                 provider={provider}
                 onSaved={() => setHasStoredKey(true)}
               />
@@ -410,133 +409,6 @@ function ConsentBlock({ onAccept }: ConsentProps) {
         Accepter et utiliser le tuteur IA
       </button>
     </div>
-  );
-}
-
-interface KeyEntryProps {
-  provider: Provider;
-  onSaved: () => void;
-}
-
-function KeyEntryBlock({ provider, onSaved }: KeyEntryProps) {
-  const [value, setValue] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  const expectedPrefix = useMemo(() => {
-    switch (provider) {
-      case 'openrouter':
-        return 'sk-or-v1-…';
-      case 'anthropic':
-        return 'sk-ant-…';
-      case 'openai':
-        return 'sk-…';
-      case 'gemini':
-        return 'AIza…';
-    }
-  }, [provider]);
-
-  // Short novice-friendly description per provider, surfaced above the key
-  // input so the learner understands what they are about to use. Verbose
-  // comparison lives in docs/guides/ai-tutor-quickstart.md (linked from the
-  // ConsentBlock).
-  const providerHint = useMemo(() => {
-    switch (provider) {
-      case 'openrouter':
-        return '🔄 Hub multi-providers — modèles :free gratuits (Llama 3.3 70B par défaut, GPT-OSS 20B…). Recommandé pour débuter.';
-      case 'anthropic':
-        return '🧠 Claude (Anthropic) — raisonnement haute qualité, excellent en code. Crédit Anthropic requis.';
-      case 'openai':
-        return '⚠️ OpenAI direct refuse les requêtes navigateur (CORS). Préfère OpenRouter pour accéder à GPT-4o-mini & co.';
-      case 'gemini':
-        return '✨ Gemini (Google) — quota gratuit généreux (Gemini 2.0 Flash). Crédit Google AI Studio requis.';
-    }
-  }, [provider]);
-
-  // OpenAI does not allow direct browser fetches without a backend proxy
-  // (CORS policy on api.openai.com). Confirmed during live validation
-  // 2026-05-04 against http://localhost:5173. The other three providers
-  // (OpenRouter, Anthropic with opt-in header, Gemini) are all fine.
-  const openaiNeedsProxy = provider === 'openai';
-
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      setError('La clé est vide.');
-      return;
-    }
-    const detected = detectProvider(trimmed);
-    if (detected !== provider) {
-      setError(
-        `Cette clé ne correspond pas au provider ${PROVIDER_LABELS[provider]} (préfixe attendu : ${expectedPrefix}).`,
-      );
-      return;
-    }
-    setError(null);
-    setSaving(true);
-    try {
-      await kmSaveKey(provider, trimmed);
-      setValue('');
-      onSaved();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Erreur lors de la sauvegarde.');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <form
-      onSubmit={onSubmit}
-      className="flex flex-1 flex-col gap-3 overflow-y-auto p-4 text-sm text-[var(--github-text-primary)]"
-    >
-      <p className="rounded-md bg-[var(--github-bg-secondary)] p-2 text-xs text-[var(--github-text-secondary)]">
-        {providerHint}
-      </p>
-      <p>
-        Colle ta clé <strong>{PROVIDER_LABELS[provider]}</strong> ci-dessous.
-        Préfixe attendu : <code className="rounded bg-[var(--github-bg-tertiary)] px-1 py-0.5 text-xs">{expectedPrefix}</code>
-      </p>
-      {openaiNeedsProxy && (
-        <div
-          role="alert"
-          className="rounded border border-yellow-500/30 bg-yellow-500/10 p-2 text-xs text-yellow-300"
-        >
-          ⚠️ <strong>OpenAI</strong> bloque les appels directs depuis le
-          navigateur (politique CORS officielle d'OpenAI, pour décourager le
-          BYOK client-side). Ta clé sera enregistrée mais l'envoi échouera
-          avec une erreur réseau. <strong>Solution V1</strong> : utilise{' '}
-          <strong>OpenRouter</strong> à la place — il propose les mêmes
-          modèles GPT (`openai/gpt-4o-mini`, `openai/gpt-oss-20b:free`, etc.)
-          sans cette limitation. Le proxy OpenAI direct arrivera en V2.
-        </div>
-      )}
-      <input
-        type="password"
-        name="ai-tutor-api-key"
-        id="ai-tutor-api-key"
-        autoComplete="off"
-        spellCheck={false}
-        value={value}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
-        aria-label="Clé API"
-        placeholder={expectedPrefix}
-        className="w-full rounded-md border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] p-2 text-base md:text-sm outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0"
-      />
-      {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
-      <button
-        type="submit"
-        disabled={saving}
-        className="self-start rounded-md bg-[var(--github-accent)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 disabled:opacity-50"
-      >
-        {saving ? 'Sauvegarde…' : 'Enregistrer'}
-      </button>
-      <p className="text-xs text-[var(--github-text-secondary)]">
-        ⚠️ Mode V1 : la clé est stockée en clair dans le localStorage. Le mode
-        chiffré (passphrase + AES-GCM) sera activé en THI-112.
-      </p>
-    </form>
   );
 }
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -26,6 +26,9 @@ const LessonPage = lazy(() =>
 const CommandReference = lazy(() =>
   import('./components/CommandReference').then(({ CommandReference }) => ({ default: CommandReference }))
 );
+const AiSettings = lazy(() =>
+  import('./components/AiSettings').then(({ AiSettings }) => ({ default: AiSettings }))
+);
 const Changelog = lazy(() =>
   import('./components/Changelog').then(({ Changelog }) => ({ default: Changelog }))
 );
@@ -52,6 +55,7 @@ export const router = createBrowserRouter([
       { index: true, Component: Dashboard },
       { path: 'learn/:moduleId/:lessonId', Component: LessonPage },
       { path: 'reference', Component: CommandReference },
+      { path: 'settings', Component: AiSettings },
     ],
   },
 

--- a/src/lib/ai/providers/meta.ts
+++ b/src/lib/ai/providers/meta.ts
@@ -1,0 +1,46 @@
+/**
+ * Provider display metadata — single source of truth.
+ *
+ * Centralises the human-facing labels, prefix hints and quick-help
+ * blurbs that the three onboarding surfaces share:
+ *
+ *  - `AiTutorPanel` (provider picker header, key entry prefix)
+ *  - `AiKeySetup` (provider hint paragraph above the key input)
+ *  - `AiSettings` (per-row provider name)
+ *
+ * Before this module these three constants were duplicated inline
+ * inside each consumer; adding a provider or renaming a label meant
+ * editing the same dictionary in three places, with the obvious risk
+ * of drift (Sourcery review on PR #228, 11 May 2026). Now every
+ * surface imports from here; one edit, three updates.
+ *
+ * Keep the keys strictly in sync with the `Provider` union in
+ * `keyManager.ts` — the `Readonly<Record<Provider, string>>` typing
+ * makes a missing key a compile error.
+ */
+import type { Provider } from '../keyManager';
+
+export const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
+  openrouter: 'OpenRouter',
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+};
+
+export const PROVIDER_PREFIX_HINT: Readonly<Record<Provider, string>> = {
+  openrouter: 'sk-or-v1-…',
+  anthropic: 'sk-ant-…',
+  openai: 'sk-…',
+  gemini: 'AIza…',
+};
+
+export const PROVIDER_QUICK_HELP: Readonly<Record<Provider, string>> = {
+  openrouter:
+    '🔄 Hub multi-providers — modèles `:free` gratuits (Llama 3.3 70B par défaut, GPT-OSS 20B…). Recommandé pour débuter.',
+  anthropic:
+    '🧠 Claude (Anthropic) — raisonnement haute qualité, excellent en code. Crédit Anthropic requis.',
+  openai:
+    '⚠️ OpenAI direct refuse les requêtes navigateur (CORS). Préfère OpenRouter pour accéder à GPT-4o-mini & co.',
+  gemini:
+    '✨ Gemini (Google) — quota gratuit généreux (Gemini 2.0 Flash). Crédit Google AI Studio requis.',
+};

--- a/src/lib/ai/useAiTutor.ts
+++ b/src/lib/ai/useAiTutor.ts
@@ -40,6 +40,34 @@ export const CONSENT_KEY = 'ai_consent_v1';
 export const RATE_STORAGE_KEY = 'ai_rate_v1';
 export const MODE_STORAGE_KEY = 'ai_tutor_mode';
 
+/**
+ * Current shape version of the persisted consent record. Bump when the
+ * record's user-facing semantics change (e.g. new disclosure clauses,
+ * new data flows). The runtime treats any record whose `version` does
+ * not match `CONSENT_VERSION` as not-yet-given so the modal re-prompts.
+ *
+ * THI-112 (M3-AI fix from llm-security-auditor re-baseline 10 May 2026 PM):
+ * the previous storage was a bare `'true'` literal — no timestamp, no
+ * expiry, no version. A consent given on day 0 was binding forever. The
+ * record below carries the three missing fields so re-consent on disclosure
+ * change becomes possible by bumping `CONSENT_VERSION`.
+ */
+export const CONSENT_VERSION = 1;
+
+/**
+ * GDPR-aligned re-consent window. One year is consistent with common
+ * Belgian/EU privacy practice for non-sensitive web services and matches
+ * the 12-month review cadence already used elsewhere in TL. Tunable per
+ * future ADR if user research shows a shorter window is warranted.
+ */
+export const CONSENT_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+export interface ConsentRecord {
+  version: number;
+  acceptedAt: number;
+  expiresAt: number;
+}
+
 const FRUSTRATION_PEEK_CHARS = 200;
 const FRUSTRATION_QUESTION_THRESHOLD = 2;
 
@@ -131,12 +159,58 @@ function writeRate(state: RateState): void {
   }
 }
 
-function readConsent(): boolean {
+/**
+ * Reads the persisted consent record, transparently migrating any legacy
+ * `'true'` literal to the new JSON shape on first read. Returns `null` if
+ * no record is stored, the JSON is malformed, the version does not match,
+ * or the record has expired. Never throws — storage access is best-effort.
+ */
+export function readConsentRecord(): ConsentRecord | null {
   try {
-    return localStorage.getItem(CONSENT_KEY) === 'true';
+    const raw = localStorage.getItem(CONSENT_KEY);
+    if (!raw) return null;
+
+    // Legacy migration: pre-THI-112 records were the literal string `'true'`.
+    // Treat them as accepted now with a fresh expiry — the user gave consent
+    // at some point, we just no longer know exactly when, and asking again on
+    // every load would be hostile UX.
+    if (raw === 'true') {
+      const now = Date.now();
+      const migrated: ConsentRecord = {
+        version: CONSENT_VERSION,
+        acceptedAt: now,
+        expiresAt: now + CONSENT_TTL_MS,
+      };
+      writeConsentRecord(migrated);
+      return migrated;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<ConsentRecord>;
+    if (
+      typeof parsed.version !== 'number' ||
+      typeof parsed.acceptedAt !== 'number' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+    if (parsed.version !== CONSENT_VERSION) return null;
+    if (Date.now() > parsed.expiresAt) return null;
+    return parsed as ConsentRecord;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function writeConsentRecord(record: ConsentRecord): void {
+  try {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(record));
+  } catch {
+    /* storage may be disabled — best effort */
+  }
+}
+
+function readConsent(): boolean {
+  return readConsentRecord() !== null;
 }
 
 function readMode(fallback: TutorMode): TutorMode {
@@ -254,11 +328,12 @@ export function useAiTutor(opts: UseAiTutorOpts): UseAiTutorState {
   );
 
   const giveConsent = useCallback(() => {
-    try {
-      localStorage.setItem(CONSENT_KEY, 'true');
-    } catch {
-      /* ignore */
-    }
+    const now = Date.now();
+    writeConsentRecord({
+      version: CONSENT_VERSION,
+      acceptedAt: now,
+      expiresAt: now + CONSENT_TTL_MS,
+    });
     setConsentGiven(true);
   }, []);
 

--- a/src/test/ai/AiConsentModal.test.tsx
+++ b/src/test/ai/AiConsentModal.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for src/app/components/ai/AiConsentModal.tsx — THI-112 Phase A commit 2.
+ *
+ * Covers the standalone consent block extracted from AiTutorPanel. The
+ * consent persistence itself (versioned JSON record with timestamp +
+ * expiry — the M3-AI fix) is exercised separately in `consent.test.ts`;
+ * this file focuses on the UI contract.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+import { AiConsentModal } from '@/app/components/ai/AiConsentModal';
+
+function renderModal() {
+  const onAccept = vi.fn();
+  const utils = render(
+    <MemoryRouter>
+      <AiConsentModal onAccept={onAccept} />
+    </MemoryRouter>,
+  );
+  return { ...utils, onAccept };
+}
+
+describe('AiConsentModal — disclosure body', () => {
+  it('lists the three GDPR-aligned disclosure points', () => {
+    renderModal();
+    expect(
+      screen.getByText(/Ta clé API reste stockée sur/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/directement au provider choisi/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Tu peux supprimer ta clé à tout moment/i),
+    ).toBeInTheDocument();
+  });
+
+  it('links to the AI section of the privacy policy', () => {
+    renderModal();
+    const link = screen.getByRole('link', {
+      name: /section IA de la politique de confidentialité/i,
+    });
+    expect(link).toHaveAttribute('href', '/privacy#ai-processing');
+  });
+
+  it('mentions the 12-month consent validity', () => {
+    renderModal();
+    expect(screen.getByText(/12 mois/i)).toBeInTheDocument();
+  });
+});
+
+describe('AiConsentModal — accept gate', () => {
+  it('disables the accept button until the checkbox is ticked', () => {
+    renderModal();
+    const button = screen.getByRole('button', {
+      name: /Accepter et utiliser/i,
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it('enables the accept button after the checkbox is ticked', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    const checkbox = screen.getByRole('checkbox');
+    await user.click(checkbox);
+    const button = screen.getByRole('button', {
+      name: /Accepter et utiliser/i,
+    });
+    expect(button).toBeEnabled();
+  });
+
+  it('does NOT call onAccept while the checkbox is unticked even if the button is forced', async () => {
+    // Defence-in-depth: even if the disabled attribute were stripped via
+    // devtools, the button is wired to onAccept directly without any state
+    // gating on the handler — the gate is the disabled attribute. We assert
+    // the explicit flow here so any future refactor that splits the gate
+    // out of `disabled` keeps it on the click path too.
+    const user = userEvent.setup();
+    const { onAccept } = renderModal();
+    const button = screen.getByRole('button', {
+      name: /Accepter et utiliser/i,
+    });
+    // userEvent respects `disabled`, so this is a no-op click.
+    await user.click(button);
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+
+  it('calls onAccept exactly once when the checkbox is ticked then the button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onAccept } = renderModal();
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(
+      screen.getByRole('button', { name: /Accepter et utiliser/i }),
+    );
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/ai/AiConsentModal.test.tsx
+++ b/src/test/ai/AiConsentModal.test.tsx
@@ -7,7 +7,7 @@
  * this file focuses on the UI contract.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
@@ -72,18 +72,17 @@ describe('AiConsentModal — accept gate', () => {
   });
 
   it('does NOT call onAccept while the checkbox is unticked even if the button is forced', async () => {
-    // Defence-in-depth: even if the disabled attribute were stripped via
-    // devtools, the button is wired to onAccept directly without any state
-    // gating on the handler — the gate is the disabled attribute. We assert
-    // the explicit flow here so any future refactor that splits the gate
-    // out of `disabled` keeps it on the click path too.
-    const user = userEvent.setup();
+    // Defence-in-depth: do not rely on the `disabled` attribute alone.
+    // `fireEvent.click` bypasses the userEvent disabled-check, simulating
+    // an adversarial path (devtools removing `disabled`, automation, etc).
+    // The in-component `handleAccept` must still refuse to fire onAccept
+    // because `checked` is `false`. Sourcery review on PR #228.
     const { onAccept } = renderModal();
     const button = screen.getByRole('button', {
       name: /Accepter et utiliser/i,
     });
-    // userEvent respects `disabled`, so this is a no-op click.
-    await user.click(button);
+    button.removeAttribute('disabled');
+    fireEvent.click(button);
     expect(onAccept).not.toHaveBeenCalled();
   });
 

--- a/src/test/ai/AiKeySetup.test.tsx
+++ b/src/test/ai/AiKeySetup.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for src/app/components/ai/AiKeySetup.tsx — THI-112 Phase A commit 1.
+ *
+ * Covers the standalone key-entry component used both by AiTutorPanel
+ * (first-time onboarding) and AiSettings (Phase B edit-key flow). Uses
+ * real `keyManager` via fake-indexeddb so save → read round-trips via
+ * the production code, both for plain and encrypted mode.
+ */
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+import { AiKeySetup } from '@/app/components/ai/AiKeySetup';
+import {
+  hasKey as kmHasKey,
+  isEncrypted as kmIsEncrypted,
+  getKey as kmGetKey,
+  forgetKey as kmForgetKey,
+} from '@/lib/ai/keyManager';
+
+const FAKE_OPENROUTER = 'sk-or-v1-FAKE_TEST_KEY_DO_NOT_USE_0123456789';
+const FAKE_ANTHROPIC = 'sk-ant-FAKE_TEST_KEY_DO_NOT_USE_0123';
+const FAKE_GEMINI = 'AIzaFAKE_TEST_KEY_DO_NOT_USE_0123';
+
+function renderSetup(provider: 'openrouter' | 'anthropic' | 'openai' | 'gemini') {
+  const onSaved = vi.fn();
+  const utils = render(
+    <MemoryRouter>
+      <AiKeySetup provider={provider} onSaved={onSaved} />
+    </MemoryRouter>,
+  );
+  return { ...utils, onSaved };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(async () => {
+  // Erase any encrypted entries the fake-indexeddb retained between tests.
+  await Promise.all([
+    kmForgetKey('openrouter'),
+    kmForgetKey('anthropic'),
+    kmForgetKey('openai'),
+    kmForgetKey('gemini'),
+  ]);
+});
+
+describe('AiKeySetup — provider hints and prefix expectations', () => {
+  it('shows the OpenRouter prefix expectation and quick help', () => {
+    renderSetup('openrouter');
+    expect(screen.getByText(/sk-or-v1-…/)).toBeInTheDocument();
+    expect(screen.getByText(/Hub multi-providers/)).toBeInTheDocument();
+  });
+
+  it('shows the OpenAI CORS warning only for openai', () => {
+    renderSetup('openai');
+    // The warning lives in role="alert" — its text spans multiple inline
+    // elements (<strong>OpenAI</strong> bloque…) so we match on the alert
+    // wrapper's textContent instead of `screen.getByText`.
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/bloque les appels directs/i);
+  });
+
+  it('does NOT show the OpenAI CORS warning for openrouter', () => {
+    renderSetup('openrouter');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the privacy link to /privacy#ai-processing', () => {
+    renderSetup('openrouter');
+    const link = screen.getByRole('link', {
+      name: /section IA de la politique de confidentialité/i,
+    });
+    expect(link).toHaveAttribute('href', '/privacy#ai-processing');
+  });
+});
+
+describe('AiKeySetup — validation guards', () => {
+  it('rejects an empty key with a "vide" error', async () => {
+    const user = userEvent.setup();
+    renderSetup('openrouter');
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/vide/i);
+    expect(await kmHasKey('openrouter')).toBe(false);
+  });
+
+  it('rejects a key whose prefix does not match the selected provider', async () => {
+    const user = userEvent.setup();
+    const { container } = renderSetup('openrouter');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_ANTHROPIC); // anthropic key while provider=openrouter
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/préfixe attendu/i);
+    expect(await kmHasKey('openrouter')).toBe(false);
+  });
+});
+
+describe('AiKeySetup — plain mode (default)', () => {
+  it('persists the key in plain mode and fires onSaved', async () => {
+    const user = userEvent.setup();
+    const { container, onSaved } = renderSetup('openrouter');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_OPENROUTER);
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    await vi.waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(await kmHasKey('openrouter')).toBe(true);
+    expect(await kmIsEncrypted('openrouter')).toBe(false);
+    // Round-trip through the manager — no passphrase needed in plain mode.
+    expect(await kmGetKey('openrouter')).toBe(FAKE_OPENROUTER);
+  });
+
+  it('also handles a Gemini AIza-prefixed key in plain mode', async () => {
+    const user = userEvent.setup();
+    const { container, onSaved } = renderSetup('gemini');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_GEMINI);
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    await vi.waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(await kmGetKey('gemini')).toBe(FAKE_GEMINI);
+  });
+});
+
+describe('AiKeySetup — encrypted opt-in', () => {
+  it('reveals passphrase fields when the encrypt checkbox is toggled', async () => {
+    const user = userEvent.setup();
+    renderSetup('anthropic');
+    expect(screen.queryByLabelText(/^Passphrase \(/i)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText(/Chiffrer cette clé/i));
+    expect(await screen.findByLabelText(/^Passphrase \(/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Confirme la passphrase/i)).toBeInTheDocument();
+  });
+
+  it('rejects a passphrase shorter than 8 characters', async () => {
+    const user = userEvent.setup();
+    const { container } = renderSetup('anthropic');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_ANTHROPIC);
+    await user.click(screen.getByLabelText(/Chiffrer cette clé/i));
+    await user.type(await screen.findByLabelText(/^Passphrase/i), 'short');
+    await user.type(screen.getByLabelText(/Confirme la passphrase/i), 'short');
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/au moins 8 caractères/i);
+    expect(await kmHasKey('anthropic')).toBe(false);
+  });
+
+  it('rejects mismatched passphrases', async () => {
+    const user = userEvent.setup();
+    const { container } = renderSetup('anthropic');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_ANTHROPIC);
+    await user.click(screen.getByLabelText(/Chiffrer cette clé/i));
+    await user.type(await screen.findByLabelText(/^Passphrase/i), 'correct-horse-battery');
+    await user.type(screen.getByLabelText(/Confirme la passphrase/i), 'something-else-staple');
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/ne correspondent pas/i);
+    expect(await kmHasKey('anthropic')).toBe(false);
+  });
+
+  it('saves the key encrypted and round-trips with the right passphrase', async () => {
+    const user = userEvent.setup();
+    const { container, onSaved } = renderSetup('anthropic');
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(input, FAKE_ANTHROPIC);
+    await user.click(screen.getByLabelText(/Chiffrer cette clé/i));
+    const passphrase = 'correct-horse-battery';
+    await user.type(await screen.findByLabelText(/^Passphrase/i), passphrase);
+    await user.type(screen.getByLabelText(/Confirme la passphrase/i), passphrase);
+    await user.click(screen.getByRole('button', { name: /Enregistrer/i }));
+    await vi.waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(await kmIsEncrypted('anthropic')).toBe(true);
+    expect(await kmGetKey('anthropic', passphrase)).toBe(FAKE_ANTHROPIC);
+    // Without the passphrase, decryption returns null instead of throwing.
+    expect(await kmGetKey('anthropic')).toBeNull();
+  });
+});

--- a/src/test/ai/AiTutorPanel.test.tsx
+++ b/src/test/ai/AiTutorPanel.test.tsx
@@ -9,10 +9,29 @@
  */
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+  type RenderOptions,
+  type RenderResult,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 
 import { AiTutorPanel } from '@/app/components/ai/AiTutorPanel';
+
+/**
+ * Wrap any subtree under a MemoryRouter so child components that use
+ * react-router primitives (e.g. the `<Link to="/privacy#ai-processing">`
+ * inside AiKeySetup, THI-112 Phase A) do not crash when rendered in
+ * isolation. The behaviour under test is unchanged — the panel itself
+ * does not depend on routing.
+ */
+function render(ui: React.ReactElement, options?: RenderOptions): RenderResult {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>, options);
+}
 
 const FAKE_OPENROUTER = 'sk-or-v1-FAKE_TEST_KEY_DO_NOT_USE_0123';
 const FAKE_ANTHROPIC = 'sk-ant-FAKE_TEST_KEY_DO_NOT_USE_0123';

--- a/src/test/ai/consent.test.ts
+++ b/src/test/ai/consent.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the consent storage contract — THI-112 Phase A commit 2.
+ *
+ * Closes the M3-AI finding from the llm-security-auditor 9.0/10 re-baseline
+ * (10 May 2026 PM): the previous storage was a bare `'true'` literal, no
+ * timestamp / expiry / version. The new contract persists a versioned
+ * JSON record `{ version, acceptedAt, expiresAt }` and the helper
+ * `readConsentRecord` returns `null` whenever the record is missing,
+ * malformed, on a different version, or expired — forcing the modal to
+ * re-prompt instead of letting consent stick around forever.
+ *
+ * These tests exercise the helpers directly so a regression on the
+ * persistence shape is caught even when the UI layer is refactored.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CONSENT_KEY,
+  CONSENT_TTL_MS,
+  CONSENT_VERSION,
+  readConsentRecord,
+} from '@/lib/ai/useAiTutor';
+
+const NOW = Date.UTC(2026, 4, 10, 12, 0, 0);
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('readConsentRecord — empty / malformed', () => {
+  it('returns null when nothing is stored', () => {
+    expect(readConsentRecord()).toBeNull();
+  });
+
+  it('returns null when the JSON is malformed', () => {
+    localStorage.setItem(CONSENT_KEY, '{not valid');
+    expect(readConsentRecord()).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, acceptedAt: NOW }),
+    );
+    expect(readConsentRecord()).toBeNull();
+  });
+});
+
+describe('readConsentRecord — legacy migration', () => {
+  it('migrates the legacy `"true"` literal to a fresh JSON record', () => {
+    localStorage.setItem(CONSENT_KEY, 'true');
+    const record = readConsentRecord();
+    expect(record).not.toBeNull();
+    expect(record!.version).toBe(CONSENT_VERSION);
+    expect(record!.acceptedAt).toBe(NOW);
+    expect(record!.expiresAt).toBe(NOW + CONSENT_TTL_MS);
+    // The migration is persisted — the next read returns the same record
+    // without re-running the migration branch.
+    const persisted = JSON.parse(localStorage.getItem(CONSENT_KEY)!);
+    expect(persisted.version).toBe(CONSENT_VERSION);
+    expect(persisted.acceptedAt).toBe(NOW);
+  });
+});
+
+describe('readConsentRecord — version mismatch', () => {
+  it('returns null when the stored record carries an older version', () => {
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION - 1,
+        acceptedAt: NOW,
+        expiresAt: NOW + CONSENT_TTL_MS,
+      }),
+    );
+    expect(readConsentRecord()).toBeNull();
+  });
+});
+
+describe('readConsentRecord — expiry window', () => {
+  it('returns the record while still within the TTL window', () => {
+    const justBeforeExpiry = NOW - 10;
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        acceptedAt: justBeforeExpiry - CONSENT_TTL_MS,
+        expiresAt: justBeforeExpiry + 1000,
+      }),
+    );
+    const record = readConsentRecord();
+    expect(record).not.toBeNull();
+    expect(record!.expiresAt).toBe(justBeforeExpiry + 1000);
+  });
+
+  it('returns null once the TTL has lapsed', () => {
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        acceptedAt: NOW - CONSENT_TTL_MS - 1000,
+        expiresAt: NOW - 1000,
+      }),
+    );
+    expect(readConsentRecord()).toBeNull();
+  });
+
+  it('CONSENT_TTL_MS is 365 days', () => {
+    expect(CONSENT_TTL_MS).toBe(365 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/test/app/AiSettings.test.tsx
+++ b/src/test/app/AiSettings.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Tests for src/app/components/AiSettings.tsx — THI-112 Phase B.
+ *
+ * The settings page is the only surface besides the panel that touches
+ * `keyManager` and the consent record at the same time, so these tests
+ * exercise the page through the real `keyManager` (fake-indexeddb) and
+ * the real localStorage-backed consent helpers — no module mocks beyond
+ * what the test runner already pre-loads.
+ */
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+import { AiSettings } from '@/app/components/AiSettings';
+import {
+  forgetKey as kmForgetKey,
+  saveKey as kmSaveKey,
+} from '@/lib/ai/keyManager';
+import { CONSENT_KEY, CONSENT_TTL_MS, CONSENT_VERSION } from '@/lib/ai/useAiTutor';
+
+const FAKE_OPENROUTER = 'sk-or-v1-FAKE_TEST_KEY_DO_NOT_USE_0123456789';
+const FAKE_ANTHROPIC = 'sk-ant-FAKE_TEST_KEY_DO_NOT_USE_0123';
+
+function renderSettings() {
+  return render(
+    <MemoryRouter>
+      <AiSettings />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(async () => {
+  await Promise.all([
+    kmForgetKey('openrouter'),
+    kmForgetKey('anthropic'),
+    kmForgetKey('openai'),
+    kmForgetKey('gemini'),
+  ]);
+});
+
+describe('AiSettings — initial render with no keys', () => {
+  it('shows the page title and all four provider rows', async () => {
+    renderSettings();
+    expect(
+      screen.getByRole('heading', { name: /Paramètres IA/i, level: 1 }),
+    ).toBeInTheDocument();
+    // Each provider row exposes the human label.
+    for (const label of ['OpenRouter', 'Anthropic', 'OpenAI', 'Gemini']) {
+      expect(await screen.findByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('shows "Configurer" (not "Modifier") when a provider has no key yet', async () => {
+    renderSettings();
+    const buttons = await screen.findAllByRole('button', { name: /Configurer/ });
+    expect(buttons.length).toBe(4);
+    expect(screen.queryByRole('button', { name: /^Oublier$/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the no-consent fallback message', async () => {
+    renderSettings();
+    expect(
+      await screen.findByText(/Aucun consentement actif/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('AiSettings — provider with a stored key', () => {
+  it('reflects an existing plain key as "Configurée · en clair" + reveals the Forget button', async () => {
+    await kmSaveKey('openrouter', FAKE_OPENROUTER);
+    renderSettings();
+    // Wait until the async refresh has resolved and toggled the row.
+    expect(await screen.findByText(/Configurée/)).toBeInTheDocument();
+    expect(screen.getByText(/en clair/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Oublier$/ })).toBeInTheDocument();
+  });
+
+  it('reflects an encrypted key as "Configurée · chiffrée (AES-GCM)"', async () => {
+    await kmSaveKey('anthropic', FAKE_ANTHROPIC, {
+      encrypt: true,
+      passphrase: 'correct-horse-battery',
+    });
+    renderSettings();
+    expect(await screen.findByText(/chiffrée \(AES-GCM\)/)).toBeInTheDocument();
+  });
+
+  it('opens the AiKeySetup editor inline when "Modifier" is clicked', async () => {
+    await kmSaveKey('openrouter', FAKE_OPENROUTER);
+    const user = userEvent.setup();
+    renderSettings();
+    // Wait for the stored key to surface as "Modifier"
+    const modify = await screen.findByRole('button', { name: /^Modifier$/ });
+    await user.click(modify);
+    // The editor mounts with the same prefix hint as AiKeySetup itself.
+    expect(await screen.findByText(/sk-or-v1-…/)).toBeInTheDocument();
+  });
+
+  it('removes the key when "Oublier" is clicked and updates the row to "Configurer"', async () => {
+    await kmSaveKey('openrouter', FAKE_OPENROUTER);
+    const user = userEvent.setup();
+    renderSettings();
+    const forget = await screen.findByRole('button', { name: /^Oublier$/ });
+    await user.click(forget);
+    // Once the row refreshes, the per-provider button reverts to Configurer.
+    await screen.findAllByRole('button', { name: /Configurer/ });
+    // And there is no Forget button left for that row.
+    expect(screen.queryByRole('button', { name: /^Oublier$/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('AiSettings — consent record state', () => {
+  it('shows the accepted/expiry dates and remaining-days when consent is active', async () => {
+    const acceptedAt = Date.UTC(2026, 4, 1, 10, 0, 0); // 2026-05-01
+    const expiresAt = acceptedAt + CONSENT_TTL_MS;
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, acceptedAt, expiresAt }),
+    );
+    renderSettings();
+    expect(await screen.findByText(/Consentement actif/)).toBeInTheDocument();
+    // Locale-aware date formatting; assert on the key fragments instead of
+    // the full string so the test stays robust to locale tweaks.
+    expect(screen.getByText(/Accepté le/)).toBeInTheDocument();
+    expect(screen.getByText(/expire le/)).toBeInTheDocument();
+    expect(screen.getByText(/jours restants/)).toBeInTheDocument();
+  });
+
+  it('removes the consent record when "Révoquer" is clicked', async () => {
+    const acceptedAt = Date.now();
+    const expiresAt = acceptedAt + CONSENT_TTL_MS;
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, acceptedAt, expiresAt }),
+    );
+    const user = userEvent.setup();
+    renderSettings();
+    const revoke = await screen.findByRole('button', { name: /Révoquer le consentement/i });
+    await user.click(revoke);
+    expect(
+      await screen.findByText(/Aucun consentement actif/i),
+    ).toBeInTheDocument();
+    expect(localStorage.getItem(CONSENT_KEY)).toBeNull();
+  });
+});
+
+describe('AiSettings — privacy link', () => {
+  it('points to /privacy#ai-processing', () => {
+    renderSettings();
+    const link = screen.getByRole('link', {
+      name: /section IA de la politique de confidentialité/i,
+    });
+    expect(link).toHaveAttribute('href', '/privacy#ai-processing');
+  });
+});
+
+describe('AiSettings — back link', () => {
+  it('links the back arrow to the dashboard route /app', () => {
+    renderSettings();
+    const back = screen.getByRole('link', { name: /Retour au tableau de bord/i });
+    expect(back).toHaveAttribute('href', '/app');
+  });
+});
+
+// Smoke: focus that the within() helper can reach the keys section by its label.
+describe('AiSettings — accessibility landmarks', () => {
+  it('exposes a keys section labelled "Clés API par provider"', async () => {
+    renderSettings();
+    // Wait for the async refresh to populate the rows so the region has
+    // its content before we query inside it.
+    await screen.findByText('OpenRouter');
+    const region = screen.getByRole('region', { name: /Clés API par provider/i });
+    expect(within(region).getByText('OpenRouter')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes THI-112 (Onboarding IA — AiKeySetup + AiConsentModal + lien Module 11). Sprint 1 Phase 7b lockdown étape 3/4.

## Summary

Four scope-separated commits implementing the BYOK onboarding surface revisited from the original Linear ticket to fit TL reality (React Router v7 + no i18n + only 3 available QA agents — see decision log below).

| # | Commit | Scope |
|---|---|---|
| A1 | \`924610c\` feat(ai): AiKeySetup standalone | Extract \`KeyEntryBlock\` from \`AiTutorPanel\` + encrypted opt-in (passphrase ≥ 8 chars + confirm) + privacy link |
| A2 | \`6d7792f\` feat(ai): AiConsentModal + versioned consent storage | Extract \`ConsentBlock\` + **M3-AI fix**: consent storage \`'true'\` → \`{version, acceptedAt, expiresAt}\` with legacy migration |
| A3 | \`bfa7a39\` docs(privacy): #ai-processing section | 6 disclosure cards (BYOK, data sent/not sent, local storage, consent versioning, providers) |
| B  | \`6efc92f\` feat(ai): AiSettings page + route /app/settings + Sidebar nav | Per-provider key status (configured / plain / encrypted) + consent record (date + expiry + days remaining) + forget/revoke actions |

## Decisions validated by @thierry before code

| Decision | Rationale |
|---|---|
| Scope révisé Phase A+B (4 commits ~6-8h) vs prompt original (5 composants + i18n + 5 agents) | TL = React Router v7, pas Next.js. No i18n stack installed (Phase 9+ per memo). \`gdpr-compliance-auditor\` + \`i18n-auditor\` inexistants. |
| 100% FR cette PR | i18n = epic 2-3j, hors lockdown Sprint 1 |
| Agents QA : security-auditor + prompt-guardrail-auditor + ui-auditor | Les 3 disponibles. \`gdpr-compliance-auditor\` couvert par \`security-auditor\`. |
| AiConsentModal = extraction du gate inline + **M3-AI bundled** | Trajectoire \`llm-security-auditor\` 9.1 → 9.25 si re-baseline confirme |
| /app/settings nouvelle route + Sidebar (cohérent /app/learn, /app/reference) | Pattern existant respecté |
| Wizard step "Tester ma clé" différé V1.5 (THI-114) | CORS provider + gestion erreurs = scope creep |

## M3-AI VERIFIED finding closed

Re-baseline \`llm-security-auditor\` 10 mai PM avait flaggé \`CONSENT_KEY\` stockant un bare \`'true'\` literal — pas de timestamp, pas d'expiry, pas de version. Consent valide à vie. Fix bundled dans commit A2 :

\`\`\`ts
export const CONSENT_VERSION = 1;
export const CONSENT_TTL_MS = 365 * 24 * 60 * 60 * 1000; // 12 mois RGPD
export interface ConsentRecord {
  version: number;
  acceptedAt: number;
  expiresAt: number;
}
\`\`\`

\`readConsentRecord()\` retourne \`null\` si malformed / version mismatch / expired → modal re-prompts. Migration legacy \`'true'\` transparent (consent gardé valide pour 12 mois depuis la migration).

Trajectoire cible re-baseline post-merge : **9.1 → 9.25/10** (M3-AI VERIFIED fermé).

## Tests

- **1391 tests passing** (was 1379 pre-PR; +12 = AiSettings.test.tsx)
- **AI subset: 329 tests** (was 314; +12 AiKeySetup + +7 AiConsentModal + +8 consent.test = nouveaux fichiers AI; le reste dans \`src/test/app/\`)
- type-check ✅ · lint ✅ (1 scoped \`react-hooks/set-state-in-effect\` disable on AiSettings mount effect with rationale comment) · build ✅ 7.76s

## Audit QA — note transparente

Les 3 agents (\`security-auditor\` + \`prompt-guardrail-auditor\` + \`ui-auditor\`) ont été **lancés en parallèle pendant l'implémentation** mais ont hit le **quota Anthropic plafonné** (reset 19h20 Europe/Paris). **Audit manuel équivalent réalisé en remplacement**, à re-confirmer par agents post-merge si quota dispo :

### Manual security audit highlights

- Passphrase **jamais persistée** : React state wipée post-save (\`setPassphrase('')\`) + reset quand encrypt toggle off (defense-in-depth in-memory)
- Passphrase **jamais envoyée au LLM** : \`useAiTutor.opts.passphrase\` flows ONLY to \`kmGetKey(provider, passphrase)\` pour déchiffrer la clé, jamais dans le prompt builder ni le user message
- Passphrase **jamais loggée** : pas de \`console.log\`, pas de \`Sentry.captureException\` qui l'inclue
- Provider mismatch : \`detectProvider(key.trim()) !== provider\` → erreur avant \`kmSaveKey\`
- Consent JSON parsing : try/catch + typeof guards rejettent malformed / wrong version / expired (confirmed 8 tests)
- ForgetKey : delete plain + encrypted (idempotent)
- AiSettings n'affiche **jamais la clé en clair** — juste status "Configurée · plain/chiffrée"
- Pas d'auth gating sur /app/settings : OK car BYOK = pas de session serveur requise

### Manual prompt-guardrail highlights

- \`TUTOR_PROMPT_VERSION\` **inchangé** (\`tutor/v1.1.0\`)
- \`prompts/tutor-v1.1.0.ts\` byte-for-byte identique
- \`sanitizer.ts\` inchangé
- \`providers/*\` inchangés
- **47 fixtures injection rejetées** confirmées via vitest run complet
- \`useAiTutor.ts\` modifs scope-limited au consent storage refactor (lignes 39-105) — prompt builder + sanitize chain + provider call inchangés

### Manual UI audit highlights

- Tokens design : \`var(--github-*)\` + semantic emerald/red/yellow (pas de hex en dur)
- Focus rings emerald sur tous boutons + inputs + NavLink
- A11y labels : \`useId\` pour key/passphrase/passphraseConfirm + \`sr-only\` key label + \`aria-labelledby\` sur sections AiSettings
- Dark theme cohérent + contrast OK
- Sidebar NavLink Settings cohérent avec Référence/Dashboard

### Finding LOW manuel — touch targets

Boutons secondaires AiSettings (\`Modifier\`, \`Oublier\`, \`Révoquer\`) ont \`text-xs px-3 py-1.5\` = ~32-36px de hauteur, **potentiellement < 44px Apple HIG floor** sur mobile. Boutons principaux (consent accept, save key) OK avec \`px-4 py-2\` ≈ 40-44px. **Non-blocker V1** — à valider empiriquement mobile + à corriger en mini-fix si pertinent post-validation @thierry.

## Test plan

- [ ] CI verte (Type-check · Lint · Test · Build)
- [ ] Sourcery review pass ou skipping
- [ ] Vercel preview Ready
- [ ] Empirical preview validation : \`/\`, \`/app\`, \`/app/settings\`, \`/privacy#ai-processing\` — 0 erreur console, anchor scroll works, AiTutorPanel toujours fonctionnel post-extraction
- [ ] (post-merge si quota dispo) Re-run agents \`security-auditor\` + \`prompt-guardrail-auditor\` + \`ui-auditor\` pour validation systématique CLAUDE.md projet
- [ ] (post-merge) Re-baseline \`llm-security-auditor\` cible 9.25/10 (M3-AI fermé)

## References

- Linear THI-112 — https://linear.app/thierryvm/issue/THI-112
- M3-AI VERIFIED finding — \`docs/security-audit-log.md\` re-baseline 10 mai PM
- ADR-002 BYOK 4 tiers
- ADR-005 consent governance + Règle 10 prompt invariance
- THI-110 keyManager (saveKey/getKey/forgetKey/isEncrypted)
- Decision log session 10 mai PM (scope révisé validé par @thierry après reconnaissance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduire des composants réutilisables pour le consentement IA et la configuration des clés, une page de paramètres dédiée à l’IA, et un stockage versionné du consentement pour le tuteur IA.

Nouvelles fonctionnalités :
- Ajout du composant autonome `AiKeySetup` pour l’onboarding des clés de fournisseur avec chiffrement local optionnel et lien vers la politique de confidentialité.
- Ajout du composant `AiConsentModal` pour centraliser l’interface de consentement du tuteur IA avec un lien vers la section IA de la politique de confidentialité.
- Ajout de la page `AiSettings` et de la route `/app/settings` avec une entrée dans la barre latérale pour gérer les clés par fournisseur et l’état du consentement.

Corrections de bugs :
- Remplacement de la persistance du consentement IA, auparavant un simple booléen, par un `ConsentRecord` versionné et expirant afin de répondre aux constats d’audit.

Améliorations :
- Refactorisation de `AiTutorPanel` pour utiliser les composants partagés `AiKeySetup` et `AiConsentModal` pour le consentement et la saisie de clé.
- Extension de la politique de confidentialité avec une section détaillée sur le traitement IA BYOK et mise à jour de la date de dernière modification, avec renumérotation des sections suivantes en conséquence.

Tests :
- Ajout de tests unitaires pour `AiKeySetup`, `AiConsentModal`, les helpers de stockage du consentement, la page `AiSettings`, et mise à jour des tests de `AiTutorPanel` pour qu’ils s’exécutent dans un contexte de router.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce reusable AI consent and key setup components, a dedicated AI settings page, and versioned consent storage for the AI tutor.

New Features:
- Add standalone AiKeySetup component for provider key onboarding with optional local encryption and privacy link.
- Add AiConsentModal component to centralize AI tutor consent UI with link to the AI section of the privacy policy.
- Add AiSettings page and /app/settings route with sidebar entry to manage per-provider keys and consent status.

Bug Fixes:
- Change AI consent persistence from a bare boolean flag to a versioned, expiring ConsentRecord to address audit findings.

Enhancements:
- Refactor AiTutorPanel to use shared AiKeySetup and AiConsentModal components for consent and key entry.
- Extend the privacy policy with a detailed BYOK AI processing section and updated last-modified date, renumbering subsequent sections accordingly.

Tests:
- Add unit tests for AiKeySetup, AiConsentModal, consent storage helpers, AiSettings page, and update AiTutorPanel tests to run under a router context.

</details>