### PR TITLE
perf(landing): THI-118 — LCP regression fix (−20 kB gzip + lazy modals)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
 >
   <url>
     <loc>https://terminallearning.dev/</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -17,287 +17,287 @@
 
   <url>
     <loc>https://terminallearning.dev/app</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/reference</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/privacy</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/pwd</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/ls-la</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/navigation/cd</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mkdir</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/touch</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/cp</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/mv</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/fichiers/rm</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/cat</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/head-tail</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/grep</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/lecture/wc</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/comprendre-permissions</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chmod</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/chown</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/sudo</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/permissions/security-permissions</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/ps</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/kill</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/top</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/processus/background</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/redirection-sortie</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/pipes</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/stderr</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/redirection/tee</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/env-vars</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/path-variable</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/shell-config</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/dotenv</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/scripts</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/variables/cron</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ping</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/curl</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/wget</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/dns</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/ssh</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://terminallearning.dev/app/learn/reseau/scp</loc>
-    <lastmod>2026-05-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { FadeIn } from './landing/FadeIn';
 import {
@@ -7,14 +7,18 @@ import {
   Compass, Monitor, LogIn, Share2, Check, Download, ArrowUp,
 } from 'lucide-react';
 import { usePWAInstall } from '../hooks/usePWAInstall';
-import { PWAInstallModal } from './PWAInstallModal';
 import { TerminalPreview } from './landing/TerminalPreview';
 import { useAuth } from '../context/AuthContext';
 import { useProgress } from '../context/ProgressContext';
-import { UserMenu } from './auth/UserMenu';
-import { LoginModal } from './auth/LoginModal';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
+
+// THI-118 — defer non-critical chunks to keep the landing critical path lean.
+// UserMenu only renders for logged-in users (minority of landing visitors);
+// LoginModal / PWAInstallModal only mount after user interaction.
+const UserMenu = lazy(() => import('./auth/UserMenu').then((m) => ({ default: m.UserMenu })));
+const LoginModal = lazy(() => import('./auth/LoginModal').then((m) => ({ default: m.LoginModal })));
+const PWAInstallModal = lazy(() => import('./PWAInstallModal').then((m) => ({ default: m.PWAInstallModal })));
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import {
   TOTAL_LESSONS, TOTAL_COMMANDS,
@@ -69,7 +73,13 @@ export function Landing() {
 
   return (
     <div className="min-h-dvh bg-[var(--github-bg)] text-[var(--github-text-primary)]" style={{ fontFamily: 'Inter, sans-serif' }}>
-      <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+      {/* Mount LoginModal only after the user opens it — keeps the lazy
+          chunk out of the landing critical path (THI-118). */}
+      {loginOpen && (
+        <Suspense fallback={null}>
+          <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+        </Suspense>
+      )}
 
       {/* ── NAV ─────────────────────────────────────────────────── */}
       {/* THI-152 brick 7bis: pt-[max(1rem,env(safe-area-inset-top))]
@@ -99,7 +109,9 @@ export function Landing() {
             <Github size={18} aria-hidden="true" />
           </a>
           {user ? (
-            <UserMenu syncStatus={syncStatus} variant="compact" />
+            <Suspense fallback={null}>
+              <UserMenu syncStatus={syncStatus} variant="compact" />
+            </Suspense>
           ) : (
             <Button
               variant="nav-link"
@@ -286,7 +298,11 @@ export function Landing() {
         </div>
       </section>
 
-      {showPWAModal && <PWAInstallModal onClose={() => setShowPWAModal(false)} />}
+      {showPWAModal && (
+        <Suspense fallback={null}>
+          <PWAInstallModal onClose={() => setShowPWAModal(false)} />
+        </Suspense>
+      )}
 
       {/* ── TRUST BADGES ────────────────────────────────────────── */}
       <section className="max-w-6xl mx-auto px-6 py-8">

--- a/src/app/components/NotFound.tsx
+++ b/src/app/components/NotFound.tsx
@@ -1,15 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router';
 import { Terminal, Home, Github, BookOpen, Zap, Shield, Heart, Clock, type LucideIcon } from 'lucide-react';
-import { curriculum } from '../data/curriculum';
-import { commandCatalogue } from '../data/commandCatalogue';
-import { ENVIRONMENTS } from '../types/curriculum';
+import { TOTAL_LESSONS, TOTAL_COMMANDS, ACTIVE_ENVIRONMENTS_COUNT } from '../data/landingContent';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
-
-const TOTAL_LESSONS = curriculum.reduce((sum, mod) => sum + mod.lessons.length, 0);
-const TOTAL_COMMANDS = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
-const ACTIVE_ENVIRONMENTS = ENVIRONMENTS.filter((e) => e.status === 'active').length;
 
 const TERMINAL_LINES = [
   { prompt: '$', command: ' cd /page-introuvable', delay: 0 },
@@ -23,7 +17,7 @@ type PillVariant = 'pill-emerald' | 'pill-blue' | 'pill-amber' | 'pill-purple';
 const PILLS: Array<{ icon: LucideIcon; label: string; variant: PillVariant }> = [
   { icon: BookOpen, label: `${TOTAL_LESSONS} leçons`, variant: 'pill-emerald' },
   { icon: Terminal, label: `${TOTAL_COMMANDS}+ commandes`, variant: 'pill-blue' },
-  { icon: Zap, label: `${ACTIVE_ENVIRONMENTS} environnements`, variant: 'pill-amber' },
+  { icon: Zap, label: `${ACTIVE_ENVIRONMENTS_COUNT} environnements`, variant: 'pill-amber' },
   { icon: Shield, label: '100% gratuit', variant: 'pill-purple' },
 ];
 

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -5,16 +5,19 @@ import {
   Compass, FolderOpen, FileText, Cpu, GitMerge, GitBranch, GitFork, Globe,
   Monitor, Code2, Bot,
 } from 'lucide-react';
-import { commandCatalogue } from './commandCatalogue';
-import { ENVIRONMENTS } from '../types/curriculum';
 import type { SelectedEnvironment } from '../context/EnvironmentContext';
 
 // ── Computed totals ───────────────────────────────────────────────────────────
 
-/** Hardcoded — update when adding lessons. Source of truth: curriculum.ts. */
-export const TOTAL_LESSONS = 64;
-export const TOTAL_COMMANDS = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
-export const ACTIVE_ENVIRONMENTS = ENVIRONMENTS.filter((e) => e.status === 'active');
+// THI-118 — hardcoded to prevent the landing chunk from pulling in
+// `commandCatalogue` / `curriculum` (≈ 41 kB gzip) on first paint. The
+// landing page only needs the totals, not the full data. A drift test in
+// `src/test/landingTotals.test.ts` re-imports both and fails if these
+// constants get out of sync with the actual catalogue/curriculum.
+export const TOTAL_LESSONS = 65;
+export const TOTAL_COMMANDS = 27;
+/** Count of environments with `status: 'active'` in `types/curriculum.ts`. */
+export const ACTIVE_ENVIRONMENTS_COUNT = 3;
 
 // ── Features ──────────────────────────────────────────────────────────────────
 
@@ -168,7 +171,7 @@ export const STATS = [
   { value: String(MODULE_PREVIEWS.length), label: 'Modules', icon: BookOpen },
   { value: String(TOTAL_LESSONS), label: 'Leçons', icon: FileText },
   { value: `${TOTAL_COMMANDS}+`, label: 'Commandes', icon: Terminal },
-  { value: String(ACTIVE_ENVIRONMENTS.length), label: 'Environnements', icon: Monitor },
+  { value: String(ACTIVE_ENVIRONMENTS_COUNT), label: 'Environnements', icon: Monitor },
 ];
 
 // ── Competency levels per environment (hero section) ─────────────────────────

--- a/src/test/landingTotals.test.ts
+++ b/src/test/landingTotals.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TOTAL_LESSONS,
+  TOTAL_COMMANDS,
+  ACTIVE_ENVIRONMENTS_COUNT,
+} from '../app/data/landingContent';
+import { curriculum } from '../app/data/curriculum';
+import { commandCatalogue } from '../app/data/commandCatalogue';
+import { ENVIRONMENTS } from '../app/types/curriculum';
+
+// THI-118 — these constants are hardcoded in `landingContent.ts` so the
+// landing chunk does not import `curriculum.ts` / `commandCatalogue.ts`
+// (~41 kB gzip). If you add lessons / commands / environments, bump the
+// constants. This test fails loudly if they drift.
+describe('landingContent — totals drift guard (THI-118)', () => {
+  it('TOTAL_LESSONS matches the actual curriculum', () => {
+    const computed = curriculum.reduce((sum, mod) => sum + mod.lessons.length, 0);
+    expect(TOTAL_LESSONS).toBe(computed);
+  });
+
+  it('TOTAL_COMMANDS matches the actual command catalogue', () => {
+    const computed = commandCatalogue.reduce(
+      (sum, cat) => sum + cat.commands.length,
+      0,
+    );
+    expect(TOTAL_COMMANDS).toBe(computed);
+  });
+
+  it('ACTIVE_ENVIRONMENTS_COUNT matches active env list', () => {
+    const computed = ENVIRONMENTS.filter((e) => e.status === 'active').length;
+    expect(ACTIVE_ENVIRONMENTS_COUNT).toBe(computed);
+  });
+});


### PR DESCRIPTION
## Contexte
Sentry Weekly Report (11-18 avril 2026) avait remonté **LCP p75 sur `/` : 3.87 s → 9.31 s** (×2.4, route la plus trafiquée, 71 hits). Au-dessus du seuil Google Core Web Vitals « poor » (4 s) — bloquant crédibilité écoles à la landing.

## Diagnostic
Lighthouse mobile Slow 4G + CPU 4× sur prod `https://terminallearning.dev/` :

- **LCP element = hero `<p>` sous-titre** (texte, pas le `TerminalPreview`)
- **98.9 % du LCP time en Render delay** (2001 ms / 2025 ms) → bottleneck **JS critical path**
- Critical chain : HTML 621 ms → CSS 1237 ms → JS 1220 ms → React mount → LCP

Deux fuites identifiées :

1. **`landingContent.ts` importait `commandCatalogue` et `ENVIRONMENTS`** uniquement pour calculer `TOTAL_COMMANDS = commandCatalogue.reduce(...)` et `ACTIVE_ENVIRONMENTS.length`. Vite ne peut pas tree-shaker ces réductions → le chunk `curriculum-*.js` (~41 kB gzip) chargeait eagerly sur la landing alors que les données ne sont jamais lues là.
2. **`UserMenu`, `LoginModal`, `PWAInstallModal` importés eagerly** alors que :
   - `UserMenu` ne rend que pour `user !== null` (minorité des visiteurs landing)
   - `LoginModal` n'est monté qu'après clic « Se connecter »
   - `PWAInstallModal` n'est monté qu'après clic « Installer »

## Fix

**`src/app/data/landingContent.ts`** — hardcoder les totaux + retirer les imports :
- `TOTAL_LESSONS = 65` (avant 64 — **drift de +1 attrapé par le nouveau test** ✋)
- `TOTAL_COMMANDS = 27` (était calculé via reduce)
- `ACTIVE_ENVIRONMENTS_COUNT = 3` (remplace `ACTIVE_ENVIRONMENTS.length`)

**`src/test/landingTotals.test.ts`** — nouveau drift guard : ré-importe `curriculum`, `commandCatalogue`, `ENVIRONMENTS` côté test uniquement (pas d'impact bundle) et fail si les constantes hardcodées divergent. C'est ce test qui a immédiatement attrapé le drift 64 → 65 sur `TOTAL_LESSONS` qui était silencieux jusqu'ici.

**`src/app/components/Landing.tsx`** — passage en `React.lazy` + `Suspense` :
- `LoginModal` monté uniquement quand `loginOpen === true`
- `UserMenu` monté uniquement quand `user` existe
- `PWAInstallModal` monté uniquement quand `showPWAModal === true`

**`src/app/components/NotFound.tsx`** — déduplique les mêmes constantes via `landingContent` au lieu de répéter `curriculum.reduce(...)` / `commandCatalogue.reduce(...)` / `ENVIRONMENTS.filter(...)` (mêmes calculs, même chunk forcé).

## Bundle impact

| Chunk | Avant | Après | Delta |
| --- | --- | --- | --- |
| `Landing-*.js` | 27.29 kB gzip | 7.33 kB gzip | **−73 %** |
| `LoginModal-*.js` | (eager) | 15.97 kB gzip (lazy) | sorti du critical path |
| `UserMenu-*.js` | (eager) | 1.92 kB gzip (lazy) | sorti du critical path |
| `PWAInstallModal-*.js` | (eager) | 1.84 kB gzip (lazy) | sorti du critical path |
| `curriculum-*.js` (41.44 kB gzip) | eager sur `/` | **plus dans le graph de la landing** | gain net |

Critical path JS gzip sur `/` : ~57 kB → ~7 kB pour la landing chunk, plus aucune des deps curriculum/auth-modals.

## Validation locale

- `npx tsc --noEmit` : 0 erreurs
- `npx vitest run` : full suite green
- `npx eslint --quiet` : 0 warnings
- `npx vite preview` + Lighthouse local Slow 4G + CPU 4× : LCP 1995 ms (lab — sur localhost le TTFB est instantané donc le gain réseau ne se voit pas en lab ; la field data Sentry / Vercel Speed Insights confirmera en 24-48 h post-merge)
- Drift test attrape immédiatement le décalage `TOTAL_LESSONS` 64 → 65 — désormais protégé.

## Test plan reviewer

- [ ] Vérifier le bundle de la preview Vercel (`pnpm dlx vercel inspect` ou DevTools Network) : confirmer que `Landing-*.js` est ~7-10 kB gzip et que `curriculum-*.js` ne se charge plus sur `/`
- [ ] Vérifier que la landing s'affiche correctement (header avec « Se connecter » pour visiteur anonyme, hero, modules, etc.)
- [ ] Cliquer « Se connecter » → vérifier que `LoginModal` charge bien (lazy chunk fetch, puis modal visible)
- [ ] Si connecté : vérifier que `UserMenu` apparaît dans le header avec sync status
- [ ] Speed Insights / Sentry weekly post-merge : LCP p75 sur `/` descend sous 4 s (idéalement < 2.5 s)
- [ ] CSP / Sentry / consoles : aucune nouvelle erreur introduite par le lazy loading

Closes THI-118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)