### PR TITLE
fix(security): THI-207 clear AI session data at signout — consent RGPD + plain keys + prefs

### DIFF
--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -23,6 +23,7 @@ import { buildPlatformContext } from '@/app/data/platformContext';
 import {
   forgetKey as kmForgetKey,
   hasKey as kmHasKey,
+  PROVIDER_KEY,
   type Provider,
 } from '@/lib/ai/keyManager';
 import { DEFAULT_MODELS } from '@/lib/ai/providers';
@@ -35,8 +36,6 @@ import { AiKeySetup } from './AiKeySetup';
 import { MessageInput } from './parts/MessageInput';
 import { MessageList } from './parts/MessageList';
 import { RateLimitBadge } from './parts/RateLimitBadge';
-
-const PROVIDER_STORAGE_KEY = 'ai_tutor_provider';
 
 interface Props {
   lang?: TutorLang;
@@ -54,7 +53,7 @@ function readEnabled(): boolean {
 
 function readStoredProvider(): Provider {
   try {
-    const v = localStorage.getItem(PROVIDER_STORAGE_KEY);
+    const v = localStorage.getItem(PROVIDER_KEY);
     if (v === 'openrouter' || v === 'anthropic' || v === 'openai' || v === 'gemini') return v;
   } catch {
     /* ignore */
@@ -106,7 +105,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
   const setProvider = useCallback((next: Provider) => {
     setProviderState(next);
     try {
-      localStorage.setItem(PROVIDER_STORAGE_KEY, next);
+      localStorage.setItem(PROVIDER_KEY, next);
     } catch {
       /* ignore */
     }

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -56,11 +56,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const { supabase } = await supabaseLoader;
     if (!supabase) return;
     // THI-207 — defense-in-depth + RGPD : purge AI session data BEFORE the UI
-    // reacts to the cleared session. Awaiting guarantees that the next user
-    // who logs in on the same device sees the consent modal again and does not
-    // inherit any plain key, provider preference, rate counter, or tutor mode.
+    // reacts to the cleared session. The next user logging in on the same
+    // device must see the consent modal again and must not inherit any plain
+    // key, provider preference, rate counter, or tutor mode.
     // Encrypted IndexedDB keys are preserved by design (passphrase-gated).
-    await clearAiSessionData();
+    //
+    // The try/catch is non-optional : in privacy mode (Firefox ITP strict,
+    // some Android WebViews) `localStorage.removeItem` can throw a
+    // SecurityError. Letting it bubble up would abort `setSession(null)` and
+    // the Supabase token revocation below, leaving a zombie session — exactly
+    // the failure mode the prompt-guardrail + security audits flagged before
+    // merge.
+    try {
+      await clearAiSessionData();
+    } catch (err) {
+      console.error('[auth] clearAiSessionData failed (non-fatal):', err);
+    }
     // Clear local session immediately — the UI reacts instantly.
     // Then revoke the server-side refresh token in the background (fire-and-forget).
     // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
+import { clearAiSessionData } from '@/lib/ai/keyManager';
 
 // Dynamic import — defers the 194 kB Supabase SDK chunk from the FCP critical
 // path. The module starts loading immediately in parallel with initial render,
@@ -54,6 +55,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signOut = useCallback(async () => {
     const { supabase } = await supabaseLoader;
     if (!supabase) return;
+    // THI-207 — defense-in-depth + RGPD : purge AI session data BEFORE the UI
+    // reacts to the cleared session. Awaiting guarantees that the next user
+    // who logs in on the same device sees the consent modal again and does not
+    // inherit any plain key, provider preference, rate counter, or tutor mode.
+    // Encrypted IndexedDB keys are preserved by design (passphrase-gated).
+    await clearAiSessionData();
     // Clear local session immediately — the UI reacts instantly.
     // Then revoke the server-side refresh token in the background (fire-and-forget).
     // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the

--- a/src/lib/ai/keyManager.ts
+++ b/src/lib/ai/keyManager.ts
@@ -15,9 +15,21 @@ export interface KeySaveOpts {
   passphrase?: string;
 }
 
-const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
+/** Single source of truth for the list of supported providers (THI-207). */
+export const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
 
-const LS_PREFIX = 'ai_key_';
+/** Prefix for plain-mode API keys stored in localStorage. */
+export const LS_PREFIX = 'ai_key_';
+
+/**
+ * Storage keys for AI session state — single source of truth (THI-207).
+ * `clearAiSessionData()` purges every entry below at signout to enforce the
+ * per-user RGPD + defense-in-depth contract documented in THI-186/THI-207.
+ */
+export const PROVIDER_KEY = 'ai_tutor_provider';
+export const CONSENT_KEY = 'ai_consent_v1';
+export const RATE_KEY = 'ai_rate_v1';
+export const MODE_KEY = 'ai_tutor_mode';
 const DB_NAME = 'ai_keys_encrypted';
 const DB_VERSION = 1;
 const STORE_NAME = 'keys';
@@ -286,12 +298,12 @@ export async function clearAiSessionData(opts?: { includeEncrypted?: boolean }):
   const ss = (globalThis as { sessionStorage?: Storage }).sessionStorage;
 
   for (const p of PROVIDERS) ls.removeItem(LS_PREFIX + p);
-  ls.removeItem('ai_tutor_provider');
-  ls.removeItem('ai_consent_v1');
+  ls.removeItem(PROVIDER_KEY);
+  ls.removeItem(CONSENT_KEY);
 
   try {
-    ss?.removeItem('ai_rate_v1');
-    ss?.removeItem('ai_tutor_mode');
+    ss?.removeItem(RATE_KEY);
+    ss?.removeItem(MODE_KEY);
   } catch {
     // Best effort — sessionStorage may be disabled (privacy mode, embedded WebView).
   }

--- a/src/lib/ai/keyManager.ts
+++ b/src/lib/ai/keyManager.ts
@@ -266,6 +266,41 @@ export async function forgetKey(provider: Provider): Promise<void> {
   }
 }
 
+/**
+ * Clears all AI session data at signout (THI-207, defense-in-depth + RGPD).
+ *
+ * RGPD critical: `ai_consent_v1` survives signout in localStorage by default
+ * — next user on the same device inherits consent without seeing the modal.
+ * Plain API keys, the last selected provider, the rate counter and the tutor
+ * mode are also flushed so a sequential user does not inherit a previous
+ * user's state.
+ *
+ * Encrypted IndexedDB keys are preserved by default: the AES-GCM record is
+ * inert without its passphrase, so keeping it lets a returning user reuse
+ * their own keys instead of being pushed back to plain mode at every signout.
+ * Opt-in `includeEncrypted: true` is reserved for the explicit "Forget all
+ * AI data on this device" UX (THI-208) — never used at automatic signout.
+ */
+export async function clearAiSessionData(opts?: { includeEncrypted?: boolean }): Promise<void> {
+  const ls = getLocalStorage();
+  const ss = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+
+  for (const p of PROVIDERS) ls.removeItem(LS_PREFIX + p);
+  ls.removeItem('ai_tutor_provider');
+  ls.removeItem('ai_consent_v1');
+
+  try {
+    ss?.removeItem('ai_rate_v1');
+    ss?.removeItem('ai_tutor_mode');
+  } catch {
+    // Best effort — sessionStorage may be disabled (privacy mode, embedded WebView).
+  }
+
+  if (opts?.includeEncrypted) {
+    for (const p of PROVIDERS) await forgetKey(p);
+  }
+}
+
 /** True iff an encrypted entry exists for the provider and no plain entry shadows it. */
 export async function isEncrypted(provider: Provider): Promise<boolean> {
   assertProvider(provider);

--- a/src/lib/ai/useAiTutor.ts
+++ b/src/lib/ai/useAiTutor.ts
@@ -26,8 +26,11 @@ import {
   sanitizeUserInput,
 } from './sanitizer';
 import {
+  CONSENT_KEY,
   forgetKey as kmForgetKey,
   getKey as kmGetKey,
+  MODE_KEY,
+  RATE_KEY,
   type Provider,
 } from './keyManager';
 import { chat as providerChat, ChatError } from './providers';
@@ -36,9 +39,11 @@ import { getSystemPrompt, type TutorLang, type TutorMode } from './systemPrompt'
 
 export const RATE_LIMIT_MAX = 30;
 export const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
-export const CONSENT_KEY = 'ai_consent_v1';
-export const RATE_STORAGE_KEY = 'ai_rate_v1';
-export const MODE_STORAGE_KEY = 'ai_tutor_mode';
+
+// THI-207 — centralized in keyManager (single source of truth). Re-exported
+// here for backward compatibility with existing consumers (AiSettings.tsx +
+// AiSettings.test.tsx + consent.test.ts).
+export { CONSENT_KEY };
 
 /**
  * Current shape version of the persisted consent record. Bump when the
@@ -139,7 +144,7 @@ interface RateState {
 
 function readRate(): RateState {
   try {
-    const raw = sessionStorage.getItem(RATE_STORAGE_KEY);
+    const raw = sessionStorage.getItem(RATE_KEY);
     if (!raw) return { count: 0, windowStart: Date.now() };
     const parsed = JSON.parse(raw) as Partial<RateState>;
     if (typeof parsed.count !== 'number' || typeof parsed.windowStart !== 'number') {
@@ -153,7 +158,7 @@ function readRate(): RateState {
 
 function writeRate(state: RateState): void {
   try {
-    sessionStorage.setItem(RATE_STORAGE_KEY, JSON.stringify(state));
+    sessionStorage.setItem(RATE_KEY, JSON.stringify(state));
   } catch {
     /* storage may be disabled — best effort */
   }
@@ -215,7 +220,7 @@ function readConsent(): boolean {
 
 function readMode(fallback: TutorMode): TutorMode {
   try {
-    const v = sessionStorage.getItem(MODE_STORAGE_KEY);
+    const v = sessionStorage.getItem(MODE_KEY);
     if (v === 'direct' || v === 'socratic') return v;
   } catch {
     /* ignore */
@@ -348,7 +353,7 @@ export function useAiTutor(opts: UseAiTutorOpts): UseAiTutorState {
 
   const setMode = useCallback((next: TutorMode) => {
     try {
-      sessionStorage.setItem(MODE_STORAGE_KEY, next);
+      sessionStorage.setItem(MODE_KEY, next);
     } catch {
       /* ignore */
     }

--- a/src/test/authContextSignoutAiKeys.test.ts
+++ b/src/test/authContextSignoutAiKeys.test.ts
@@ -1,0 +1,148 @@
+/**
+ * THI-207 — AI session data isolation at signout (defense-in-depth + RGPD).
+ *
+ * Companion test to THI-186's progressContextIsolation.test.ts. Covers the AI
+ * Tutor surface: plain keys, last selected provider, RGPD consent record, rate
+ * limit counter, tutor mode (socratic/direct). Encrypted IndexedDB keys are
+ * preserved by design (passphrase-gated, opt-in via `includeEncrypted: true`
+ * reserved for the explicit "Forget all AI data on this device" UX — THI-208).
+ *
+ * RGPD critical: `ai_consent_v1` lives in localStorage and survives signout by
+ * default. Without this fix, User B logging in on the same device inherits
+ * User A's consent without seeing the consent modal — explicit violation of
+ * "consent per-user, per-session, opt-in informed".
+ */
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearAiSessionData,
+  getKey,
+  saveKey,
+  type Provider,
+} from '@/lib/ai/keyManager';
+
+const DB_NAME = 'ai_keys_encrypted';
+const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
+
+function resetIdb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    const done = () => resolve();
+    req.onsuccess = done;
+    req.onerror = done;
+    req.onblocked = done;
+  });
+}
+
+function seedPlainKeys(): void {
+  localStorage.setItem('ai_key_openrouter', 'sk-or-v1-userA');
+  localStorage.setItem('ai_key_anthropic', 'sk-ant-userA');
+  localStorage.setItem('ai_key_openai', 'sk-userA');
+  localStorage.setItem('ai_key_gemini', 'AIzaUserA');
+}
+
+function seedPrefs(): void {
+  localStorage.setItem('ai_tutor_provider', 'anthropic');
+  localStorage.setItem('ai_consent_v1', JSON.stringify({ accepted: true, version: 1 }));
+  sessionStorage.setItem('ai_rate_v1', JSON.stringify({ count: 7, windowStart: Date.now() }));
+  sessionStorage.setItem('ai_tutor_mode', 'socratic');
+}
+
+beforeEach(async () => {
+  localStorage.clear();
+  sessionStorage.clear();
+  await resetIdb();
+});
+
+describe('THI-207 clearAiSessionData — 5 items + IDB preserved by default', () => {
+  it('flushes the 4 plain API keys from localStorage', async () => {
+    seedPlainKeys();
+    expect(localStorage.getItem('ai_key_openrouter')).toBe('sk-or-v1-userA');
+
+    await clearAiSessionData();
+
+    for (const p of PROVIDERS) {
+      expect(localStorage.getItem(`ai_key_${p}`)).toBeNull();
+    }
+  });
+
+  it('flushes ai_tutor_provider and ai_consent_v1 from localStorage (RGPD critical)', async () => {
+    seedPrefs();
+    expect(localStorage.getItem('ai_tutor_provider')).toBe('anthropic');
+    expect(localStorage.getItem('ai_consent_v1')).not.toBeNull();
+
+    await clearAiSessionData();
+
+    expect(localStorage.getItem('ai_tutor_provider')).toBeNull();
+    expect(localStorage.getItem('ai_consent_v1')).toBeNull();
+  });
+
+  it('flushes ai_rate_v1 and ai_tutor_mode from sessionStorage', async () => {
+    seedPrefs();
+    expect(sessionStorage.getItem('ai_rate_v1')).not.toBeNull();
+    expect(sessionStorage.getItem('ai_tutor_mode')).toBe('socratic');
+
+    await clearAiSessionData();
+
+    expect(sessionStorage.getItem('ai_rate_v1')).toBeNull();
+    expect(sessionStorage.getItem('ai_tutor_mode')).toBeNull();
+  });
+
+  it('preserves the encrypted IndexedDB key when called without opts', async () => {
+    await saveKey('anthropic', 'sk-ant-encrypted-userA', {
+      encrypt: true,
+      passphrase: 'pwd-userA',
+    });
+    seedPlainKeys();
+    seedPrefs();
+
+    await clearAiSessionData();
+
+    // Plain side fully wiped.
+    expect(localStorage.getItem('ai_key_anthropic')).toBeNull();
+    // Encrypted side still readable with the right passphrase.
+    expect(await getKey('anthropic', 'pwd-userA')).toBe('sk-ant-encrypted-userA');
+  });
+});
+
+describe('THI-207 clearAiSessionData — includeEncrypted (THI-208 future use)', () => {
+  it('also wipes the encrypted IndexedDB entries when includeEncrypted is true', async () => {
+    await saveKey('anthropic', 'sk-ant-encrypted', {
+      encrypt: true,
+      passphrase: 'pwd',
+    });
+    await saveKey('openrouter', 'sk-or-v1-encrypted', {
+      encrypt: true,
+      passphrase: 'pwd',
+    });
+    expect(await getKey('anthropic', 'pwd')).toBe('sk-ant-encrypted');
+
+    await clearAiSessionData({ includeEncrypted: true });
+
+    expect(await getKey('anthropic', 'pwd')).toBeNull();
+    expect(await getKey('openrouter', 'pwd')).toBeNull();
+  });
+});
+
+describe('THI-207 clearAiSessionData — idempotence and edges', () => {
+  it('does not throw on an empty state (idempotent)', async () => {
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+
+    await expect(clearAiSessionData()).resolves.toBeUndefined();
+    await expect(clearAiSessionData({ includeEncrypted: true })).resolves.toBeUndefined();
+  });
+
+  it('reproduces the RGPD per-user pattern (consent must re-appear for next user)', async () => {
+    // User A accepts consent → app records it in localStorage.
+    localStorage.setItem('ai_consent_v1', JSON.stringify({ accepted: true, version: 1, userId: 'A' }));
+    expect(localStorage.getItem('ai_consent_v1')).not.toBeNull();
+
+    // User A signs out → THI-207 flushes consent.
+    await clearAiSessionData();
+
+    // User B opens the app on the same device: consent record is absent,
+    // so the AI Consent modal will be shown again (RGPD per-user property).
+    expect(localStorage.getItem('ai_consent_v1')).toBeNull();
+  });
+});

--- a/src/test/authContextSignoutAiKeys.test.ts
+++ b/src/test/authContextSignoutAiKeys.test.ts
@@ -15,14 +15,18 @@
 import 'fake-indexeddb/auto';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  CONSENT_KEY,
   clearAiSessionData,
   getKey,
+  LS_PREFIX,
+  MODE_KEY,
+  PROVIDER_KEY,
+  PROVIDERS,
+  RATE_KEY,
   saveKey,
-  type Provider,
 } from '@/lib/ai/keyManager';
 
 const DB_NAME = 'ai_keys_encrypted';
-const PROVIDERS: readonly Provider[] = ['openrouter', 'anthropic', 'openai', 'gemini'];
 
 function resetIdb(): Promise<void> {
   return new Promise((resolve) => {
@@ -35,17 +39,18 @@ function resetIdb(): Promise<void> {
 }
 
 function seedPlainKeys(): void {
-  localStorage.setItem('ai_key_openrouter', 'sk-or-v1-userA');
-  localStorage.setItem('ai_key_anthropic', 'sk-ant-userA');
-  localStorage.setItem('ai_key_openai', 'sk-userA');
-  localStorage.setItem('ai_key_gemini', 'AIzaUserA');
+  // Cover every provider in the canonical list so a future addition
+  // automatically lands in the seeding loop and assertions.
+  for (const p of PROVIDERS) {
+    localStorage.setItem(`${LS_PREFIX}${p}`, `seed-${p}-userA`);
+  }
 }
 
 function seedPrefs(): void {
-  localStorage.setItem('ai_tutor_provider', 'anthropic');
-  localStorage.setItem('ai_consent_v1', JSON.stringify({ accepted: true, version: 1 }));
-  sessionStorage.setItem('ai_rate_v1', JSON.stringify({ count: 7, windowStart: Date.now() }));
-  sessionStorage.setItem('ai_tutor_mode', 'socratic');
+  localStorage.setItem(PROVIDER_KEY, 'anthropic');
+  localStorage.setItem(CONSENT_KEY, JSON.stringify({ accepted: true, version: 1 }));
+  sessionStorage.setItem(RATE_KEY, JSON.stringify({ count: 7, windowStart: Date.now() }));
+  sessionStorage.setItem(MODE_KEY, 'socratic');
 }
 
 beforeEach(async () => {
@@ -55,37 +60,37 @@ beforeEach(async () => {
 });
 
 describe('THI-207 clearAiSessionData — 5 items + IDB preserved by default', () => {
-  it('flushes the 4 plain API keys from localStorage', async () => {
+  it('flushes every plain API key from localStorage', async () => {
     seedPlainKeys();
-    expect(localStorage.getItem('ai_key_openrouter')).toBe('sk-or-v1-userA');
+    expect(localStorage.getItem(`${LS_PREFIX}openrouter`)).toBe('seed-openrouter-userA');
 
     await clearAiSessionData();
 
     for (const p of PROVIDERS) {
-      expect(localStorage.getItem(`ai_key_${p}`)).toBeNull();
+      expect(localStorage.getItem(`${LS_PREFIX}${p}`)).toBeNull();
     }
   });
 
-  it('flushes ai_tutor_provider and ai_consent_v1 from localStorage (RGPD critical)', async () => {
+  it('flushes the last provider and the consent record from localStorage (RGPD critical)', async () => {
     seedPrefs();
-    expect(localStorage.getItem('ai_tutor_provider')).toBe('anthropic');
-    expect(localStorage.getItem('ai_consent_v1')).not.toBeNull();
+    expect(localStorage.getItem(PROVIDER_KEY)).toBe('anthropic');
+    expect(localStorage.getItem(CONSENT_KEY)).not.toBeNull();
 
     await clearAiSessionData();
 
-    expect(localStorage.getItem('ai_tutor_provider')).toBeNull();
-    expect(localStorage.getItem('ai_consent_v1')).toBeNull();
+    expect(localStorage.getItem(PROVIDER_KEY)).toBeNull();
+    expect(localStorage.getItem(CONSENT_KEY)).toBeNull();
   });
 
-  it('flushes ai_rate_v1 and ai_tutor_mode from sessionStorage', async () => {
+  it('flushes the rate counter and the tutor mode from sessionStorage', async () => {
     seedPrefs();
-    expect(sessionStorage.getItem('ai_rate_v1')).not.toBeNull();
-    expect(sessionStorage.getItem('ai_tutor_mode')).toBe('socratic');
+    expect(sessionStorage.getItem(RATE_KEY)).not.toBeNull();
+    expect(sessionStorage.getItem(MODE_KEY)).toBe('socratic');
 
     await clearAiSessionData();
 
-    expect(sessionStorage.getItem('ai_rate_v1')).toBeNull();
-    expect(sessionStorage.getItem('ai_tutor_mode')).toBeNull();
+    expect(sessionStorage.getItem(RATE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(MODE_KEY)).toBeNull();
   });
 
   it('preserves the encrypted IndexedDB key when called without opts', async () => {
@@ -99,7 +104,7 @@ describe('THI-207 clearAiSessionData — 5 items + IDB preserved by default', ()
     await clearAiSessionData();
 
     // Plain side fully wiped.
-    expect(localStorage.getItem('ai_key_anthropic')).toBeNull();
+    expect(localStorage.getItem(`${LS_PREFIX}anthropic`)).toBeNull();
     // Encrypted side still readable with the right passphrase.
     expect(await getKey('anthropic', 'pwd-userA')).toBe('sk-ant-encrypted-userA');
   });
@@ -135,14 +140,14 @@ describe('THI-207 clearAiSessionData — idempotence and edges', () => {
 
   it('reproduces the RGPD per-user pattern (consent must re-appear for next user)', async () => {
     // User A accepts consent → app records it in localStorage.
-    localStorage.setItem('ai_consent_v1', JSON.stringify({ accepted: true, version: 1, userId: 'A' }));
-    expect(localStorage.getItem('ai_consent_v1')).not.toBeNull();
+    localStorage.setItem(CONSENT_KEY, JSON.stringify({ accepted: true, version: 1, userId: 'A' }));
+    expect(localStorage.getItem(CONSENT_KEY)).not.toBeNull();
 
     // User A signs out → THI-207 flushes consent.
     await clearAiSessionData();
 
     // User B opens the app on the same device: consent record is absent,
     // so the AI Consent modal will be shown again (RGPD per-user property).
-    expect(localStorage.getItem('ai_consent_v1')).toBeNull();
+    expect(localStorage.getItem(CONSENT_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Closes [THI-207](https://linear.app/thierryvm/issue/THI-207-clear-ai-session-data-at-signout-plain-keys-consent-rgpd-prefs-defense)
- ⚠️ **RGPD critical** : `ai_consent_v1` (localStorage) survivait au signout — next user OAuth héritait du consent sans voir la modal. Pattern verrouillé : consent **per-user**, **per-session**, **opt-in informé**.
- Defense-in-depth dans la lignée de THI-186 (progress data leak), appliqué à la surface AI Tutor.
- 5 items flushés (4 plain keys + consent + provider + rate + mode), encrypted IDB **preserved**.
- 7 nouveaux tests, 0 régression sur les 47 tests keyManager + auth existants.

## ⚠️ RGPD critical — finding révélé par lecture du code

Le scope initial décrit par l'audit du 17 mai supposait `ai-consent-session` en sessionStorage. La lecture du code (`useAiTutor.ts:170-206`) a révélé que la vraie clé est `ai_consent_v1` en **localStorage**, donc persistante entre sessions OAuth.

Conséquence directe : User A accepte le consent → signout → User B login → **modal jamais affichée** → consent hérité sans interaction utilisateur. Violation explicite RGPD.

Le challenge du scope par lecture du code (`memory/feedback_challenge_certainty.md` appliqué) a évité un fix passant à côté du bug le plus grave du sprint.

## Scope verrouillé (5 items + IDB keep)

| Item | Storage | Action |
|---|---|---|
| `ai_key_{openrouter,anthropic,openai,gemini}` × 4 | localStorage | FLUSH |
| `ai_tutor_provider` | localStorage | FLUSH |
| `ai_consent_v1` | localStorage | **FLUSH (RGPD critique)** |
| `ai_rate_v1` | sessionStorage | FLUSH |
| `ai_tutor_mode` | sessionStorage | FLUSH |
| IndexedDB encrypted | IndexedDB | **KEEP** (passphrase-gated, opt-in via `includeEncrypted: true` pour [THI-208](https://linear.app/thierryvm/issue/THI-208)) |

## Changements

- `src/lib/ai/keyManager.ts` (+33 lines) — nouvelle API `clearAiSessionData({ includeEncrypted? })`
- `src/app/context/AuthContext.tsx` (+8 lines) — `await clearAiSessionData()` au début de `signOut()`, avant `setSession(null)`
- `src/test/authContextSignoutAiKeys.test.ts` (+149 lines) — 7 tests sur le modèle `progressContextIsolation.test.ts` (THI-186), avec `fake-indexeddb`

## Test plan

- [ ] CI verte (type-check + lint + test + build)
- [ ] Sourcery vert (ou SKIPPED rate-limit acceptable)
- [ ] **Cascade agents** (scope `src/lib/ai/*` touché) :
  - [ ] `prompt-guardrail-auditor` — 0 CRITICAL requis
  - [ ] `security-auditor` — 0 CRITICAL/HIGH requis (RGPD + auth flow)
- [ ] **Validation Voie A Chrome MCP** (preuve empirique RGPD fix) :
  - [ ] Login OAuth → setup clé plain OpenRouter + clé encrypted Anthropic (passphrase)
  - [ ] Accepter consent modal, envoyer messages au tuteur, switch mode `socratic` → `direct`
  - [ ] Signout via sidebar
  - [ ] DevTools : localStorage `ai_key_*` + `ai_tutor_provider` + `ai_consent_v1` **ABSENTS**, sessionStorage `ai_rate_v1` + `ai_tutor_mode` **ABSENTS**, IndexedDB entry Anthropic **PRÉSENTE**
  - [ ] Re-login → **consent modal s'affiche à nouveau** (preuve empirique du RGPD fix)
  - [ ] AiSettings affiche Anthropic toujours "encrypted" (re-saisie passphrase OK)

## Notes

- Future ticket [THI-208](https://linear.app/thierryvm/issue/THI-208) — bouton UX "Forget all AI data on this device" qui utilisera `clearAiSessionData({ includeEncrypted: true })` pour wiper aussi les clés encrypted (cas changement de device, prêt de laptop, revente).
- Pattern strict respecté : push done ≠ task done — validation visuelle Voie A obligatoire avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Imposer l’effacement, à chaque déconnexion, de l’état de session lié à l’IA afin d’éviter que des utilisateurs suivants sur le même appareil n’héritent du consentement ou des préférences IA d’un autre utilisateur, tout en préservant par défaut les clés chiffrées.

Bug Fixes :
- S’assurer que le flag de consentement IA stocké dans `localStorage` est supprimé à la déconnexion, afin que les nouvelles sessions OAuth doivent donner leur consentement à nouveau de manière explicite.
- Empêcher que des utilisateurs successifs héritent, après une déconnexion, des clés d’API IA, compteurs de taux, sélection de fournisseur et mode tuteur des utilisateurs précédents.

Enhancements :
- Introduire un helper réutilisable `clearAiSessionData` pour nettoyer de façon centralisée l’état lié à l’IA dans `localStorage` et `sessionStorage`, avec une option permettant également de supprimer les clés chiffrées pour de futurs flux explicites d’effacement de données.

Tests :
- Ajouter des tests complets couvrant le comportement d’effacement des données de session IA, la préservation des clés chiffrées, l’idempotence et la sémantique de consentement RGPD par utilisateur lors de la déconnexion.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce per-signout clearing of AI-related session state to prevent subsequent users on the same device from inheriting AI consent or preferences, while preserving encrypted keys by default.

Bug Fixes:
- Ensure AI consent flag stored in localStorage is cleared on signout so new OAuth sessions must explicitly re-consent.
- Prevent sequential users from inheriting previous users’ AI API keys, rate counters, provider selection, and tutor mode after signout.

Enhancements:
- Introduce a reusable clearAiSessionData helper to centrally wipe AI-related localStorage and sessionStorage state, with an option to also remove encrypted keys for future explicit data-wipe flows.

Tests:
- Add comprehensive tests covering AI session data clearing behavior, encrypted key preservation, idempotence, and RGPD per-user consent semantics at signout.

</details>