### PR TITLE
security(auth): THI-221 — RequireAuth opt-in wrapper (preserve anonymous-friendly UX)

### DIFF
--- a/src/app/components/ProfilePage.tsx
+++ b/src/app/components/ProfilePage.tsx
@@ -24,6 +24,7 @@ import { ArrowLeft, Github, KeyRound, Mail, Monitor, Sliders } from 'lucide-reac
 
 import { useAuth } from '../context/AuthContext';
 import { useEnvironment, ENV_META } from '../context/EnvironmentContext';
+import { RequireAuth } from './auth/RequireAuth';
 import { UserAvatar } from './auth/UserAvatar';
 
 // OAuth provider label + icon — mirrors the subset of providers we currently
@@ -56,34 +57,30 @@ function ProviderBadge({ provider }: { provider: string | undefined }) {
 }
 
 export function ProfilePage() {
-  const { user, initialized } = useAuth();
+  return (
+    <RequireAuth
+      fallback={
+        <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
+          <p className="text-[var(--github-text-secondary)] text-sm font-mono">
+            Vous devez être connecté pour accéder à votre profil.{' '}
+            <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">
+              Retour à l&apos;accueil
+            </Link>
+          </p>
+        </main>
+      }
+    >
+      <ProfilePageContent />
+    </RequireAuth>
+  );
+}
+
+function ProfilePageContent() {
+  // RequireAuth above guarantees user is non-null and session is initialized.
+  const { user } = useAuth();
   const { selectedEnv } = useEnvironment();
 
-  // Wait for Supabase session resolution before deciding to show the
-  // "not authenticated" message — without this guard, a legitimate user
-  // sees the fallback flash for ~100-300ms while Supabase initialises
-  // (security-auditor H1 finding, THI-42 PR #1).
-  if (!initialized) {
-    return (
-      <main className="flex-1 flex items-center justify-center min-h-[40vh]" aria-busy="true">
-        <p className="text-[var(--github-text-secondary)] text-sm font-mono">Chargement…</p>
-      </main>
-    );
-  }
-
-  // Auth guard — render fallback (no redirect) when initialised but no user.
-  // `AuthProvider` does not redirect on guarded routes — each component
-  // owns its fallback. Centralised <RequireAuth> wrapper at Layout level
-  // tracked as security-auditor follow-up for PR #3.
-  if (!user) {
-    return (
-      <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
-        <p className="text-[var(--github-text-secondary)] text-sm font-mono">
-          Vous devez être connecté pour accéder à votre profil. <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">Retour à l&apos;accueil</Link>
-        </p>
-      </main>
-    );
-  }
+  if (!user) return null; // type-narrowing for TS — never reached at runtime
 
   const avatarUrl =
     (user.user_metadata?.avatar_url as string | undefined) ??

--- a/src/app/components/auth/RequireAuth.tsx
+++ b/src/app/components/auth/RequireAuth.tsx
@@ -1,0 +1,71 @@
+/**
+ * RequireAuth — THI-221 opt-in auth guard wrapper.
+ *
+ * Centralises the loading state + auth fallback pattern that ProfilePage
+ * carried inline (THI-42 PR #1 / security-auditor H1 fix). Used as an
+ * opt-in wrapper around components that require an authenticated user.
+ *
+ * Anonymous-friendly UX is preserved : Terminal Learning routes under
+ * /app/* are accessible to guests by default (local-only progression).
+ * RequireAuth is only applied to components that genuinely need a user
+ * context (ProfilePage, future teacher/admin dashboards in Phase 9).
+ *
+ * Pattern :
+ *   <RequireAuth>
+ *     <MyAuthGatedPage />
+ *   </RequireAuth>
+ *
+ * Optional `fallback` prop lets a caller override the default "Vous
+ * devez être connecté" message — useful for role-mismatch fallbacks
+ * (e.g. <RequireAuth fallback={<TeacherUpgradeCTA />}> in Phase 9).
+ */
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+
+import { useAuth } from '../../context/AuthContext';
+
+interface RequireAuthProps {
+  /** The component(s) to render once the user is authenticated. */
+  children: ReactNode;
+  /**
+   * Optional fallback rendered when initialised but no user. Defaults to a
+   * generic "must be logged in" message with a link to /.
+   * Must not contain unsanitised user input (callers building dynamic
+   * role-mismatch fallbacks in Phase 9 — sanitise upstream before passing).
+   */
+  fallback?: ReactNode;
+}
+
+export function RequireAuth({ children, fallback }: RequireAuthProps) {
+  const { user, initialized } = useAuth();
+
+  // Wait for Supabase session resolution before deciding to show the
+  // fallback. Without this guard a legitimate user sees the fallback
+  // flash for ~100-300ms while Supabase initialises (THI-42 H1 fix).
+  if (!initialized) {
+    return (
+      <main className="flex-1 flex items-center justify-center min-h-[40vh]" aria-busy="true">
+        <p className="text-[var(--github-text-secondary)] text-sm font-mono">Chargement…</p>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <>
+        {fallback ?? (
+          <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
+            <p className="text-[var(--github-text-secondary)] text-sm font-mono">
+              Vous devez être connecté pour accéder à cette page.{' '}
+              <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">
+                Retour à l&apos;accueil
+              </Link>
+            </p>
+          </main>
+        )}
+      </>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/test/requireAuth.test.tsx
+++ b/src/test/requireAuth.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for RequireAuth — THI-221 opt-in auth guard wrapper.
+ *
+ * Covers :
+ *  - loading state while session is initialising (no fallback flash)
+ *  - default fallback when initialised but no user
+ *  - custom fallback override prop
+ *  - children rendered only when user is authenticated AND session initialised
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+type AuthState = {
+  user: { email?: string } | null;
+  initialized: boolean;
+};
+
+const authState: AuthState = { user: null, initialized: true };
+
+vi.mock('../app/context/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user, initialized: authState.initialized }),
+}));
+
+import { RequireAuth } from '../app/components/auth/RequireAuth';
+
+function renderGuarded(children: React.ReactNode, fallback?: React.ReactNode) {
+  return render(
+    <MemoryRouter>
+      <RequireAuth fallback={fallback}>{children}</RequireAuth>
+    </MemoryRouter>
+  );
+}
+
+// Reset authState between tests to avoid order-dependent false positives.
+beforeEach(() => {
+  authState.user = null;
+  authState.initialized = true;
+});
+
+describe('RequireAuth — loading state', () => {
+  it('renders "Chargement…" while session is initialising and never shows fallback', () => {
+    authState.user = null;
+    authState.initialized = false;
+    renderGuarded(<p>Protected content</p>);
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+    expect(screen.queryByText(/vous devez être connecté/i)).not.toBeInTheDocument();
+  });
+
+  it('sets aria-busy on the loading container for assistive tech', () => {
+    authState.user = null;
+    authState.initialized = false;
+    const { container } = renderGuarded(<p>Protected content</p>);
+    const busy = container.querySelector('[aria-busy="true"]');
+    expect(busy).not.toBeNull();
+  });
+});
+
+describe('RequireAuth — fallback when unauthenticated', () => {
+  it('renders the default "Vous devez être connecté" fallback when no user', () => {
+    authState.user = null;
+    authState.initialized = true;
+    renderGuarded(<p>Protected content</p>);
+    expect(screen.getByText(/vous devez être connecté/i)).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+
+  it('default fallback links to / for return to home', () => {
+    authState.user = null;
+    authState.initialized = true;
+    renderGuarded(<p>Protected content</p>);
+    const link = screen.getByRole('link', { name: /retour à l'accueil/i });
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('uses custom fallback when provided', () => {
+    authState.user = null;
+    authState.initialized = true;
+    renderGuarded(<p>Protected content</p>, <p>Custom denied page</p>);
+    expect(screen.getByText('Custom denied page')).toBeInTheDocument();
+    expect(screen.queryByText(/vous devez être connecté/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+});
+
+describe('RequireAuth — authenticated render', () => {
+  it('renders children when user is present and session is initialised', () => {
+    authState.user = { email: 'auth@example.com' };
+    authState.initialized = true;
+    renderGuarded(<p>Protected content</p>);
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
+    expect(screen.queryByText(/vous devez être connecté/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Chargement…')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract ProfilePage inline auth guard into reusable `<RequireAuth>` wrapper
- OPT-IN by design — not Layout-level blanket wrap (preserves anonymous-friendly UX)
- Custom `fallback` prop for future role-mismatch UX (Phase 9 admin/teacher)
- 6 new tests in `requireAuth.test.tsx` + 35 existing tests (profilePage + userAvatar) unchanged

## Scope revision
Original ticket assumed homogeneous auth guard pattern across `/app/*` routes. Reconnaissance revealed only ProfilePage has the full pattern — Dashboard/LessonPage/AiSettings/CommandReference are anonymous-friendly by design. Revised scope : extract reusable wrapper (no Layout wrap that would break invité UX), use it in ProfilePage, ready for Phase 9 routes.

## Closes
Closes THI-221

## Files
- `src/app/components/auth/RequireAuth.tsx` — new (~75 lines)
- `src/app/components/ProfilePage.tsx` — refactored to `<RequireAuth fallback={...}><ProfilePageContent /></RequireAuth>`
- `src/test/requireAuth.test.tsx` — new (6 tests, beforeEach reset)

## security-auditor verdict
✅ APPROVE (score holds 9.2/10) — H1 race condition fix from THI-42 preserved, anonymous-friendly UX preserved, no new attack surface. 2 LOW findings applied :
- L1 : JSDoc note that custom fallback must not contain unsanitised user input
- L2 : `beforeEach` reset in tests to prevent order-dependent false positives

## Test plan
- [ ] CI green (vitest 1469+6 = 1475 / 0 / type-check / lint / build)
- [ ] Voie A : `/app/profile` logged-in → render OK (validates wrapper passes user through)
- [ ] Voie A : `/app/profile` logged-out → fallback "Vous devez être connecté pour accéder à votre profil" (custom message via fallback prop)
- [ ] Voie A : Dashboard / Reference / Settings logged-out → still accessible (anonymous-friendly UX preserved, no Layout-level wrap regression)

## Refs
- THI-42 PR #1 H1 race condition fix consolidated
- Phase 9 prep : pattern ready for role-gated routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)