### PR TITLE
security(avatar): THI-220 — defense-in-depth URL validation (UserAvatar.tsx)

### DIFF
--- a/src/app/components/auth/UserAvatar.tsx
+++ b/src/app/components/auth/UserAvatar.tsx
@@ -1,11 +1,49 @@
 /**
- * UserAvatar — THI-42 PR #1 shell.
+ * UserAvatar — THI-42 PR #1 shell + THI-220 defense-in-depth validation.
  *
  * Extracted from UserMenu.tsx so Profile Hub (`/app/profile`) can reuse the
  * same OAuth avatar rendering (GitHub `avatar_url` / Google `picture`) with
  * the same initials fallback. PR #2 will extend with upload to Supabase
  * Storage (custom avatar) — for PR #1 we keep it read-only.
+ *
+ * THI-220 adds component-level URL validation as a defense-in-depth layer
+ * underneath CSP `img-src` (THI-219). If a malformed or unexpected host
+ * sneaks past Supabase Auth metadata (compromised IdP, manual user_metadata
+ * tampering, future provider added without CSP update), the component
+ * silently falls back to initials instead of attempting a rejected request.
  */
+
+// Mirror the CSP `img-src` allow-list (vercel.json). Keep in sync when adding
+// or removing OAuth providers. Long-term consolidation: THI-223 vercel.ts.
+const AVATAR_ALLOWED_HOSTS = new Set([
+  'avatars.githubusercontent.com',
+  'lh1.googleusercontent.com',
+  'lh2.googleusercontent.com',
+  'lh3.googleusercontent.com',
+  'lh4.googleusercontent.com',
+  'lh5.googleusercontent.com',
+  'lh6.googleusercontent.com',
+]);
+
+/**
+ * Validates an OAuth avatar URL :
+ *  - must parse as a URL
+ *  - must use HTTPS
+ *  - hostname must be in the allow-list
+ *
+ * Returns false on any error rather than throwing, so the component can
+ * decide between rendering the img or the initials fallback without try/catch.
+ */
+export function isValidAvatarUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:') return false;
+    return AVATAR_ALLOWED_HOSTS.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export interface UserAvatarProps {
   /** OAuth provider avatar URL (GitHub `avatar_url` / Google `picture`). */
   avatarUrl?: string;
@@ -23,7 +61,7 @@ const SIZE_CLASSES: Record<UserAvatarProps['size'], string> = {
 
 export function UserAvatar({ avatarUrl, initials, size }: UserAvatarProps) {
   const cls = SIZE_CLASSES[size];
-  if (avatarUrl) {
+  if (avatarUrl && isValidAvatarUrl(avatarUrl)) {
     return (
       <img
         src={avatarUrl}

--- a/src/test/userAvatar.test.tsx
+++ b/src/test/userAvatar.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for UserAvatar — THI-220 defense-in-depth URL validation.
+ *
+ * Covers :
+ *  - isValidAvatarUrl() pure function (host allow-list + HTTPS-only)
+ *  - render branches : valid url → <img>, invalid url → fallback initials
+ *  - all allowed hosts (GitHub + lh1-lh6) accepted
+ *  - rejected schemes (http, javascript, data, file) → fallback
+ *  - rejected hosts (uc.googleusercontent.com, evil.com) → fallback
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { UserAvatar, isValidAvatarUrl } from '../app/components/auth/UserAvatar';
+
+// ── isValidAvatarUrl pure function ──────────────────────────────────────────
+
+describe('isValidAvatarUrl — allow-list enforcement', () => {
+  it.each([
+    'https://avatars.githubusercontent.com/u/123456?v=4',
+    'https://lh1.googleusercontent.com/a/ACg8oc',
+    'https://lh2.googleusercontent.com/a/foo',
+    'https://lh3.googleusercontent.com/a/bar',
+    'https://lh4.googleusercontent.com/a/baz',
+    'https://lh5.googleusercontent.com/a/qux',
+    'https://lh6.googleusercontent.com/a/quux',
+  ])('accepts allow-listed host: %s', (url) => {
+    expect(isValidAvatarUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'http://avatars.githubusercontent.com/u/123', // not HTTPS
+    'https://uc.googleusercontent.com/abc', // user-content host (Drive/Gmail)
+    'https://lh7.googleusercontent.com/a/foo', // future host, not yet allow-listed
+    'https://evil.com/a/foo',
+    'https://avatars.githubusercontent.com.evil.com/a', // subdomain hijack attempt
+    'https://avatars.githubusercontent.com.evil/a', // similar
+    'javascript:alert(1)', // XSS attempt
+    'data:image/png;base64,iVBORw0KGgo=', // data URL (CSP `data:` allowed but we reject here)
+    'file:///etc/passwd', // local file scheme
+    '', // empty string
+    'not-a-url',
+    '//avatars.githubusercontent.com/u/123', // protocol-relative
+  ])('rejects unauthorized URL: %s', (url) => {
+    expect(isValidAvatarUrl(url)).toBe(false);
+  });
+});
+
+// ── UserAvatar render branches ──────────────────────────────────────────────
+
+describe('UserAvatar — render branches', () => {
+  it('renders <img> when avatarUrl is a valid GitHub avatar', () => {
+    const { container } = render(
+      <UserAvatar
+        avatarUrl="https://avatars.githubusercontent.com/u/123?v=4"
+        initials="T"
+        size="md"
+      />
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('https://avatars.githubusercontent.com/u/123?v=4');
+  });
+
+  it('renders <img> when avatarUrl is a valid Google avatar (lh3)', () => {
+    const { container } = render(
+      <UserAvatar avatarUrl="https://lh3.googleusercontent.com/a/x" initials="T" size="sm" />
+    );
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('falls back to initials when avatarUrl is undefined', () => {
+    render(<UserAvatar initials="T" size="lg" />);
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('falls back to initials when avatarUrl uses an unauthorized host', () => {
+    const { container } = render(
+      <UserAvatar
+        avatarUrl="https://uc.googleusercontent.com/danger"
+        initials="X"
+        size="md"
+      />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(screen.getByText('X')).toBeInTheDocument();
+  });
+
+  it('falls back to initials when avatarUrl uses http (not HTTPS)', () => {
+    const { container } = render(
+      <UserAvatar
+        avatarUrl="http://avatars.githubusercontent.com/u/123"
+        initials="H"
+        size="md"
+      />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(screen.getByText('H')).toBeInTheDocument();
+  });
+
+  it('falls back to initials on javascript: scheme XSS attempt', () => {
+    const { container } = render(
+      <UserAvatar avatarUrl="javascript:alert(1)" initials="J" size="md" />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Component-level allow-list in `UserAvatar.tsx` mirrors CSP img-src (THI-219)
- HTTPS scheme only + host allow-list (GitHub + Google lh1-lh6)
- Rejects http://, javascript:, data:, file://, uc.googleusercontent.com, lh7+, evil.com etc → fallback initials
- 25 unit tests covering pure function + render branches

## Closes
Closes THI-220

## Files
- `src/app/components/auth/UserAvatar.tsx` — +30 lines (export `isValidAvatarUrl` + ALLOWED_HOSTS Set + render guard)
- `src/test/userAvatar.test.tsx` — new (120 lines, 25 tests)

## Defense-in-depth rationale
CSP img-src is the primary defense (browser-level). Component-level validation adds a second layer covering :
- Compromised IdP returning attacker-controlled URLs
- Manual `user_metadata` tampering via Supabase client
- Future OAuth provider added without parallel CSP update
- Silent fallback to initials instead of triggering a rejected request

## Test plan
- [ ] CI green (vitest 1444+25 = 1469 / 0 / type-check / lint / build)
- [ ] Voie A : login OAuth GitHub → avatar still renders (existing allow-listed host)
- [ ] Voie A : test.student logged-in → fallback initials (no avatar URL, unchanged)
- [ ] Sourcery review traité si comments

## Refs
- THI-42 PR #1 (Profile Hub) — UserAvatar created
- THI-219 (CSP img-src) — parallel defense
- security-auditor M2 finding 2026-05-18 on PR #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)