### PR TITLE
chore(security): THI-180 — revoke EXECUTE on trigger-only SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/014_revoke_security_definer_rpc.sql
+++ b/supabase/migrations/014_revoke_security_definer_rpc.sql
@@ -15,6 +15,30 @@
 -- their TRIGGER definitions without consulting GRANTs. Revoking is therefore
 -- safe and closes the relevant PostgREST exposure surface.
 --
+-- ─── EXECUTE retention policy (per Sourcery review on PR #237) ──────────────
+-- After this migration, EXECUTE on each function is held by:
+--   • `handle_new_user()`         → `postgres` (owner) only.
+--                                   Invoked by the auth.users INSERT trigger,
+--                                   which fires under `supabase_auth_admin`
+--                                   (cross-schema) without needing EXECUTE.
+--   • `prevent_role_escalation()` → `postgres` (owner) only.
+--                                   Invoked by the profiles UPDATE trigger
+--                                   under the calling user — `postgres` owns
+--                                   the trigger and runs it with definer rights.
+--   • `rls_auto_enable()`         → `postgres` (owner) + `service_role`.
+--                                   Manual admin helper, invoked via
+--                                   Supabase service_role key (Dashboard /
+--                                   migration runner / admin scripts).
+--                                   `service_role` retains EXECUTE because it
+--                                   bypasses RLS and inherits all privileges
+--                                   on `public` by default — listed here so
+--                                   future cleanup migrations preserve it.
+--
+-- ─── Idempotency (per Sourcery review on PR #237) ───────────────────────────
+-- Each REVOKE + COMMENT is wrapped in a `DO` block that checks `pg_proc` first.
+-- If a function has been renamed or dropped, the block becomes a no-op instead
+-- of failing the whole migration. Safe to re-run across environments.
+--
 -- Refs:
 --   - Supabase advisor lints 0028 + 0029
 --   - Detected during THI-131 PR #236 cascade audit
@@ -28,35 +52,61 @@
 --   - Auth → Settings → "Leaked password protection" → ON
 --     (closes the auth_leaked_password_protection advisor)
 
--- ── Trigger-only functions: SAFE to revoke (no callers via REST or RLS) ─────
-
--- 1. handle_new_user() — fires on INSERT into auth.users (defined 001_init.sql:44).
+-- ── 1. handle_new_user() — fires on INSERT into auth.users (001_init.sql:44).
 --    Never called as RPC; never referenced in RLS policies.
-revoke execute on function public.handle_new_user() from anon, authenticated;
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'handle_new_user'
+      and pg_get_function_identity_arguments(p.oid) = ''
+  ) then
+    execute 'revoke execute on function public.handle_new_user() from anon, authenticated';
+    execute $cmt$comment on function public.handle_new_user() is
+      'TRIGGER on auth.users INSERT — auto-creates profile row with role=student. '
+      'SECURITY DEFINER for cross-schema write (auth → public). '
+      'EXECUTE retained by postgres (owner) only. '
+      'Revoked from anon/authenticated (THI-180) — invoked by trigger, never RPC.'$cmt$;
+  end if;
+end$$;
 
--- 2. prevent_role_escalation() — fires on UPDATE OF role ON profiles
---    (defined 005_rbac_roles.sql:128). Trigger only.
-revoke execute on function public.prevent_role_escalation() from anon, authenticated;
+-- ── 2. prevent_role_escalation() — fires on UPDATE OF role ON profiles
+--    (005_rbac_roles.sql:128). Trigger only.
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'prevent_role_escalation'
+      and pg_get_function_identity_arguments(p.oid) = ''
+  ) then
+    execute 'revoke execute on function public.prevent_role_escalation() from anon, authenticated';
+    execute $cmt$comment on function public.prevent_role_escalation() is
+      'TRIGGER on profiles UPDATE — blocks unauthorized role escalation. '
+      'SECURITY DEFINER to read parent profile institution_id without RLS recursion. '
+      'EXECUTE retained by postgres (owner) only. '
+      'Revoked from anon/authenticated (THI-180) — invoked by trigger, never RPC.'$cmt$;
+  end if;
+end$$;
 
