### PR TITLE
chore(ui): THI-153 — unified destructive red + sonner cleanup + shadcn slot docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "react-markdown": "^10.1.0",
         "react-router": "7.13.0",
         "remark-gfm": "^4.0.1",
-        "sonner": "2.0.3",
         "tailwind-merge": "3.2.0",
         "tw-animate-css": "1.3.8",
         "zod": "^4.3.6"
@@ -4437,7 +4436,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4447,7 +4445,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6811,7 +6809,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -12669,16 +12666,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/sonner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.3.tgz",
-      "integrity": "sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-markdown": "^10.1.0",
     "react-router": "7.13.0",
     "remark-gfm": "^4.0.1",
-    "sonner": "2.0.3",
     "tailwind-merge": "3.2.0",
     "tw-animate-css": "1.3.8",
     "zod": "^4.3.6"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,7 +16,7 @@ function FallbackUI() {
   return (
     <div className="min-h-dvh bg-[var(--github-bg)] flex items-center justify-center text-[var(--github-text-primary)] font-mono">
       <div className="text-center space-y-4">
-        <p className="text-[#f85149] text-lg">Une erreur inattendue s'est produite.</p>
+        <p className="text-[var(--github-red)] text-lg">Une erreur inattendue s'est produite.</p>
         <Button
           variant="outline"
           onClick={() => window.location.reload()}

--- a/src/app/components/AiSettings.tsx
+++ b/src/app/components/AiSettings.tsx
@@ -207,7 +207,7 @@ export function AiSettings() {
                       <button
                         type="button"
                         onClick={() => void onForget(s.provider)}
-                        className="flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs text-red-300 outline-none hover:bg-red-500/20 focus-visible:ring-2 focus-visible:ring-red-500/60"
+                        className="flex items-center gap-1 rounded-md border border-[var(--github-red)]/40 bg-[var(--github-red)]/10 px-3 py-1.5 text-xs text-[var(--github-red)] outline-none hover:bg-[var(--github-red)]/20 focus-visible:ring-2 focus-visible:ring-[var(--github-red)]/60"
                       >
                         <Trash2 size={12} aria-hidden="true" />
                         Oublier
@@ -262,7 +262,7 @@ export function AiSettings() {
               <button
                 type="button"
                 onClick={() => void onRevokeConsent()}
-                className="mt-3 flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs text-red-300 outline-none hover:bg-red-500/20 focus-visible:ring-2 focus-visible:ring-red-500/60"
+                className="mt-3 flex items-center gap-1 rounded-md border border-[var(--github-red)]/40 bg-[var(--github-red)]/10 px-3 py-1.5 text-xs text-[var(--github-red)] outline-none hover:bg-[var(--github-red)]/20 focus-visible:ring-2 focus-visible:ring-[var(--github-red)]/60"
               >
                 <Trash2 size={12} aria-hidden="true" />
                 Révoquer le consentement

--- a/src/app/components/AiSettings.tsx
+++ b/src/app/components/AiSettings.tsx
@@ -54,6 +54,36 @@ interface ProviderStatus {
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+// THI-153 / Sourcery review on #234 — the forget-key and revoke-consent
+// buttons share the exact same destructive styling (only `mt-3` differs).
+// Extracting a tiny local helper keeps the truly-duplicated styles in one
+// place so a future palette change touches one line instead of two.
+// Banner / inline error usages elsewhere (AiTutorPanel, MessageInput,
+// RateLimitBadge) share the `var(--github-red)` color token but not the
+// surrounding layout, so they stay inlined intentionally.
+interface DestructiveActionButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: React.ReactNode;
+}
+
+function DestructiveActionButton({
+  icon,
+  children,
+  className = '',
+  ...rest
+}: DestructiveActionButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`flex items-center gap-1 rounded-md border border-[var(--github-red)]/40 bg-[var(--github-red)]/10 px-3 py-1.5 text-xs text-[var(--github-red)] outline-none hover:bg-[var(--github-red)]/20 focus-visible:ring-2 focus-visible:ring-[var(--github-red)]/60 ${className}`.trim()}
+      {...rest}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
 function formatDateFr(ts: number): string {
   return new Date(ts).toLocaleDateString('fr-FR', {
     day: '2-digit',
@@ -204,14 +234,12 @@ export function AiSettings() {
                       {s.configured ? 'Modifier' : 'Configurer'}
                     </button>
                     {s.configured && (
-                      <button
-                        type="button"
+                      <DestructiveActionButton
                         onClick={() => void onForget(s.provider)}
-                        className="flex items-center gap-1 rounded-md border border-[var(--github-red)]/40 bg-[var(--github-red)]/10 px-3 py-1.5 text-xs text-[var(--github-red)] outline-none hover:bg-[var(--github-red)]/20 focus-visible:ring-2 focus-visible:ring-[var(--github-red)]/60"
+                        icon={<Trash2 size={12} aria-hidden="true" />}
                       >
-                        <Trash2 size={12} aria-hidden="true" />
                         Oublier
-                      </button>
+                      </DestructiveActionButton>
                     )}
                   </div>
                 </div>
@@ -259,14 +287,13 @@ export function AiSettings() {
                 </strong>{' '}
                 ({daysRemaining(consent.expiresAt)} jours restants).
               </p>
-              <button
-                type="button"
+              <DestructiveActionButton
                 onClick={() => void onRevokeConsent()}
-                className="mt-3 flex items-center gap-1 rounded-md border border-[var(--github-red)]/40 bg-[var(--github-red)]/10 px-3 py-1.5 text-xs text-[var(--github-red)] outline-none hover:bg-[var(--github-red)]/20 focus-visible:ring-2 focus-visible:ring-[var(--github-red)]/60"
+                className="mt-3"
+                icon={<Trash2 size={12} aria-hidden="true" />}
               >
-                <Trash2 size={12} aria-hidden="true" />
                 Révoquer le consentement
-              </button>
+              </DestructiveActionButton>
             </div>
           ) : (
             <div className="rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] p-4 text-sm text-[var(--github-text-secondary)]">

--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -21,7 +21,7 @@ export function Layout() {
         {/* Mobile top bar */}
         <div className="lg:hidden shrink-0 h-14 border-b border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] flex items-center gap-3 px-3">
           <MenuButton onClick={() => setSidebarOpen(true)} />
-          <span className="text-sm text-[var(--github-text-primary)] font-mono">Terminal Master</span>
+          <span className="text-sm text-[var(--github-text-primary)] font-mono">Terminal Learning</span>
         </div>
 
         <main className="flex-1 overflow-y-auto min-h-0">

--- a/src/app/components/TerminalEmulator.tsx
+++ b/src/app/components/TerminalEmulator.tsx
@@ -272,7 +272,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
                 <span className="text-[var(--github-text-primary)] break-all">{line.text}</span>
               </div>
             ) : line.type === 'error' ? (
-              <div className="text-[#f85149]">{line.text}</div>
+              <div className="text-[var(--github-red)]">{line.text}</div>
             ) : line.type === 'success' ? (
               <div className="text-[#3fb950]">{line.text}</div>
             ) : line.type === 'info' ? (

--- a/src/app/components/ai/AiKeySetup.tsx
+++ b/src/app/components/ai/AiKeySetup.tsx
@@ -245,7 +245,7 @@ export function AiKeySetup({ provider, onSaved, className }: AiKeySetupProps) {
       </fieldset>
 
       {error && (
-        <p className="text-xs text-red-400" role="alert">
+        <p className="text-xs text-[var(--github-red)]" role="alert">
           {error}
         </p>
       )}

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -351,7 +351,7 @@ function ErrorBanner({ code, message }: { code: string; message: string }) {
   return (
     <div
       role="alert"
-      className="border-b border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+      className="border-b border-[var(--github-red)]/30 bg-[var(--github-red)]/10 px-3 py-2 text-xs text-[var(--github-red)]"
     >
       <strong className="font-semibold">{code}</strong> — {message}
     </div>

--- a/src/app/components/ai/parts/MessageInput.tsx
+++ b/src/app/components/ai/parts/MessageInput.tsx
@@ -65,7 +65,7 @@ export function MessageInput({ onSend, disabled }: Props) {
       />
       <div className="flex items-center justify-between">
         <span
-          className={`text-xs ${overshoot ? 'text-red-400' : 'text-[var(--github-text-secondary)]'}`}
+          className={`text-xs ${overshoot ? 'text-[var(--github-red)]' : 'text-[var(--github-text-secondary)]'}`}
           aria-live="polite"
         >
           {Math.max(0, remaining)} / {MAX_CHARS}

--- a/src/app/components/ai/parts/RateLimitBadge.tsx
+++ b/src/app/components/ai/parts/RateLimitBadge.tsx
@@ -20,7 +20,7 @@ export function RateLimitBadge({ remaining, total = 30, onReset }: Props) {
   const low = remaining <= 5;
   const empty = remaining === 0;
   const colour = empty
-    ? 'bg-red-500/15 text-red-400 hover:bg-red-500/25'
+    ? 'bg-[var(--github-red)]/15 text-[var(--github-red)] hover:bg-[var(--github-red)]/25'
     : low
       ? 'bg-yellow-500/15 text-yellow-400 hover:bg-yellow-500/25'
       : 'bg-[var(--github-bg-tertiary)] text-[var(--github-text-secondary)] hover:bg-[var(--github-bg-secondary)]';

--- a/src/app/components/auth/LoginModal.tsx
+++ b/src/app/components/auth/LoginModal.tsx
@@ -211,7 +211,7 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
               />
 
               {error && (
-                <p className="text-[#f85149] text-xs font-mono">{error}</p>
+                <p className="text-[var(--github-red)] text-xs font-mono">{error}</p>
               )}
 
               <Button

--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -20,7 +20,7 @@ const SYNC_CONFIG: Record<UserMenuProps['syncStatus'], { label: string; dot: str
   local:   { label: 'Local',          dot: 'bg-[#8b949e]',               text: 'text-[var(--github-text-secondary)]' },
   syncing: { label: 'Sync…',          dot: 'bg-yellow-400 animate-pulse', text: 'text-yellow-400' },
   synced:  { label: 'Synchronisé',    dot: 'bg-emerald-400',              text: 'text-emerald-400' },
-  error:   { label: 'Erreur de sync', dot: 'bg-[#f85149]',               text: 'text-[#f85149]' },
+  error:   { label: 'Erreur de sync', dot: 'bg-[var(--github-red)]',               text: 'text-[var(--github-red)]' },
 };
 
 function UserAvatar({ avatarUrl, initials, size }: { avatarUrl?: string; initials: string; size: 'sm' | 'md' }) {
@@ -134,7 +134,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
           size="link-inline"
           onClick={handleSignOut}
           disabled={signingOut}
-          className="w-full gap-2 py-1.5 rounded-md text-xs font-mono text-[#f85149] border border-[#f85149]/20 hover:bg-[#f85149]/10 hover:text-[#f85149] hover:border-[#f85149]/40 transition-all focus-visible:ring-[#f85149]/60 focus-visible:ring-2 focus-visible:ring-offset-0"
+          className="w-full gap-2 py-1.5 rounded-md text-xs font-mono text-[var(--github-red)] border border-[var(--github-red)]/20 hover:bg-[var(--github-red)]/10 hover:text-[var(--github-red)] hover:border-[var(--github-red)]/40 transition-all focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0"
         >
           <LogOut size={12} aria-hidden="true" />
           {signingOut ? 'Déconnexion…' : 'Se déconnecter'}
@@ -189,7 +189,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
               role="menuitem"
               onClick={handleSignOut}
               disabled={signingOut}
-              className="w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[#f85149] font-mono hover:bg-[#f85149]/10 hover:text-[#f85149] rounded-none transition-colors focus-visible:ring-[#f85149]/60 focus-visible:ring-2 focus-visible:ring-offset-0"
+              className="w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[var(--github-red)] font-mono hover:bg-[var(--github-red)]/10 hover:text-[var(--github-red)] rounded-none transition-colors focus-visible:ring-emerald-500/60 focus-visible:ring-2 focus-visible:ring-offset-0"
             >
               <LogOut size={14} aria-hidden="true" />
               {signingOut ? 'Déconnexion…' : 'Se déconnecter'}

--- a/src/app/components/ui/badge.tsx
+++ b/src/app/components/ui/badge.tsx
@@ -4,6 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
 
+// THI-153 — same note as button.tsx: the TL `pill-*` variants always
+// supply their own colors, so the base `focus-visible:ring-ring/50` and
+// `aria-invalid:ring-destructive/*` slots stay inactive. Kept for the
+// shadcn `default` / `destructive` / `secondary` / `outline` variants
+// which a future feature might still reach for.
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -4,6 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
 
+// THI-153 — Terminal Learning uses a 100 % custom GitHub-dark design
+// system: every `tl-*` / `emerald-*` variant below overrides the focus
+// ring with its own emerald token, and we never set `aria-invalid` on
+// our buttons. The default shadcn slots (`focus-visible:ring-ring/50`,
+// `aria-invalid:ring-destructive/*`) therefore stay inactive for the TL
+// variants. They are kept on the base class because the shadcn
+// `default` / `destructive` / `outline` / `secondary` / `ghost` / `link`
+// variants are still exported for occasional reuse via shadcn primitives
+// and rely on those tokens. Do not strip the slots without first
+// migrating those upstream consumers (badge.tsx mirrors this).
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -98,6 +98,16 @@
   --github-subtle: #484f58;
   --github-accent: #238636;
   --github-accent-hover: #2ea043;
+  /* THI-153 — single source of truth for the GitHub-themed danger
+   * color (logout, errors, destructive actions). Modern Tailwind v4
+   * supports opacity modifiers on arbitrary values, so usage in
+   * components looks like `text-[var(--github-red)]` and
+   * `bg-[var(--github-red)]/10`. Replaces the `#f85149` literal that
+   * was duplicated across UserMenu, LoginModal, TerminalEmulator,
+   * App.tsx. The Tailwind `red-*` palette in pedagogical components
+   * (Dashboard processus category, CommandReference, level-5 badge)
+   * is intentional and stays. */
+  --github-red: #f85149;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
Audit findings umbrella post-Sprint 1 étape 1/4 — UI debt cleanup. Cherry-picked les 4 items qui ont survécu à la re-vérification du 16 mai (sur les 5 initiaux : M1 button variants orphelines s'est révélé périmé, toutes utilisées).

### H1 — 3 palettes red consolidées dans `--github-red`
- Nouvelle CSS var dans `theme.css` : `--github-red: #f85149` (couleur danger GitHub-canonique)
- Migration des composants AI/auth qui mixaient `text-[#f85149]` literal + Tailwind `red-300/400/500` :
  - `App.tsx` FallbackUI, `LoginModal` error, `TerminalEmulator` error line
  - `UserMenu` sync-error dot + card + compact logout
  - `AiSettings` forget-key + revoke-consent destructive buttons
  - `AiKeySetup` error message, `AiTutorPanel` error banner
  - `MessageInput` overshoot counter, `RateLimitBadge` empty state
- Tailwind v4 opacity modifiers sur var : `bg-[var(--github-red)]/10`, `border-[var(--github-red)]/40`, etc.
- **Out-of-scope (volontairement conservé Tailwind `red-*`)** : Dashboard processus category, CommandReference processus card, level-5 badge → palette **pédagogique** (intentionnelle, pas destructive).
- **WCAG 2.2 AA vérifié** par ui-auditor : 4.12–4.9:1 sur fond dark + bgs opacity-tinted.

### C1 — UserMenu logout focus ring aligné emerald
- `ring-[#f85149]/60` → `ring-emerald-500/60` sur card + compact variants.
- Garde le rouge pour border/text/hover (signale destructive), restaure cohérence keyboard focus avec le standard THI-152 emerald.

### C2 — Slots shadcn morts documentés (pas strippés)
- `button.tsx` + `badge.tsx` gardent les slots `focus-visible:ring-ring/50` + `aria-invalid:ring-destructive/*` car les variants shadcn `default` / `destructive` / etc. en dépendent encore.
- Header comments ajoutés expliquant pourquoi les variants TL `tl-*` / `emerald-*` les overrident → désormais auto-documenté pour les futurs contributeurs.

### H2 — `sonner` désinstallé (-45 kB minified)
- Zéro import dans `src/`. La seule mention est dans `curriculum.ts` (Module 11 IA, exemple textuel d'hallucination IA).
- Référence pédagogique préservée.

### M1 — RE-VÉRIFIÉ, pas de changement
- Audit 9 mai flaguait 5 button variants orphelines : `tl-tab`, `tl-tab-active`, `tl-list-row`, `tl-nav-inline`, `tl-nav-inline-xs`.
- Re-grep 16 mai : **toutes activement utilisées** (PWAInstallModal, Dashboard, LessonPage 7 call sites).
- Audit était stale → aucun retrait.

## Validation
- `npx tsc --noEmit` → **0 erreurs**
- `npx eslint --quiet` (touched files) → **0 warnings**
- `npx vitest run` → **1386 passed | 20 skipped | 0 errors**
- `npm run build` → Landing chunk **7.32 kB gzip** (baseline THI-118 préservée)
- Agent `ui-auditor` → **SHIP-READY** (a flaggé L265 AiSettings revoke-consent button comme migration oubliée — corrigée dans ce même commit avant push)

## Test plan reviewer

- [ ] Vérifier visuellement sur preview Vercel : couleur rouge cohérente sur logout UserMenu / consent modal error / AiSettings destructive buttons / RateLimitBadge empty state
- [ ] Vérifier focus ring emerald sur logout button (sidebar + dropdown header)
- [ ] Vérifier que `npm run build` ne charge plus `sonner-*.js` chunk
- [ ] Vérifier que les variants `tl-*` continuent de bien rendre (Dashboard, LessonPage, PWAInstallModal tabs)

Closes [THI-153](https://linear.app/thierryvm/issue/THI-153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolider les couleurs d’UI destructives dans un jeton partagé à thème GitHub, documenter le comportement des slots shadcn et supprimer une dépendance de toast inutilisée.

Enhancements:
- Unifier tous les états destructifs/d’erreur dans les composants d’authentification, d’IA, de terminal et de limitation de débit afin d’utiliser une seule variable de thème `--github-red` avec un style cohérent.
- Aligner les anneaux de focus du bouton de déconnexion dans le menu utilisateur avec le style de focus émeraude tout en préservant la sémantique rouge pour les actions destructives.
- Ajouter des commentaires de documentation aux variantes de base des boutons et badges pour expliquer la conservation des slots de focus shadcn et de `aria-invalid` pour les consommateurs en amont.

Build:
- Supprimer la dépendance inutilisée `sonner` du bundle de l’application.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate destructive UI colors into a shared GitHub-themed token, document shadcn slot behavior, and remove an unused toast dependency.

Enhancements:
- Unify all destructive/error states across auth, AI, terminal, and rate-limit components to use a single `--github-red` theme variable with consistent styling.
- Align logout button focus rings in the user menu with the emerald focus style while preserving red semantics for destructive actions.
- Add documentation comments to button and badge base variants to explain retained shadcn focus and aria-invalid slots for upstream consumers.

Build:
- Remove the unused `sonner` dependency from the application bundle.

</details>