### PR TITLE
docs(process): codify 17 mai doctrine — Voie A/B/C + token bypass discipline + STOP graduation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,11 +193,17 @@ Toute PR DOIT être validée visuellement avant merge, SAUF exception explicite 
 - Mention obligatoire dans le message merge : "Voie C — docs-only, scope vérifié, 0 risque runtime"
 
 ### Sécurité tokens bypass — input ET output side (codifié 17 mai 2026)
-- **JAMAIS `curl -I`** sur URL Vercel protégée : la response `Set-Cookie: _vercel_jwt=<JWT>` contient le RAW bypass token dans son payload base64-décodable. Capter ce header en tool result = compromission du contexte conversation.
-- **Pattern obligatoire** smoke test : `curl -sS -o /dev/null -w "HTTP %{http_code}\n" -H "x-vercel-protection-bypass: $bypass" <URL>`
+- **JAMAIS `curl -I`** sur URL Vercel protégée : la response `Set-Cookie: _vercel_jwt=<JWT>` contient le RAW bypass token dans son payload base64-décodable. Capter ce header en tool result = compromission du contexte de conversation.
+- **Pattern obligatoire** smoke test (placeholders : `$bypass` = valeur du token, `<PREVIEW_URL>` = URL `https://terminal-learning-*.vercel.app/...`) :
+  ```bash
+  bypass="<VERCEL_PROTECTION_BYPASS_VALUE>"
+  curl -sS -o /dev/null -w "HTTP %{http_code}\n" \
+       -H "x-vercel-protection-bypass: $bypass" \
+       "<PREVIEW_URL>"
+  ```
 - Si headers nécessaires (debug) : `curl -sS -D /tmp/h -o /tmp/b ...` puis `grep -vi '^set-cookie:\|_vercel_jwt' /tmp/h` puis `rm /tmp/h /tmp/b`
