### PR TITLE
feat(profile): THI-42 PR #1 — Profile Hub shell + UserMenu Mon profil link

### DIFF
--- a/src/app/components/ProfilePage.tsx
+++ b/src/app/components/ProfilePage.tsx
@@ -1,0 +1,186 @@
+/**
+ * ProfilePage — THI-42 PR #1 (shell).
+ *
+ * Profile Hub minimal under `/app/profile`. Scope verrouillé D1-D4 :
+ *  - D1 : pas de SettingsPage.tsx créée (obsolète post-AiSettings THI-112) —
+ *         on link vers `/app/settings` existant pour AI key + consent management
+ *  - D2 : Avatar OAuth read-only (GitHub `avatar_url` / Google `picture`).
+ *         Upload custom Supabase Storage = PR #2 différable.
+ *  - D3 : Environnement actif affiché en read-only avec lien vers la sidebar
+ *         (switcher réel reste dans la Sidebar — extraction du composant = PR #2 ou plus tard).
+ *  - D4 : Mini-PR lti-auditor déjà livrée.
+ *
+ * UserMenu (variant card + compact dropdown) gagne un lien "Mon profil"
+ * vers cette page dans la même PR.
+ *
+ * Cette page ne mute rien côté serveur — c'est un hub read-only pour PR #1.
+ * PR #2 ajoutera l'édition (pseudo, bio, langue, notif prefs, danger zone).
+ * PR #3 ajoutera les sections role-aware (Mes classes pour teacher, Admin
+ * Panel pour admin) dans le UserMenu dropdown ET ici via tabs.
+ */
+import { Link } from 'react-router';
+import { Helmet } from 'react-helmet-async';
+import { ArrowLeft, Github, KeyRound, Mail, Monitor, Sliders } from 'lucide-react';
+
+import { useAuth } from '../context/AuthContext';
+import { useEnvironment, ENV_META } from '../context/EnvironmentContext';
+import { UserAvatar } from './auth/UserAvatar';
+
+// OAuth provider label + icon — mirrors the subset of providers we currently
+// support in LoginModal (GitHub + Google email/password). Anything else
+// falls back to the generic "Email" label.
+function ProviderBadge({ provider }: { provider: string | undefined }) {
+  if (provider === 'github') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)]">
+        <Github size={12} aria-hidden="true" />
+        Connecté via GitHub
+      </span>
+    );
+  }
+  if (provider === 'google') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)]">
+        {/* lucide-react has no Google icon — we use a colored G letter */}
+        <span aria-hidden="true" className="w-3 h-3 rounded-full bg-gradient-to-br from-blue-500 via-red-500 to-yellow-500" />
+        Connecté via Google
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)]">
+      <Mail size={12} aria-hidden="true" />
+      Connecté par email
+    </span>
+  );
+}
+
+export function ProfilePage() {
+  const { user, initialized } = useAuth();
+  const { selectedEnv } = useEnvironment();
+
+  // Wait for Supabase session resolution before deciding to show the
+  // "not authenticated" message — without this guard, a legitimate user
+  // sees the fallback flash for ~100-300ms while Supabase initialises
+  // (security-auditor H1 finding, THI-42 PR #1).
+  if (!initialized) {
+    return (
+      <main className="flex-1 flex items-center justify-center min-h-[40vh]" aria-busy="true">
+        <p className="text-[var(--github-text-secondary)] text-sm font-mono">Chargement…</p>
+      </main>
+    );
+  }
+
+  // Auth guard — render fallback (no redirect) when initialised but no user.
+  // `AuthProvider` does not redirect on guarded routes — each component
+  // owns its fallback. Centralised <RequireAuth> wrapper at Layout level
+  // tracked as security-auditor follow-up for PR #3.
+  if (!user) {
+    return (
+      <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
+        <p className="text-[var(--github-text-secondary)] text-sm font-mono">
+          Vous devez être connecté pour accéder à votre profil. <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">Retour à l&apos;accueil</Link>
+        </p>
+      </main>
+    );
+  }
+
+  const avatarUrl =
+    (user.user_metadata?.avatar_url as string | undefined) ??
+    (user.user_metadata?.picture as string | undefined);
+  const displayName =
+    (user.user_metadata?.full_name as string | undefined) ??
+    (user.user_metadata?.user_name as string | undefined) ??
+    user.email?.split('@')[0] ??
+    'Utilisateur';
+  const initials = displayName[0].toUpperCase();
+  const provider = user.app_metadata?.provider;
+
+  const envMeta = ENV_META[selectedEnv];
+
+  return (
+    <main className="flex-1 px-6 py-8 max-w-4xl mx-auto w-full">
+      <Helmet>
+        <title>Mon profil — Terminal Learning</title>
+        <meta name="description" content="Profil utilisateur Terminal Learning — identité, environnement, paramètres IA." />
+      </Helmet>
+
+      <Link
+        to="/app"
+        className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)] hover:text-[var(--github-text-primary)] transition-colors mb-6 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+      >
+        <ArrowLeft size={12} aria-hidden="true" />
+        Retour au tableau de bord
+      </Link>
+
+      <h1 className="text-2xl font-semibold text-[var(--github-text-primary)] mb-2">Mon profil</h1>
+      <p className="text-sm text-[var(--github-text-secondary)] mb-8">
+        Informations de compte, environnement actif et paramètres. <span className="text-[var(--github-text-secondary)]/70">Édition de profil et danger zone disponibles bientôt.</span>
+      </p>
+
+      {/* ── Identité ──────────────────────────────────────────────────── */}
+      <section className="mb-8" aria-labelledby="profile-identity-heading">
+        <h2 id="profile-identity-heading" className="text-sm font-medium text-[var(--github-text-secondary)] font-mono uppercase tracking-wider mb-3">
+          Identité
+        </h2>
+        <div className="px-5 py-5 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] flex items-center gap-5">
+          <UserAvatar avatarUrl={avatarUrl} initials={initials} size="lg" />
+          <div className="min-w-0 flex-1">
+            <p className="text-lg text-[var(--github-text-primary)] font-medium truncate">{displayName}</p>
+            <p className="text-sm text-[var(--github-text-secondary)] truncate font-mono">{user.email}</p>
+            <div className="mt-2">
+              <ProviderBadge provider={typeof provider === 'string' ? provider : undefined} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Environnement actif ──────────────────────────────────────────── */}
+      <section className="mb-8" aria-labelledby="profile-env-heading">
+        <h2 id="profile-env-heading" className="text-sm font-medium text-[var(--github-text-secondary)] font-mono uppercase tracking-wider mb-3">
+          Environnement actif
+        </h2>
+        <div className="px-5 py-4 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] flex items-center gap-4">
+          <Monitor size={20} className={envMeta.color} aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-[var(--github-text-primary)] font-medium">{envMeta.label}</p>
+            <p className="text-xs text-[var(--github-text-secondary)] font-mono">{envMeta.shell} · {envMeta.promptPreview}</p>
+          </div>
+          <p className="text-xs text-[var(--github-text-secondary)]/70 font-mono shrink-0">
+            Modifier dans la sidebar
+          </p>
+        </div>
+      </section>
+
+      {/* ── Paramètres ────────────────────────────────────────────────── */}
+      <section aria-labelledby="profile-settings-heading">
+        <h2 id="profile-settings-heading" className="text-sm font-medium text-[var(--github-text-secondary)] font-mono uppercase tracking-wider mb-3">
+          Paramètres
+        </h2>
+        <div className="space-y-2">
+          <Link
+            to="/app/settings"
+            className="flex items-center gap-3 px-5 py-4 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] hover:border-emerald-500/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+          >
+            <KeyRound size={20} className="text-[var(--github-text-secondary)]" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-[var(--github-text-primary)] font-medium">Paramètres IA</p>
+              <p className="text-xs text-[var(--github-text-secondary)] font-mono">
+                Gérer les clés API par provider et le consentement RGPD
+              </p>
+            </div>
+          </Link>
+          <div className="flex items-center gap-3 px-5 py-4 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] opacity-60">
+            <Sliders size={20} className="text-[var(--github-text-secondary)]" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-[var(--github-text-primary)] font-medium">Préférences avancées</p>
+              <p className="text-xs text-[var(--github-text-secondary)] font-mono">
+                Notifications, langue, danger zone — bientôt disponible
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/components/ProfilePage.tsx
+++ b/src/app/components/ProfilePage.tsx
@@ -107,7 +107,7 @@ export function ProfilePage() {
 
       <Link
         to="/app"
-        className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)] hover:text-[var(--github-text-primary)] transition-colors mb-6 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+        className="inline-flex items-center gap-1.5 text-xs font-mono text-[var(--github-text-secondary)] hover:text-[var(--github-text-primary)] transition-colors mb-4 -mx-2 px-2 py-3 min-h-11 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
       >
         <ArrowLeft size={12} aria-hidden="true" />
         Retour au tableau de bord