--- 3. rls_auto_enable() — admin helper, manual invocation only (no RLS user)
-revoke execute on function public.rls_auto_enable() from anon, authenticated;
-
--- ── Documentation comments ──────────────────────────────────────────────────
-
-comment on function public.handle_new_user() is
-  'TRIGGER on auth.users INSERT — auto-creates profile row with role=student. '
-  'SECURITY DEFINER for cross-schema write (auth → public). '
-  'EXECUTE revoked from anon/authenticated (THI-180) — invoked by trigger only.';
-
-comment on function public.prevent_role_escalation() is
-  'TRIGGER on profiles UPDATE — blocks unauthorized role escalation. '
-  'SECURITY DEFINER to read parent profile institution_id without RLS recursion. '
-  'EXECUTE revoked from anon/authenticated (THI-180) — invoked by trigger only.';
-
-comment on function public.rls_auto_enable() is
-  'Admin helper to enable RLS on new tables. '
-  'SECURITY DEFINER for ALTER TABLE permission. '
-  'EXECUTE revoked from anon/authenticated (THI-180) — admin manual invocation only.';
+-- ── 3. rls_auto_enable() — admin helper, manual invocation only (no RLS user).
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'rls_auto_enable'
+      and pg_get_function_identity_arguments(p.oid) = ''
+  ) then
+    execute 'revoke execute on function public.rls_auto_enable() from anon, authenticated';
+    execute $cmt$comment on function public.rls_auto_enable() is
+      'Admin helper to enable RLS on new tables. '
+      'SECURITY DEFINER for ALTER TABLE permission. '
+      'EXECUTE retained by postgres (owner) AND service_role (admin invocation). '
+      'Revoked from anon/authenticated (THI-180) — never user-facing.'$cmt$;
+  end if;
+end$$;
 
 -- ── NOT revoked (deliberate — would break RLS policies) ─────────────────────
 --

--- a/supabase/migrations/014_revoke_security_definer_rpc.sql
+++ b/supabase/migrations/014_revoke_security_definer_rpc.sql
@@ -1,0 +1,74 @@
+-- ─── 014: Revoke EXECUTE on SECURITY DEFINER trigger functions (THI-180) ────
+-- Supabase Database Advisors (16 mai 2026) flagged 6 SECURITY DEFINER
+-- functions in the `public` schema as callable via `/rest/v1/rpc/*` by
+-- the `anon` and `authenticated` roles.
+--
+-- ⚠️ **NOT ALL CAN BE REVOKED** — three of them are invoked from inside RLS
+-- policies (`get_my_role`, `get_my_institution_id`, `is_teacher_of_class`).
+-- PostgreSQL requires the calling role to hold the EXECUTE privilege even
+-- when a SECURITY DEFINER function is invoked indirectly via a USING clause,
+-- so revoking EXECUTE from `authenticated` would break every RLS-protected
+-- read on `profiles`, `institutions`, `classes`, etc.
+--
+-- The three remaining SECURITY DEFINER functions are **trigger-only** — they
+-- are never appropriate to call as `/rest/v1/rpc/<name>` and PostgreSQL fires
+-- their TRIGGER definitions without consulting GRANTs. Revoking is therefore
+-- safe and closes the relevant PostgREST exposure surface.
+--
+-- Refs:
+--   - Supabase advisor lints 0028 + 0029
+--   - Detected during THI-131 PR #236 cascade audit
+--   - Linear: THI-180 (this migration)
+--   - Linear: THI-182 (follow-up — move RLS helpers to a `private` schema
+--     not exposed via PostgREST, completes the warning closure)
+--   - 005_rbac_roles.sql (original SECURITY DEFINER intent)
+--   - https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable
+--
+-- Manual follow-up (NOT in this migration — requires Dashboard click):
+--   - Auth → Settings → "Leaked password protection" → ON
+--     (closes the auth_leaked_password_protection advisor)
+
+-- ── Trigger-only functions: SAFE to revoke (no callers via REST or RLS) ─────
+
+-- 1. handle_new_user() — fires on INSERT into auth.users (defined 001_init.sql:44).
+--    Never called as RPC; never referenced in RLS policies.
+revoke execute on function public.handle_new_user() from anon, authenticated;
+
+-- 2. prevent_role_escalation() — fires on UPDATE OF role ON profiles
+--    (defined 005_rbac_roles.sql:128). Trigger only.
+revoke execute on function public.prevent_role_escalation() from anon, authenticated;
+
+-- 3. rls_auto_enable() — admin helper, manual invocation only (no RLS user)
+revoke execute on function public.rls_auto_enable() from anon, authenticated;
+
+-- ── Documentation comments ──────────────────────────────────────────────────
+
+comment on function public.handle_new_user() is
+  'TRIGGER on auth.users INSERT — auto-creates profile row with role=student. '
+  'SECURITY DEFINER for cross-schema write (auth → public). '
+  'EXECUTE revoked from anon/authenticated (THI-180) — invoked by trigger only.';
+
+comment on function public.prevent_role_escalation() is
+  'TRIGGER on profiles UPDATE — blocks unauthorized role escalation. '
+  'SECURITY DEFINER to read parent profile institution_id without RLS recursion. '
+  'EXECUTE revoked from anon/authenticated (THI-180) — invoked by trigger only.';
+
+comment on function public.rls_auto_enable() is
+  'Admin helper to enable RLS on new tables. '
+  'SECURITY DEFINER for ALTER TABLE permission. '
+  'EXECUTE revoked from anon/authenticated (THI-180) — admin manual invocation only.';
+
+-- ── NOT revoked (deliberate — would break RLS policies) ─────────────────────
+--
+-- public.get_my_role()                  → invoked in ~15 RLS USING clauses
+-- public.get_my_institution_id()        → invoked in profiles/institutions RLS
+-- public.is_teacher_of_class(uuid)      → invoked in classes/enrollments RLS
+--
+-- These three functions retain their `EXECUTE` grant on authenticated (and
+-- anon, where applicable) because the PostgreSQL RLS evaluation runs the
+-- USING expression under the calling user's role. Revoking would cause every
+-- protected SELECT to fail with `permission denied for function`.
+--
+-- The advisor warning on these three is **acknowledged** and tracked in
+-- THI-182: move them to a `private` schema that PostgREST does not expose,
+-- update the ~15 policy references in one bundled migration.