-- **Principe discard-by-default** : afficher uniquement ce qu'on veut, jamais filter ce qu'on ne veut pas (un filter dépend de connaître tous les noms de headers possibles, le discard ne dépend que de savoir ce qu'on demande)
-- Référence détaillée : `~/.claude/projects/.../memory/reference_vercel_bypass.md` — Vecteurs 1 (input 24/04) + 2 (output 17/05)
+- **Principe discard-by-default** : afficher uniquement ce qu'on veut, jamais filtrer ce qu'on ne veut pas (un filtre dépend de connaître tous les noms de headers possibles, le discard ne dépend que de savoir ce qu'on demande)
+- Référence détaillée : `~/.claude/projects/.../memory/reference_vercel_bypass.md` — Vecteurs 1 (input 24/04) + 2 (output 17/05) — *ressource locale développeur (mémoire Claude Code), hors repo*
 
 ### Graduation STOP sécurité (codifié 17 mai 2026)
 - STOP sécurité ≠ rotation automatique. STOP = pause + **évaluation graduée**.
@@ -206,11 +212,17 @@ Toute PR DOIT être validée visuellement avant merge, SAUF exception explicite 
   2. **Durée** : leak conversation-only meurt au prochain `/compact` ou fin de session — pas de fenêtre d'exploitation au-delà
   3. **Coût rotation** : cheap (regen 3 min) vs cher (clé API avec crédit consommé, 5 comptes test liés)
   4. **Pattern reproductible** : FIX pattern d'abord, ROTATE seulement si surface publique
-- Référence : `~/.claude/projects/.../memory/feedback_graduation_stop_security.md`
+- Référence : `~/.claude/projects/.../memory/feedback_graduation_stop_security.md` — *ressource locale développeur (mémoire Claude Code), hors repo*
 
 ### Discipline séquentielle PR ↔ branche
 - **Une PR à la fois jusqu'à merge.** Pas de création de branche pour PR N+1 avant que PR N soit mergée.
-- Exception : si PR N est bloquée par review externe long terme, documenter explicitement dans la session le démarrage en parallèle (sinon dette mentale d'oubli garantie).
+- **Exception 1 — review externe long terme** : si PR N est bloquée par review externe (Sourcery, Vercel, validation visuelle pending), documenter explicitement dans la session le démarrage en parallèle (sinon dette mentale d'oubli garantie).
+- **Exception 2 — hotfix production cassée** : si la prod est down ou un bug critique impacte les utilisateurs, un `fix/hotfix-*` court (≤ 5 fichiers, scope chirurgical) peut être ouvert en parallèle d'une PR feature en cours. Conditions cumulatives :
+  - Branche **depuis `main`** (pas depuis la branche feature en cours)
+  - Une seule responsabilité (le hotfix), pas d'embarquement de polish
+  - Mention explicite dans la PR : `[HOTFIX]` en titre + lien vers incident (Sentry, rapport user, etc.)
+  - Validation Voie A obligatoire (pas Voie C même si docs) sauf si la prod est inaccessible — auquel cas Voie B humaine immédiate
+  - Reprise de la PR feature interrompue documentée à la fin du hotfix (todo + branche checkout explicite)
 
 ### Migrations Supabase — auto-géré
 - Toute nouvelle migration doit être appliquée **sans attendre** via le MCP Supabase ou le CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,51 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
   ```
   Si Sourcery a commenté → corriger dans un commit fixup → repousser → ALORS proposer le merge
   Si Sourcery = SKIPPED (rate limit hebdomadaire atteint) → acceptable, procéder au merge
-- **Jamais merger sans validation visuelle Vercel explicite de Thierry** (Chrome + mobile)
+- **Jamais merger sans validation visuelle Vercel explicite de Thierry** (Chrome + mobile) — sauf Voie C ci-dessous
 - Après merge → issue Linear → Done + mettre à jour `docs/plan.md`
+
+### Validation visuelle preview Vercel — matrice 3 voies (codifié 17 mai 2026)
+Toute PR DOIT être validée visuellement avant merge, SAUF exception explicite Voie C. Choix de la voie en fonction du scope :
+
+**Voie A — Chrome DevTools MCP avec bypass header (par défaut)**
+- Quand : PR touche `src/` (UI, composants, routes), `api/`, `vercel.json`, ou tout fichier impactant le runtime
+- Méthode : Chrome MCP `new_page` sur preview URL avec query param unique :
+  `?x-vercel-protection-bypass=<VALEUR>&x-vercel-set-bypass-cookie=samesitenone`
+- Une seule navigation avec query param par hostname (le cookie persiste) — règle anti-leak `reference_vercel_bypass.md`
+- Vérifs obligatoires : `take_snapshot` + `take_screenshot` + `list_console_messages` (zéro erreur rouge) + `list_network_requests` (zéro 4xx/5xx)
+- Pages à tester : selon scope PR (au minimum la page modifiée, idéalement `/` + page modifiée)
+
+**Voie B — Browser utilisateur direct (fallback)**
+- Quand : Chrome MCP coince sur l'injection bypass, ou si validation rapide suffit
+- Méthode : Thierry charge l'URL dans son browser (session Vercel SSO déjà active)
+- Durée : 30 secondes max, pas de babysitting
+- Limite : pas adaptée si scope PR > 1-2 pages à tester en profondeur
+
+**Voie C — Skip validation visuelle (exceptionnel, conditions cumulatives)**
+- PR 100% docs (`*.md` seulement, ou `docs/`)
+- 0 fichier `src/`, `api/`, `supabase/`, `package.json`, `vercel.json`, ou tout fichier impactant runtime
+- CI verte + Sourcery vert (ou SKIPPED rate-limit acceptable)
+- Mention obligatoire dans le message merge : "Voie C — docs-only, scope vérifié, 0 risque runtime"
+
+### Sécurité tokens bypass — input ET output side (codifié 17 mai 2026)
+- **JAMAIS `curl -I`** sur URL Vercel protégée : la response `Set-Cookie: _vercel_jwt=<JWT>` contient le RAW bypass token dans son payload base64-décodable. Capter ce header en tool result = compromission du contexte conversation.
+- **Pattern obligatoire** smoke test : `curl -sS -o /dev/null -w "HTTP %{http_code}\n" -H "x-vercel-protection-bypass: $bypass" <URL>`
+- Si headers nécessaires (debug) : `curl -sS -D /tmp/h -o /tmp/b ...` puis `grep -vi '^set-cookie:\|_vercel_jwt' /tmp/h` puis `rm /tmp/h /tmp/b`
+- **Principe discard-by-default** : afficher uniquement ce qu'on veut, jamais filter ce qu'on ne veut pas (un filter dépend de connaître tous les noms de headers possibles, le discard ne dépend que de savoir ce qu'on demande)
+- Référence détaillée : `~/.claude/projects/.../memory/reference_vercel_bypass.md` — Vecteurs 1 (input 24/04) + 2 (output 17/05)
+
+### Graduation STOP sécurité (codifié 17 mai 2026)
+- STOP sécurité ≠ rotation automatique. STOP = pause + **évaluation graduée**.
+- Grille d'évaluation AVANT toute demande de rotation à l'humain :
+  1. **Surface** : publique (commit, log CI public, URL partagée hors machine) → ROTATE | locale (conversation context, `.secrets/` gitignored) → CLEAR + CONTINUE
+  2. **Durée** : leak conversation-only meurt au prochain `/compact` ou fin de session — pas de fenêtre d'exploitation au-delà
+  3. **Coût rotation** : cheap (regen 3 min) vs cher (clé API avec crédit consommé, 5 comptes test liés)
+  4. **Pattern reproductible** : FIX pattern d'abord, ROTATE seulement si surface publique
+- Référence : `~/.claude/projects/.../memory/feedback_graduation_stop_security.md`
+
+### Discipline séquentielle PR ↔ branche
+- **Une PR à la fois jusqu'à merge.** Pas de création de branche pour PR N+1 avant que PR N soit mergée.
+- Exception : si PR N est bloquée par review externe long terme, documenter explicitement dans la session le démarrage en parallèle (sinon dette mentale d'oubli garantie).
 
 ### Migrations Supabase — auto-géré
 - Toute nouvelle migration doit être appliquée **sans attendre** via le MCP Supabase ou le CLI


### PR DESCRIPTION
## Summary

Codification dans `CLAUDE.md` (section "Règles merge") des **4 nouvelles règles** déduites de l'incident bypass token output-side du 17 mai 2026 et du marathon de polish 16-17 mai (THI-186 data leak fix + post-session) :

1. **Validation visuelle preview Vercel — matrice 3 voies (A/B/C)**
2. **Sécurité tokens bypass — input ET output side**
3. **Graduation STOP sécurité — leak local-only ≠ rotation**
4. **Discipline séquentielle PR ↔ branche**

## Contexte

Pendant le marathon 16-17 mai, plusieurs frictions process ont été détectées :
- Mea culpa PR #237 (merge en autonomie sans validation visuelle Thierry)
- Incident 17/05 : fresh session a déclenché STOP suite à `curl -I` qui a capté le header `Set-Cookie: _vercel_jwt` (le JWT contient le raw bypass token dans son payload base64-décodable). Le STOP était correct mais la recommandation de rotation immédiate était disproportionnée (leak local-only, mortel au prochain `/compact`).
- Sur-réaction sécurité = ticket Opus 4.7 brûlé pour rotation non nécessaire.

Ces frictions étaient toutes liées à des **règles non codifiées** dans `CLAUDE.md`. La présente PR comble ces lacunes.

## Changes

- `CLAUDE.md` : section "Règles merge" enrichie de 4 sous-sections numérotées avec exemples bash et matrices de décision.

Pas de modification `src/`, `api/`, `supabase/`, `vercel.json`, `package.json` ni de config runtime.

## Memos référencés (hors repo, user config dir Claude — pas dans cette PR)

- `memory/reference_vercel_bypass.md` — nouvelle section "Vecteurs de leak — input ET output side (codifié 17 mai 2026)"
- `memory/feedback_graduation_stop_security.md` — nouveau memo : doctrine graduée STOP

## Verdict Voie

✅ **Voie C — docs-only**, scope vérifié :
- 1 seul fichier modifié (`CLAUDE.md`)
- 0 fichier `src/`, `api/`, `supabase/`, ou config runtime
- 0 risque runtime

## Test plan

- [x] `git diff` montre uniquement `CLAUDE.md` modifié
- [ ] CI verte (pas de test à exécuter — fichier `.md` racine)
- [ ] Sourcery vérifié (probablement SKIPPED rate-limit hebdomadaire)
- [ ] Mention Voie C dans le message merge

## Pour la prochaine session

Cette PR doit être **mergée en premier** par la fresh session (Phase 1 de l'onboarding), avant tout travail sur THI-189 / THI-42. Les règles codifiées ici sont **pré-requis** des phases suivantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Codifier de nouvelles règles de fusion et de sécurité dans le guide des contributeurs à la suite de l’incident de contournement du 17 mai 2026, en affinant la façon dont les PR sont validées et la manière dont les incidents de sécurité sont gérés.

Documentation :
- Étendre les règles de fusion de `CLAUDE.md` avec une matrice de validation des aperçus Vercel à trois voies (Voies A/B/C).
- Documenter des pratiques plus strictes de sécurité des jetons de contournement couvrant à la fois les risques côté entrée et côté sortie pour les endpoints protégés par Vercel.
- Décrire une doctrine de sécurité STOP graduée pour évaluer l’impact d’une fuite et la nécessité d’une rotation avant de demander la rotation de clés.
- Ajouter des recommandations sur la discipline des PR séquentielles et des branches afin de limiter le travail en cours parallèle.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Codify new merge and security process rules in the contributor guide following the 17 May 2026 bypass incident, refining how PRs are validated and how security incidents are handled.

Documentation:
- Expand CLAUDE.md merge rules with a three-path Vercel preview validation matrix (Voies A/B/C).
- Document stricter bypass token safety practices covering both input- and output-side risks for Vercel-protected endpoints.
- Describe a graduated STOP security doctrine to assess leakage impact and rotation necessity before requesting key rotation.
- Add guidance on sequential PR and branch discipline to limit parallel work-in-progress.

</details>