### PR TITLE
feat(seo): THI-226 — enrich Schema.org Course + FAQ écoles/RGPD (Sprint 2.5 / S1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,20 @@
             "courseMode": "online",
             "courseWorkload": "PT3H"
           },
+          "numberOfLessons": 65,
+          "hasPart": [
+            { "@type": "Course", "name": "Navigation", "url": "https://terminallearning.dev/app/learn/navigation/orientation", "educationalLevel": "Beginner", "description": "Maîtrisez vos déplacements dans le système de fichiers (pwd, ls, cd)." },
+            { "@type": "Course", "name": "Fichiers & Dossiers", "url": "https://terminallearning.dev/app/learn/fichiers/mkdir", "educationalLevel": "Beginner", "description": "Créez, copiez, déplacez et supprimez fichiers et répertoires." },
+            { "@type": "Course", "name": "Lecture de fichiers", "url": "https://terminallearning.dev/app/learn/lecture/cat", "educationalLevel": "Beginner", "description": "Affichez, recherchez et analysez le contenu des fichiers." },
+            { "@type": "Course", "name": "Permissions", "url": "https://terminallearning.dev/app/learn/permissions/comprendre-permissions", "educationalLevel": "Intermediate", "description": "Contrôlez l'accès aux fichiers et répertoires (chmod, chown, sudo)." },
+            { "@type": "Course", "name": "Processus", "url": "https://terminallearning.dev/app/learn/processus/ps", "educationalLevel": "Intermediate", "description": "Gérez les programmes en cours d'exécution (ps, kill, top, jobs)." },
+            { "@type": "Course", "name": "Redirection & Pipes", "url": "https://terminallearning.dev/app/learn/redirection/redirection-sortie", "educationalLevel": "Intermediate", "description": "Chaînez les commandes et redirigez les flux de données (>, >>, |, tee)." },
+            { "@type": "Course", "name": "Variables & Scripts", "url": "https://terminallearning.dev/app/learn/variables/env-vars", "educationalLevel": "Advanced", "description": "Maîtrisez les variables d'environnement, les fichiers de config et l'automatisation." },
+            { "@type": "Course", "name": "Réseau & SSH", "url": "https://terminallearning.dev/app/learn/reseau/ping", "educationalLevel": "Advanced", "description": "Testez la connectivité, effectuez des requêtes HTTP et connectez-vous à des serveurs distants." },
+            { "@type": "Course", "name": "Git Fondamentaux", "url": "https://terminallearning.dev/app/learn/git/git-init", "educationalLevel": "Advanced", "description": "Maîtrisez le contrôle de version avec Git — l'outil indispensable de tout développeur professionnel." },
+            { "@type": "Course", "name": "GitHub & Collaboration", "url": "https://terminallearning.dev/app/learn/github-collaboration/git-remote", "educationalLevel": "Advanced", "description": "Synchronisez avec des dépôts distants, ouvrez des Pull Requests et collaborez comme en entreprise." },
+            { "@type": "Course", "name": "L'IA comme outil dev", "url": "https://terminallearning.dev/app/learn/ia-dev/ia-dev-intro", "educationalLevel": "Advanced", "description": "Maîtrisez l'IA comme amplificateur de vos compétences — du prompt au déploiement." }
+          ],
           "provider": {
             "@type": "Organization",
             "name": "Terminal Learning",
@@ -202,7 +216,7 @@
               "name": "Combien de commandes et de leçons sont disponibles ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Terminal Learning propose 64 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev."
+                "text": "Terminal Learning propose 65 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev. Plus de 27 commandes documentées avec syntaxe, exemples et variantes Linux/macOS/Windows."
               }
             },
             {
@@ -210,7 +224,7 @@
               "name": "Terminal Learning fonctionne-t-il sur mobile et tablette ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Oui. L'application est responsive et fonctionne dans n'importe quel navigateur moderne, sur desktop, tablette et mobile — sans installation requise."
+                "text": "Oui. L'application est responsive et fonctionne dans n'importe quel navigateur moderne, sur desktop, tablette et mobile — sans installation requise. Le simulateur terminal s'adapte aux écrans tactiles."
               }
             },
             {
@@ -219,6 +233,30 @@
               "acceptedAnswer": {
                 "@type": "Answer",
                 "text": "Le curriculum comporte 11 modules progressifs : Navigation, Fichiers & Dossiers, Lecture de fichiers, Permissions, Processus, Redirection & Pipes, Variables & Scripts, Réseau & SSH, Git Fondamentaux, GitHub & Collaboration, et L'IA comme outil dev. Chaque module débloque le suivant."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Terminal Learning est-il adapté aux enseignants et aux établissements scolaires ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Oui. Terminal Learning est conçu pour être utilisable en classe : ressource gratuite, sans inscription obligatoire pour les élèves, progression locale par navigateur, contenu pédagogique structuré niveau A1 à C1 (CEFR informatique). L'intégration LTI 1.3 est en cours de finalisation pour Moodle, Smartschool et les LMS standards (Phase 7c). Un Admin Panel pour le suivi enseignant est prévu pour juin 2026."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Les données des utilisateurs sont-elles protégées (RGPD) ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Oui. Terminal Learning respecte le RGPD européen. Aucune donnée personnelle n'est collectée par défaut — la progression est stockée localement dans votre navigateur. Si vous créez un compte (optionnel), seul votre email et un identifiant sont stockés sur Supabase EU-west-1 (Frankfurt). Aucun tracking publicitaire, aucun cookie tiers, aucune revente de données. Détails complets dans notre politique de confidentialité."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Terminal Learning restera-t-il gratuit à long terme ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Oui. Terminal Learning est un projet bénévole, open source (MIT), et restera 100 % gratuit pour les apprenants individuels. Si une édition Établissement payante est introduite à l'avenir pour financer le développement, elle ajoutera des fonctionnalités institutionnelles (suivi classe, intégration LMS avancée) sans jamais paywaller le contenu pédagogique de base."
               }
             }
           ]

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ Terminal Learning is a beginner-friendly educational web app built with React an
 - **License**: Open source (MIT)
 - **Stack**: Vite 6, React 18, TypeScript strict, Tailwind CSS v4, Supabase, Vercel
 