--- a/src/app/components/auth/UserAvatar.tsx
+++ b/src/app/components/auth/UserAvatar.tsx
@@ -1,0 +1,43 @@
+/**
+ * UserAvatar — THI-42 PR #1 shell.
+ *
+ * Extracted from UserMenu.tsx so Profile Hub (`/app/profile`) can reuse the
+ * same OAuth avatar rendering (GitHub `avatar_url` / Google `picture`) with
+ * the same initials fallback. PR #2 will extend with upload to Supabase
+ * Storage (custom avatar) — for PR #1 we keep it read-only.
+ */
+export interface UserAvatarProps {
+  /** OAuth provider avatar URL (GitHub `avatar_url` / Google `picture`). */
+  avatarUrl?: string;
+  /** Single-character fallback when no avatar URL is available. */
+  initials: string;
+  /** Visual size — small (sidebar card / nav button) vs medium (dropdown / profile page). */
+  size: 'sm' | 'md' | 'lg';
+}
+
+const SIZE_CLASSES: Record<UserAvatarProps['size'], string> = {
+  sm: 'w-8 h-8 text-sm',
+  md: 'w-10 h-10 text-base',
+  lg: 'w-20 h-20 text-2xl',
+};
+
+export function UserAvatar({ avatarUrl, initials, size }: UserAvatarProps) {
+  const cls = SIZE_CLASSES[size];
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt=""
+        aria-hidden="true"
+        className={`${cls} rounded-full shrink-0`}
+      />
+    );
+  }
+  return (
+    <span
+      className={`${cls} rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 font-mono shrink-0 select-none`}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { LogOut, LogIn, User } from 'lucide-react';
+import { Link, useNavigate } from 'react-router';
+import { LogOut, LogIn, User, CircleUser } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useFocusTrap } from '../../../lib/hooks/useFocusTrap';
 import { Button } from '../ui/button';