### PR DESCRIPTION
## Summary

Closes **3 of 7 Supabase Database Advisor WARN findings** detected during the THI-131 PR #236 cascade audit (16 mai 2026, pré-existants).

- Migration `014_revoke_security_definer_rpc.sql` : `REVOKE EXECUTE FROM anon, authenticated` sur 3 fonctions **trigger-only** (safe, zero RLS impact).
- 3 autres fonctions épargnées (senior reverse course) — elles sont invoquées par ~15 RLS policies → revoke = breakage. Tracked **THI-182** (private schema migration, follow-up séparé).
- 1 finding restant (leaked password protection) → manuel @thierry sur Dashboard, 1 clic.

## Motivation

`supabase advisors` (Database → Security) flag les SECURITY DEFINER functions exposées via `/rest/v1/rpc/*`. Pour les **triggers**, PostgreSQL invoke sans consulter GRANT → revoke = clean closure de l'exposition REST sans casse RLS.

## Self-review

- [x] **Senior reverse course documenté** dans le SQL header — 3 fonctions trigger-only revoked, 3 RLS-essential épargnées
- [x] **Test usage des fonctions** : `grep` confirme que `handle_new_user`, `prevent_role_escalation`, `rls_auto_enable` n'apparaissent qu'en `CREATE TRIGGER ... EXECUTE FUNCTION` (jamais en USING clause RLS, jamais en RPC frontend)
- [x] **RLS-essential épargnées** : `get_my_role`, `get_my_institution_id`, `is_teacher_of_class` documentées dans le SQL header + ticket follow-up **THI-182** (Backlog Low, structural migration to `private` schema, 2-3h effort)
- [x] **RBAC tests verts** : 40 pass / 20 skipped (Phase 9 awaiting infra)
- [x] **Vitest full** : 1405 pass / 20 skipped (baseline préservée)
- [x] **type-check + lint** clean
- [x] **No frontend changes** — pure SQL

## Evidence