-## Curriculum (11 modules, 64 lessons)
+## Curriculum (11 modules, 65 lessons)
 
 ### Module 1 — Navigation
 `pwd`, `ls`, `ls -la`, `cd` — moving through the file system

--- a/src/test/seo.test.ts
+++ b/src/test/seo.test.ts
@@ -125,6 +125,48 @@ describe('SEO -- JSON-LD structured data (Schema.org)', () => {
     const app = g.find((n) => n['@type'] === 'SoftwareApplication');
     expect(app?.['isAccessibleForFree']).toBe(true);
   });
+
+  // THI-226 enrichissement Schema.org Course — empêche le drift du nombre de leçons
+  // et garantit que chaque module est listé comme sous-cours pour Google + LLM retrievals.
+  it('Course.numberOfLessons === 65 (anti-drift)', () => {
+    const g = extractJsonLd()['@graph'] as Array<Record<string, unknown>>;
+    const course = g.find((n) => n['@type'] === 'Course');
+    expect(course?.['numberOfLessons']).toBe(65);
+  });
+
+  it('Course.hasPart contient 11 modules avec URLs valides', () => {
+    const g = extractJsonLd()['@graph'] as Array<Record<string, unknown>>;
+    const course = g.find((n) => n['@type'] === 'Course');
+    const parts = course?.['hasPart'] as Array<Record<string, unknown>> | undefined;
+    expect(Array.isArray(parts)).toBe(true);
+    expect(parts).toHaveLength(11);
+    for (const part of parts!) {
+      expect(part['@type']).toBe('Course');
+      expect(typeof part['name']).toBe('string');
+      expect((part['url'] as string).startsWith('https://terminallearning.dev/app/learn/')).toBe(true);
+      expect(['Beginner', 'Intermediate', 'Advanced']).toContain(part['educationalLevel']);
+    }
+  });
+
+  it('FAQPage contient au moins 9 questions (cibles écoles + RGPD + gratuité)', () => {
+    const g = extractJsonLd()['@graph'] as Array<Record<string, unknown>>;
+    const faq = g.find((n) => n['@type'] === 'FAQPage');
+    const entities = faq?.['mainEntity'] as Array<Record<string, unknown>> | undefined;
+    expect(Array.isArray(entities)).toBe(true);
+    expect(entities!.length).toBeGreaterThanOrEqual(9);
+    // School-targeted question must be present
+    const schoolQ = entities!.find((q) => /enseignants|établissements|école/i.test(q['name'] as string));
+    expect(schoolQ).toBeDefined();
+    // RGPD question must be present
+    const rgpdQ = entities!.find((q) => /RGPD|données|confidentialité/i.test(q['name'] as string));
+    expect(rgpdQ).toBeDefined();
+  });
+
+  it('Aucune référence orpheline "64 leçons" (anti-drift documentaire)', () => {
+    const html = readHtml();
+    expect(html).not.toContain('64 leçons');
+    expect(html).not.toContain('64 lessons');
+  });
 });
 
 // -- GEO ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Enrich existing Schema.org `Course` JSON-LD with `numberOfLessons: 65` + `hasPart` array (11 sub-Course entries with URLs + educationalLevel)
- Extend `FAQPage` from 6 → 9 questions targeting B2B schools / RGPD / long-term gratuité
- Fix documentary drift `64 → 65 leçons` in `index.html` FAQ + `public/llms.txt`
- 4 new anti-drift tests in `seo.test.ts` (68 total passing)

## Closes
Part of THI-226 umbrella (SEO/GEO/AEO Sprint 2.5 foundation). No closing — umbrella stays open until full S5.

## Files
- `index.html` — Course schema enriched + FAQPage 3 new Q&A
- `public/llms.txt` — 1-line drift fix
- `src/test/seo.test.ts` — 4 new test cases

## Test plan
- [x] vitest seo.test.ts 68/68 passing locally
- [x] type-check + lint clean
- [ ] CI green
- [ ] Voie A : Chrome MCP preview Vercel — vérifier que rich result test Google passe (https://search.google.com/test/rich-results)
- [ ] No regression Lighthouse Landing SEO 100/100 (baseline `docs/perf-baseline-2026-05-18.md`)

## SEO impact attendu (post-indexation 2-4 semaines)
- Featured snippets potentiels sur 3 questions B2B/RGPD/gratuité
- LLM citations enrichies (Perplexity/Claude Search verront `hasPart` array → meilleur retrieval)
- Course rich result eligibility (Google Search Console)

## Refs
- Spike Vercel Analytics : `docs/spike-vercel-analytics-2026-05-18.md` (PR2 docs)
- Perf baseline : `docs/perf-baseline-2026-05-18.md` (PR2 docs)
- Phase 9 umbrella : THI-225 (parallel track)
- Agent challenge 18/05 recommandait sequencing JSON-LD avant programmatic SEO

🤖 Generated with [Claude Code](https://claude.com/claude-code)