+import { UserAvatar } from './UserAvatar';
 
 interface UserMenuProps {
   syncStatus: 'local' | 'synced' | 'syncing' | 'error';
@@ -17,23 +18,14 @@ interface UserMenuProps {
 }
 
 const SYNC_CONFIG: Record<UserMenuProps['syncStatus'], { label: string; dot: string; text: string }> = {
-  local:   { label: 'Local',          dot: 'bg-[#8b949e]',               text: 'text-[var(--github-text-secondary)]' },
+  local:   { label: 'Local',          dot: 'bg-[var(--github-text-secondary)]',               text: 'text-[var(--github-text-secondary)]' },
   syncing: { label: 'Sync…',          dot: 'bg-yellow-400 animate-pulse', text: 'text-yellow-400' },
   synced:  { label: 'Synchronisé',    dot: 'bg-emerald-400',              text: 'text-emerald-400' },
   error:   { label: 'Erreur de sync', dot: 'bg-[var(--github-red)]',               text: 'text-[var(--github-red)]' },
 };
 
-function UserAvatar({ avatarUrl, initials, size }: { avatarUrl?: string; initials: string; size: 'sm' | 'md' }) {
-  const cls = size === 'sm' ? 'w-8 h-8 text-sm' : 'w-10 h-10 text-base';
-  if (avatarUrl) {
-    return <img src={avatarUrl} alt="" aria-hidden="true" className={`${cls} rounded-full shrink-0`} />;
-  }
-  return (
-    <span className={`${cls} rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 font-mono shrink-0 select-none`}>
-      {initials}
-    </span>
-  );
-}
+// UserAvatar extracted to ./UserAvatar.tsx (THI-42 PR #1) so ProfilePage can
+// reuse the same OAuth avatar rendering with identical sizing semantics.
 
 export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMenuProps) {
   const { user, signOut } = useAuth();
@@ -77,7 +69,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
     return (
       <div className="px-3 py-2.5 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)]">
         <div className="flex items-center gap-2.5 mb-2.5">
-          <span className="w-8 h-8 rounded-full bg-[#21262d] border border-[var(--github-border-primary)] flex items-center justify-center shrink-0">
+          <span className="w-8 h-8 rounded-full bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] flex items-center justify-center shrink-0">
             <User size={14} className="text-[var(--github-text-secondary)]" aria-hidden="true" />
           </span>
           <div className="flex-1 min-w-0">
@@ -120,7 +112,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
             <UserAvatar avatarUrl={avatarUrl} initials={initials} size="sm" />
             <span
               aria-hidden="true"
-              className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[#161b22] ${sync.dot}`}
+              className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[var(--github-bg-tertiary)] ${sync.dot}`}
             />
           </div>
           <div className="flex-1 min-w-0">
@@ -129,6 +121,17 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
           </div>
           {extraActions && <div className="flex items-center gap-1 shrink-0">{extraActions}</div>}
         </div>
+        <Button
+          asChild
+          variant="emerald-soft"
+          size="link-inline"
+          className="w-full gap-2 min-h-11 py-1.5 mb-1.5 rounded-md text-xs font-mono hover:border-emerald-500/40"
+        >
+          <Link to="/app/profile">
+            <CircleUser size={12} aria-hidden="true" />
+            Mon profil
+          </Link>
+        </Button>
         <Button
           variant="ghost"
           size="link-inline"
@@ -159,7 +162,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
         <UserAvatar avatarUrl={avatarUrl} initials={initials} size="sm" />
         <span
           aria-hidden="true"
-          className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[#0d1117] ${sync.dot}`}
+          className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-[var(--github-bg)] ${sync.dot}`}
         />
       </Button>
 
@@ -183,6 +186,15 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
             </div>
           </div>
           <div className="py-1" role="none">
+            <Link
+              to="/app/profile"
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              className="flex items-center w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[var(--github-text-primary)] font-mono hover:bg-[var(--github-border-secondary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+            >
+              <CircleUser size={14} aria-hidden="true" />
+              Mon profil
+            </Link>
             <Button
               variant="ghost"
               size="link-inline"

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -68,6 +68,9 @@ const CommandReference = lazyWithRetry(() =>
 const AiSettings = lazyWithRetry(() =>
   import('./components/AiSettings').then(({ AiSettings }) => ({ default: AiSettings }))
 );
+const ProfilePage = lazyWithRetry(() =>
+  import('./components/ProfilePage').then(({ ProfilePage }) => ({ default: ProfilePage }))
+);
 const Changelog = lazyWithRetry(() =>
   import('./components/Changelog').then(({ Changelog }) => ({ default: Changelog }))
 );
@@ -95,6 +98,7 @@ export const router = createBrowserRouter([
       { path: 'learn/:moduleId/:lessonId', Component: LessonPage },
       { path: 'reference', Component: CommandReference },
       { path: 'settings', Component: AiSettings },
+      { path: 'profile', Component: ProfilePage },
     ],
   },
 

--- a/src/test/profilePage.test.tsx
+++ b/src/test/profilePage.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for ProfilePage — THI-42 PR #1 shell.
+ *
+ * Covers:
+ *  - authenticated user with avatar_url + full_name → renders identity card
+ *  - authenticated user with email-only (no metadata) → falls back to email prefix as display name
+ *  - authenticated user via Google → renders Google provider badge
+ *  - authenticated user via GitHub → renders GitHub provider badge
+ *  - authenticated user via email → renders generic email badge
+ *  - environment switcher section renders current env label + shell preview
+ *  - settings section links to /app/settings (THI-112 existing page)
+ *  - back-link points to /app dashboard
+ *  - unauthenticated user → renders fallback guard message
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+type AuthMock = {
+  user: {
+    email?: string;
+    user_metadata?: Record<string, unknown>;
+    app_metadata?: Record<string, unknown>;
+  } | null;
+  initialized: boolean;
+};
+
+const authState: AuthMock = { user: null, initialized: true };
+
+vi.mock('../app/context/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user, initialized: authState.initialized }),
+}));
+
+vi.mock('../app/context/EnvironmentContext', async () => {
+  const actual = await vi.importActual<typeof import('../app/context/EnvironmentContext')>(
+    '../app/context/EnvironmentContext'
+  );
+  return {
+    ...actual,
+    useEnvironment: () => ({
+      selectedEnv: 'linux' as const,
+      setEnvironment: vi.fn(),
+    }),
+  };
+});
+
+import { ProfilePage } from '../app/components/ProfilePage';
+
+function renderProfile() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <ProfilePage />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+// ── Auth guard ────────────────────────────────────────────────────────────────
+
+describe('ProfilePage — auth guard', () => {
+  it('renders loading state while AuthContext is initialising', () => {
+    authState.user = null;
+    authState.initialized = false;
+    renderProfile();
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+    // The "vous devez être connecté" fallback must NOT flash for legitimate
+    // users while their session is being resolved (security-auditor H1).
+    expect(screen.queryByText(/vous devez être connecté/i)).not.toBeInTheDocument();
+  });
+
+  it('renders fallback message when initialised but no user is authenticated', () => {
+    authState.user = null;
+    authState.initialized = true;
+    renderProfile();
+    expect(screen.getByText(/vous devez être connecté/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /retour à l'accueil/i })).toBeInTheDocument();
+  });
+});
+
+// ── Authenticated rendering ───────────────────────────────────────────────────
+
+describe('ProfilePage — authenticated user', () => {
+  it('renders display name and email from user_metadata', () => {
+    authState.user = {
+      email: 'thierry@example.com',
+      user_metadata: { full_name: 'Thierry Vanmeeteren', avatar_url: 'https://example.com/avatar.png' },
+      app_metadata: { provider: 'github' },
+    };
+    renderProfile();
+    expect(screen.getByText('Thierry Vanmeeteren')).toBeInTheDocument();
+    expect(screen.getByText('thierry@example.com')).toBeInTheDocument();
+  });
+
+  it('falls back to email prefix when no metadata is present', () => {
+    authState.user = { email: 'fallback@example.com', user_metadata: {}, app_metadata: {} };
+    renderProfile();
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+  });
+
+  it('renders GitHub provider badge when app_metadata.provider is "github"', () => {
+    authState.user = {
+      email: 'gh@example.com',
+      user_metadata: { user_name: 'octocat', avatar_url: 'https://example.com/oc.png' },
+      app_metadata: { provider: 'github' },
+    };
+    renderProfile();
+    expect(screen.getByText(/connecté via github/i)).toBeInTheDocument();
+  });
+
+  it('renders Google provider badge when app_metadata.provider is "google"', () => {
+    authState.user = {
+      email: 'g@example.com',
+      user_metadata: { full_name: 'Google User', picture: 'https://example.com/g.png' },
+      app_metadata: { provider: 'google' },
+    };
+    renderProfile();
+    expect(screen.getByText(/connecté via google/i)).toBeInTheDocument();
+  });
+
+  it('renders generic email badge when app_metadata.provider is "email"', () => {
+    authState.user = {
+      email: 'pure-email@example.com',
+      user_metadata: {},
+      app_metadata: { provider: 'email' },
+    };
+    renderProfile();
+    expect(screen.getByText(/connecté par email/i)).toBeInTheDocument();
+  });
+
+  it('renders active environment section with shell + prompt preview', () => {
+    authState.user = { email: 'env-test@example.com', user_metadata: {}, app_metadata: {} };
+    renderProfile();
+    expect(screen.getByText('Linux')).toBeInTheDocument();
+    expect(screen.getByText(/bash \/ zsh/i)).toBeInTheDocument();
+  });
+
+  it('renders link to /app/settings for AI key + consent management', () => {
+    authState.user = { email: 'settings@example.com', user_metadata: {}, app_metadata: {} };
+    renderProfile();
+    const settingsLink = screen.getByRole('link', { name: /paramètres ia/i });
+    expect(settingsLink).toBeInTheDocument();
+    expect(settingsLink).toHaveAttribute('href', '/app/settings');
+  });
+
+  it('renders back-link to /app dashboard', () => {
+    authState.user = { email: 'back@example.com', user_metadata: {}, app_metadata: {} };
+    renderProfile();
+    const backLink = screen.getByRole('link', { name: /retour au tableau de bord/i });
+    expect(backLink).toBeInTheDocument();
+    expect(backLink).toHaveAttribute('href', '/app');
+  });
+});


### PR DESCRIPTION
## Summary

Premier livrable Sprint 2 Phase 4 — Profile Hub shell minimal sous `/app/profile` + lien "Mon profil" dans UserMenu (variant card + compact dropdown). Scope verrouillé **D1-D4** par backup décisionnaire 17/05 + audits cascade ui-auditor + security-auditor déjà passés et fixes intégrés.

Ticket : [**THI-42**](https://linear.app/thierryvm/issue/THI-42).

## Scope verrouillé (D1-D4)

- **D1** : PAS de `SettingsPage.tsx` créée — lien vers `/app/settings` existant (THI-112)
- **D2** : Avatar OAuth read-only (GitHub `avatar_url` / Google `picture`) — upload custom = PR #2 différable post-10 juin
- **D3** : Switcher env affiché read-only avec mention "Modifier dans la sidebar" (composant Sidebar intact)
- **D4** : N/A (lti-auditor déjà livrée)

## Fichiers modifiés

| Fichier | Type | Lignes |
|---|---|---|
| `src/app/components/ProfilePage.tsx` | **nouveau** | +186 |
| `src/app/components/auth/UserAvatar.tsx` | **nouveau (extraction DRY)** | +43 |
| `src/app/components/auth/UserMenu.tsx` | refactor + Profile link | +29/-17 |
| `src/app/routes.ts` | nouvelle route `/app/profile` | +4 |
| `src/test/profilePage.test.tsx` | **nouveau (10 tests)** | +156 |

**Total : +418/-17 lignes**.

## Audits cascade — déjà passés et fixes intégrés

### ui-auditor 🔴 → ✅ TOUS FIXÉS

4 CRITICAL pré-existantes hardcoded hex flaggées dans UserMenu.tsx (drive-by cleanup) :
- `bg-[#8b949e]` → `bg-[var(--github-text-secondary)]`
- `bg-[#21262d]` → `bg-[var(--github-border-secondary)]`
- `border-[#161b22]` → `border-[var(--github-bg-tertiary)]`
- `border-[#0d1117]` → `border-[var(--github-bg)]`

W1 fix : focus-visible emerald ring ajouté sur back-link ProfilePage.

### security-auditor 9.2/10 → H1 ✅ FIXÉ

H1 (race condition auth guard) : `ProfilePage` test désormais `initialized` avant `!user`, affiche un loading state pendant ~100-300ms de résolution session Supabase au lieu de flasher le message "vous devez être connecté" à un user authentifié.

Test dédié dans suite (`renders loading state while AuthContext is initialising`).

## Audits backlog non-bloquants (post-merge à tracer)

- **security-auditor M1** : CSP `lh3.googleusercontent.com` → wildcard `*.googleusercontent.com` (modif `vercel.json`, scope dédié hors PR #1). Workaround comptes G Suite avec avatars sur lh4/lh5/lh6.
- **security-auditor M2** : Avatar URL validation defense-in-depth (PR #2 — CSP couvre déjà).
- **security recommendation** : `<RequireAuth>` wrapper centralisé `Layout.tsx` (dette transversale dans Dashboard / LessonPage / ProfilePage). Backlog PR #3.

## Test plan

- [x] Lint clean
- [x] Type-check clean
- [x] **1434 tests pass (+10 profilePage), 0 régression sur les 1424 existants**
- [x] ui-auditor : 4 CRITICAL → 0, W1 → 0
- [x] security-auditor : H1 → 0, score 9.2/10 maintenu
- [ ] CI verte
- [ ] **Voie A Chrome MCP iPhone 14 + desktop 1280×800** sur preview Vercel :
  - Login compte test (.env.test) → UserMenu sidebar → click "Mon profil"
  - Profile Hub render : avatar OAuth + display_name + email + provider badge
  - Env section affichage correct + lien settings → /app/settings
  - Back-link → /app dashboard
  - UserMenu compact dropdown sur Landing : "Mon profil" item visible AVANT "Se déconnecter"
  - Test signout : régression THI-207 zero (clearAiSessionData toujours appelé)
  - 0 console error / 0 4xx-5xx network

## Verdict Voie

**Voie A obligatoire** — modifie `src/`, scope UI nouveau (1 page + 2 composants). Pas éligible Voie C.

Closes [THI-42](https://linear.app/thierryvm/issue/THI-42) PR #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)