```
$ grep -rn "handle_new_user\|prevent_role_escalation\|rls_auto_enable" supabase/migrations/
→ all references are CREATE TRIGGER ... EXECUTE FUNCTION
→ zero references in USING / WITH CHECK clauses
→ safe to revoke EXECUTE from anon/authenticated

$ npx vitest run src/test/rbac
→ Test Files  1 passed | 1 skipped (2)
→ Tests  40 passed | 20 skipped (60)
```

## Application (manual @thierry — historic context)

`supabase migration list --linked` montre que les migrations 001-013 ne sont **pas trackées** dans `schema_migrations` (elles ont été appliquées via MCP `apply_migration` historiquement). `supabase db push` essaierait de tout réappliquer → casserait. 

**Apply manuel via Dashboard SQL Editor** :
1. Ouvre [Supabase Dashboard → SQL Editor](https://supabase.com/dashboard/project/jdnukbpkjyyyjpuwgxhv/sql/new)
2. Colle le contenu de `supabase/migrations/014_revoke_security_definer_rpc.sql`
3. Run — 5 secondes, idempotent
4. Vérifie `Database → Advisors` → 3 WARN doivent disparaître

**Pendant que tu y es** : `Authentication → Settings → toggle ON "Leaked password protection"` (1 clic, ferme le 4ème WARN — `auth_leaked_password_protection`).

## Findings restants après merge + apply

| Finding | Status | Ticket |
|---|---|---|
| `handle_new_user` exposed | ✅ Fermé (cette PR) | THI-180 |
| `prevent_role_escalation` exposed | ✅ Fermé (cette PR) | THI-180 |
| `rls_auto_enable` exposed | ✅ Fermé (cette PR) | THI-180 |
| `auth_leaked_password_protection` | 🔜 Manuel Dashboard | THI-180 |
| `get_my_role` exposed | 🔜 Backlog (private schema migration) | **THI-182** |
| `get_my_institution_id` exposed | 🔜 Backlog | THI-182 |
| `is_teacher_of_class` exposed | 🔜 Backlog | THI-182 |

Net result : 7 WARN → 3 WARN (tracked, structural fix planifié).

## Test plan

- [ ] CI verte (Type-check · Lint · Test · Build)
- [ ] Sourcery review propre (ou SKIPPED rate-limit)
- [ ] Vercel preview SUCCESS (devrait être identique à main — pas de frontend touché)
- [ ] @thierry applique migration 014 via Dashboard SQL Editor post-merge
- [ ] @thierry flip leaked_password_protection ON
- [ ] Re-run Supabase Advisors → confirme 3 WARN fermés + 1 leaked password fermé
- [ ] Smoke test : login + onAuthStateChange flow toujours fonctionnel (trigger `handle_new_user` invoqué par INSERT auth.users, transparent côté client)

## Refs

- Linear : THI-180 (this PR), THI-182 (follow-up private schema)
- Détecté lors de PR #236 (THI-131 LTI Auth MVP)
- Migrations sources : `005_rbac_roles.sql`, `007_fix_rls_recursion.sql`, `010_security_fixes.sql`
- Supabase docs : [advisor lint 0028](https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Ajoute une migration de base de données pour renforcer la sécurité autour des fonctions `SECURITY DEFINER` tout en préservant le comportement RLS.

Corrections de bugs :
- Ferme trois avertissements de Supabase Database Advisor en révoquant le droit `EXECUTE` sur les fonctions `SECURITY DEFINER` utilisées uniquement comme déclencheurs (`trigger-only`) pour les rôles `anon` et `authenticated`.

Améliorations :
- Documente, via des commentaires SQL, la posture de sécurité et l’utilisation prévue des principales fonctions `SECURITY DEFINER`, en précisant celles qui restent accordées en raison de dépendances RLS ainsi que la migration de suivi prévue.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a database migration to tighten security around SECURITY DEFINER functions while preserving RLS behavior.

Bug Fixes:
- Close three Supabase Database Advisor warnings by revoking EXECUTE on trigger-only SECURITY DEFINER functions from anon and authenticated roles.

Enhancements:
- Document the security posture and intended usage of key SECURITY DEFINER functions via SQL comments, including which remain granted due to RLS dependencies and the planned follow-up migration.

</details>