### PR TITLE
docs: Sprint 2.5 / S1 setup — sas 48h drop + perf baseline + spike Vercel + marketing kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ pnpm-debug.log*
 .claude/screenshots/
 .claude-screenshots/
 
+# Lighthouse raw JSON traces — too heavy (~500KB-1MB each). Summary in markdown
+# docs/perf-baseline-*.md instead. Re-run via commands in baseline.md if needed.
+docs/perf-history/*.json
+!docs/perf-history/.gitkeep
+
 # Supabase CLI temp files
 supabase/.temp/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,13 +214,10 @@ Toute PR DOIT être validée visuellement avant merge, SAUF exception explicite 
   4. **Pattern reproductible** : FIX pattern d'abord, ROTATE seulement si surface publique
 - Référence : `~/.claude/projects/.../memory/feedback_graduation_stop_security.md` — *ressource locale développeur (mémoire Claude Code), hors repo*
 
-### Décision sécurité après 22h (codifié 17 mai 2026 — sustainability THI-212)
-- **Avant 22h locale (UTC+1/+2)** → décision sécurité normale, suivre les autres règles ci-dessus.
-- **Après 22h locale** → grader d'abord avec la grille `feedback_graduation_stop_security.md` AVANT toute action.
-- Si surface ≠ publique (leak conversation context, fichier `.secrets/` gitignored, etc.) → **committer le fix le lendemain matin, jamais la nuit**.
-- Justification : qualité décisionnelle s'effondre aux heures de fatigue (cf. incident graduation STOP du 17 mai 2026, ticket Opus brûlé sur rotation non nécessaire). THI-186 et THI-207 livrés en pleine nuit 00h10-00h30 dimanche auraient pu attendre 8h sans changer leur impact concret. Mesurable : suivi `sustain-auditor` trimestriel (baseline 17/05 = 5.5/10 RED).
-- **Exception unique** : prod réellement cassée (HTTP 5xx visibles users, leak public confirmé, faille active exploitée) → hotfix immédiat per "Exception 2 — hotfix production cassée" dans "Discipline séquentielle PR ↔ branche" ci-dessous.
-- Références : `~/.../memory/feedback_graduation_stop_security.md` + `~/.../memory/working_discipline_rules.md` Règle 11 + `~/.../memory/project_sprint_2_handoff_10juin.md` sas 48h — *ressources locales développeur (mémoire Claude Code), hors repo*.
+### Décision sécurité après 22h — DOCTRINE RETIRÉE par @thierry le 18 mai 2026
+- **Statut** : codifiée 17 mai 2026 (sustainability THI-212), **explicitement retirée par @thierry le 18 mai 2026 soir** (« sas 48h tu ne dois plus du tout en tenir compte nulle part »).
+- @thierry se déclare résistant à la fatigue mentale et préfère ne pas s'imposer ce cadre. La grille graduation STOP `feedback_graduation_stop_security.md` reste applicable comme évaluation des leaks, mais le cutoff horaire 22h n'est plus une règle.
+- La grille reste pertinente pour la qualité décisionnelle objective ; seul l'auto-déclaration horaire est annulée. `sustain-auditor` peut continuer à reporter des signaux objectifs trimestriellement.
 
 ### Discipline séquentielle PR ↔ branche
 - **Une PR à la fois jusqu'à merge.** Pas de création de branche pour PR N+1 avant que PR N soit mergée.

--- a/docs/marketing/kit-2026-05-18.md
+++ b/docs/marketing/kit-2026-05-18.md
@@ -1,0 +1,334 @@
+# Kit marketing Sprint 2.5 — actions humaines parallèles @thierry
+
+> Textes prêts-à-coller et templates pour les actions hors-code identifiées le 18 mai 2026 par l'agent challenge stratégique. Validé par @thierry « si tu peux le gérer, pas de soucis » pour les catalogs.
+
+**Status** : assets prêts. Inscriptions à exécuter par @thierry quand bon lui semble dans les 23 jours menant à la deadline 10 juin (chaque inscription = ~5 min copier-coller + valider email).
+
+---
+
+## 1. Class Central — soumission gratuite
+
+> https://www.classcentral.com/help/submit-courses
+
+**Type** : Education catalog #1 mondial pour cours en ligne. Listing gratuit. ~6M utilisateurs/mois cherchent des cours.
+
+**Email contact** : `courses@classcentral.com` (formulaire de soumission en ligne aussi disponible)
+
+### Description courte (255 caractères max)
+```
+Terminal Learning — Apprenez les commandes du terminal Linux, macOS et Windows dans un émulateur interactif. 11 modules progressifs, 65 leçons, 27+ commandes documentées. 100% gratuit, open source, sans inscription requise.
+```
+
+### Description longue (catalog detail page)
+```
+Terminal Learning est une plateforme pédagogique gratuite et open source pour apprendre les commandes du terminal Unix-like (Linux, macOS) et Windows (PowerShell). 
+
+Conçue pour les débutants, elle propose 11 modules progressifs couvrant la navigation, la gestion de fichiers, les permissions, les processus, la redirection, les variables, le réseau, SSH, Git, GitHub et l'utilisation de l'IA comme outil de développement.
+
+Chaque leçon inclut un émulateur terminal interactif qui valide les commandes saisies en temps réel. La progression est sauvegardée localement dans le navigateur — aucune inscription n'est requise pour commencer. Un compte optionnel (GitHub ou Google) permet de synchroniser la progression entre plusieurs appareils.
+
+100% gratuit à vie, sans publicité, sans tracking. Open source sous licence MIT. Disponible en français, accessible WCAG 2.2 AAA, fonctionne sur desktop, tablette et mobile.
+
+Conçu pour les apprenants autodidactes, les enseignants, les centres de formation et les écoles d'ingénieurs.
+```
+
+### Métadonnées
+- **Niveau** : Débutant à Intermédiaire
+- **Langue** : Français
+- **Durée** : ~3 heures (workload)
+- **Sujets** : Linux, Bash, Shell, DevOps, Système d'exploitation, Git, GitHub, IA pour développeurs
+- **Lien direct** : https://terminallearning.dev
+- **Lien GitHub** : https://github.com/thierryvm/TerminalLearning
+- **Auteur** : Thierry Vanmeeteren
+- **Tarif** : Gratuit (Free)
+- **Certificat** : Non (pas encore — peut-être Open Badges 3.0 en Phase 10+)
+
+---
+
+## 2. OER Commons — Open Educational Resources
+
+> https://www.oercommons.org/contribute
+
+**Type** : Catalog académique pour ressources éducatives ouvertes. Très utilisé par enseignants universitaires US + EU.
+
+**Email contact** : Formulaire web "Contribute" + connexion via compte gratuit
+
+### Métadonnées (mêmes que Class Central + ajustements)
+- **License** : CC-BY-SA-4.0 (ou MIT pour le code) — préciser MIT pour le code, et "Free to use educationally" pour le contenu pédagogique
+- **Educational Level** : Higher Education, Vocational Training, Adult Education
+- **Material Type** : Interactive Resource, Software, Tutorial
+- **Subject** : Computer Science, Software Engineering, Information Technology
+- **Language** : French
+- **Accessibility** : WCAG 2.2 AAA conformant
+
+### Description (catalog)
+```
+Terminal Learning is a free, open-source interactive web platform teaching command-line skills for Linux, macOS, and Windows. It features 11 progressive modules (65 lessons) covering navigation, file management, permissions, processes, redirection, variables, networking, SSH, Git, GitHub, and AI as a developer tool. 
+
+A built-in terminal emulator validates user commands in real-time. No installation or account required to start learning — progress is saved locally in the browser. Optional account (GitHub or Google) syncs progress across devices.
+
+Free forever, MIT licensed, no ads, no tracking, GDPR-compliant. French interface, suitable for self-learners, teachers, vocational schools, and higher education courses introducing Unix/Linux/DevOps basics.
+```
+
+---
+
+## 3. MERLOT II — Multimedia Educational Resource for Learning and Online Teaching
+
+> https://www.merlot.org
+
+**Type** : Catalog universitaire US (California State University network). Pour visibilité dans Higher Education US/global.
+
+**Compte** : Création gratuite, puis "Add Material" → fill form
+
+### Métadonnées
+- **Material Type** : Tutorial, Drill and Practice, Online Course Module
+- **Primary Audience** : Undergraduate, Graduate, Adult Learners, Workforce
+- **Discipline** : Computer Science / Operating Systems / Computer Networks
+- **Language** : French (Note : MERLOT accepte les ressources non-anglophones, mais visibility US réduite)
+- **Description** : même que OER Commons
+
+**Note stratégique** : MERLOT a moins de trafic FR/EU que les autres. À faire en dernier si bande passante limitée. Class Central + OER Commons = priorité.
+
+---
+
+## 4. Awesome Lists GitHub — PRs ciblées
+
+> Ces PRs sont des contributions à des listes "Awesome" populaires. Format : ajouter une ligne avec lien + description courte. Conventions : ordre alphabétique strict, description sans "the" et sans publicité, image optionnelle.
+
+### Listes à viser (par ordre d'impact)
+
+#### a. `awesome-cli-apps` (>16k stars)
+> https://github.com/agarrharr/awesome-cli-apps
+
+Section : `Learning Tools` ou `Tutorials`
+```markdown
+- [Terminal Learning](https://terminallearning.dev) - Interactive web app to learn command-line basics for Linux, macOS, and Windows. 11 modules, 65 lessons, real terminal emulator. Free and open source.
+```
+
+#### b. `awesome-shell` (~30k stars)
+> https://github.com/alebcay/awesome-shell
+
+Section : `Learning Resources` ou `Beginner-friendly`
+```markdown
+- [Terminal Learning](https://terminallearning.dev) - Free interactive platform teaching shell commands progressively. No installation; learn directly in browser. Supports Linux, macOS, and Windows shells.
+```
+
+#### c. `awesome-learn-by-doing`
+> https://github.com/exajobs/awesome-learn-by-doing
+
+Section : Command-line / DevOps
+```markdown
+- [Terminal Learning](https://terminallearning.dev) - Interactive command-line tutorial with built-in terminal emulator. 65 lessons across 11 modules. Free, open source, GDPR-compliant.
+```
+
+#### d. `awesome-free-for-dev`
+> https://github.com/ripienaar/free-for-dev
+
+Section : `Tutorials` ou `Documentation as a Service`
+```markdown
+- [Terminal Learning](https://terminallearning.dev) - Free interactive learning platform for terminal commands (Linux, macOS, Windows). MIT licensed.
+```
+
+**Workflow** :
+1. Fork la repo Awesome list correspondante
+2. Edit le `README.md` directement sur GitHub web (ajouter la ligne dans la bonne section, ordre alphabétique)
+3. Commit avec message `Add Terminal Learning to <section>`
+4. Open PR avec body court : "Adding Terminal Learning - free open-source interactive platform for learning shell/terminal commands. MIT licensed, no signup required."
+5. Si rejeté → polite reply demandant les critères manqués
+
+---
+
+## 5. Templates posts Instagram @terminallearning
+
+> Compte Instagram déjà existant : https://www.instagram.com/terminallearning/. Niche dev/débutants Linux. Style pédagogique + un peu d'humour, accessible.
+
+### Template post #1 — Annonce hat-trick sécurité 18/05 (timing immédiat)
+
+**Visual** : carrousel 3 slides (1080×1350, 4:5 portrait), style identité visuelle TL (fond #0d1117, vert accent #3ddc84, JetBrains Mono pour code, Inter pour titres)
+
+**Slide 1 (cover)** :
+```
+🔒 4 PRs sécurité
+en moins de 3 heures
+
+Schema.org enrichi
+CSP renforcée
+Avatar validation
+RequireAuth wrapper
+
+→ Score 9.2/10
+```
+
+**Slide 2 (méthode)** :
+```
+La discipline scope-revision
+
+→ Reconnaissance avant code
+→ 1 PR à la fois
+→ security-auditor obligatoire
+→ Voie A Chrome MCP
+
+Mode invité préservé ✅
+0 régression ✅
+```
+
+**Slide 3 (CTA)** :
+```
+Apprends comme on construit :
+en sécurité, en transparence.
+
+terminallearning.dev
+github.com/thierryvm/TerminalLearning
+```
+
+**Caption** (sous le carrousel) :
+```
+Sprint 2 essentiellement clos en avance. Ce week-end on a livré 4 PRs sécurité en mode chirurgical : Schema.org enrichissement, CSP allow-list googleusercontent stricte (lh1-lh6), avatar URL validation defense-in-depth, et RequireAuth wrapper opt-in qui préserve l'UX invité de Terminal Learning.
+
+Pourquoi je raconte ça ? Parce que la cybersécurité dans les apps éducatives, c'est aussi pédagogique. Mes utilisateurs (étudiants, enseignants) méritent une plateforme audit-grade.
+
+🤖 Co-construit avec Claude (Anthropic)
+🛡️ Score sécurité 9.2/10 stable
+🎓 1475 tests verts
+
+#OpenSource #Cybersecurite #Devops #Linux #ApprendreLeTerminal #EdTech #FrenchTech #BelgianTech #IndieHacker #SoloDeveloper #PassionProject
+```
+
+### Template post #2 — Annonce SEO/GEO upgrade (post-merge PR #260)
+
+**Visual** : carrousel 3 slides
+
+**Slide 1** :
+```
+🚀 Schema.org enrichi
+
+11 modules → hasPart array
+65 leçons → numberOfLessons
+6 → 9 FAQ (écoles, RGPD)
+
+Pour Google, Perplexity, ChatGPT Search.
+```
+
+**Slide 2** :
+```
+Pourquoi c'est important :
+
+Les LLM utilisent Schema.org
+pour citer des sources fiables.
+
+Plus de structure = plus de visibilité
+quand quelqu'un demande à l'IA :
+"comment apprendre le terminal ?"
+```
+
+**Slide 3** :
+```
+Le SEO 2026 n'est plus juste
+pour Google.
+
+C'est pour toutes les IA
+qui répondent à tes questions.
+
+terminallearning.dev
+```
+
+**Caption** :
+```
+Mise à jour SEO/GEO ce soir. Enrichissement Schema.org pour que Google, mais aussi Perplexity, ChatGPT Search et Claude Search, comprennent mieux ce qu'est Terminal Learning : 11 modules, 65 leçons, gratuit, open source.
+
+GEO (Generative Engine Optimization) c'est le nouveau SEO. <0.5% des sites ont un llms.txt aujourd'hui. Terminal Learning l'a.
+
+Concrètement : si tu demandes à une IA "où apprendre le terminal gratuitement ?", elle a maintenant tout ce qu'il faut pour répondre Terminal Learning avec précision.
+
+#SEO #GEO #SchemaOrg #LLM #AISearch #OpenSource #EdTech #DevTools #BelgianTech
+```
+
+### Template post #3 — Annonce admin panel (post-Phase 9 v1 livraison)
+
+À adapter après livraison effective Phase 9 v1.
+
+---
+
+## 6. Templates posts LinkedIn @thierry-vanmeeteren
+
+> Profil : https://www.linkedin.com/in/thierry-vanmeeteren-bb202a113/. Ton plus formel + storytelling + audience pro.
+
+### Template #1 — Sprint 2.5 récap (post-deadline ou mid-sprint)
+
+```
+Trois semaines pour préparer Terminal Learning à entrer dans les écoles et centres de formation. Voici comment j'ai abordé le sprint.
+
+🎯 Cible : 10 juin 2026 — démo pour pilotes B2B éducation
+
+📊 Axes stratégiques équilibrés :
+• SEO/GEO/AEO — pour que les enseignants nous trouvent
+• Admin Panel — pour la crédibilité de la démo
+• Sécurité hardening — pour signer les écoles (RGPD critique)
+
+🛠 Méthode :
+• 1 PR à la fois, scope chirurgical
+• security-auditor obligatoire sur chaque modif RBAC
+• Voie A Chrome MCP validation visuelle iPhone + desktop avant merge
+• Tests : 1475 → cible 1500+ post-sprint
+
+🤖 Co-construit avec Claude (Anthropic) en mode trio orchestrateur :
+• @cowork pour les décisions architecturales
+• @cc-tl pour l'exécution code + audits cascade
+• Moi pour la stratégie produit, la cible business et les validations métier
+
+100% gratuit, open source, MIT.
+0€ de budget infra (Vercel Hobby + Supabase Free + Sentry open-source).
+
+Si vous êtes enseignant en informatique, IUT, école d'ingénieurs, lycée pro… je cherche 1-2 enseignants pilotes pour septembre 2026. DM ouverts.
+
+#EdTech #OpenSource #Cybersecurite #SoloFounder #BelgianTech #IndieHacker #DevTools #Education
+```
+
+### Template #2 — Story personnelle (à publier 1× par mois)
+
+```
+J'ai 47 ans (à adapter par @thierry), autodidacte, et j'ai mis 30 ans à comprendre que je n'étais pas "pas capable de coder".
+
+J'ai commencé une dizaine de projets dans ma vie. Aucun terminé. À chaque abandon, la même petite voix : "tu vois, je te l'avais dit."
+
+Terminal Learning est mon premier projet terminé.
+
+Il est gratuit. Open source. Construit avec une IA (Claude) parce que coder en solo après 5 ans de maladie chronique, c'est mathématiquement impossible sans aide.
+
+Aujourd'hui : 1475 tests verts, score sécurité 9.2/10, 11 modules pédagogiques live en production, et l'objectif d'entrer dans les écoles en septembre.
+
+L'IA ne remplace pas. Elle augmente.
+
+terminallearning.dev
+
+#Autodidacte #IA #ProjetPerso #SantéMentale #Resilience #OpenSource #BelgianTech
+```
+
+---
+
+## 7. Récap priorisé des actions @thierry (par bandwidth/effort)
+
+| Action | Effort | Priorité | Quand |
+|---|---|---|---|
+| Post Instagram #1 (hat-trick sécu 18/05) | 30 min (creating visuel) | 🔥 High | Cette semaine — momentum frais |
+| Post LinkedIn #1 (sprint récap) | 15 min | 🔥 High | Cette semaine ou mi-sprint |
+| Submit Class Central | 5 min | 🟢 Med | À tout moment, validation peut prendre 1-2 semaines |
+| Submit OER Commons | 5 min + création compte | 🟢 Med | À tout moment |
+| PRs Awesome lists (4 listes) | 5-10 min par liste | 🟢 Med | Étaler sur 1 semaine |
+| Submit MERLOT | 10 min + création compte | 🔵 Low | Bandwidth permettant |
+| Post Instagram #2 (SEO/GEO post-merge #260) | 30 min | 🟢 Med | Après merge PR #260 |
+| Post LinkedIn #2 (story perso) | 15 min | 🔵 Low | 1× par mois max |
+| Demo video Loom 90s | 1-2h (apprentissage Loom + script + recording) | 🔵 Low — différé | Post-MVP Phase 9 v1 livré (sinon vidéo obsolète) |
+| Identifier enseignant pilote | Variable | 🔵 Low — réseau IG/LI | Via templates LinkedIn post + DM |
+
+**Mon avis orchestrateur** : commence par les 2 posts cette semaine (highest impact / lowest effort, momentum visible). Les catalogs peuvent attendre — leur indexation prend semaines de toute façon, donc autant les faire quand bande passante émotionnelle est là.
+
+---
+
+## Refs
+
+- Strategy plan : `memory/project_session_18may_2026_thi42_security_hattrick.md`
+- Agent challenge : recommandait 7 actions humaines parallèles → ce kit en couvre 5/7 (demo video et `.be` domain hors scope)
+- Profile IG : https://www.instagram.com/terminallearning/
+- Profile LinkedIn : https://www.linkedin.com/in/thierry-vanmeeteren-bb202a113/
+- Skill playbook : `[[social-carousel-publication]]` (Obsidian) — gotchas catbox.moe + oklch → hex pour html2canvas

--- a/docs/perf-baseline-2026-05-18.md
+++ b/docs/perf-baseline-2026-05-18.md
@@ -1,0 +1,87 @@
+# Performance Baseline — 18 mai 2026
+
+> Snapshot Lighthouse 12.6.1 + headless Chrome sur `https://terminallearning.dev` en production. Capturé en début de Sprint 2.5 (SEO/GEO + Phase 9 Admin Panel) pour mesurer objectivement les gains des sprints à venir. **Toute PR future touchant la performance doit comparer ses scores à cette baseline** — anti-régression mesurable.
+
+**Configuration** :
+- Lighthouse `12.6.1` (npm global)
+- Chrome headless `--headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage`
+- Throttling : Lighthouse default (Slow 4G simulated, CPU 4× slowdown)
+- Field data CrUX : non disponible publiquement à cette date (sera ajouté via Vercel Speed Insights export)
+- JSON brut : `docs/perf-history/2026-05-18-*-prod.json`
+
+## Résumé exécutif
+
+| Route | Perf | A11y | BP | SEO | LCP | FCP | CLS | TBT | Speed Index |
+|---|---|---|---|---|---|---|---|---|---|
+| `/` Landing | **91** | **100** | **100** | **100** | 2935ms ⚠️ | 2560ms | 0.001 ✅ | 93ms ✅ | 2560ms |
+| `/app` Dashboard | **92** | **100** | **100** | **100** | 2866ms ⚠️ | n/a | n/a | 72ms ✅ | n/a |
+| `/changelog` | **74** ⚠️ | **100** | **100** | **92** ⚠️ | 3013ms ⚠️ | n/a | n/a | **701ms** 🔴 | n/a |
+
+## Lecture
+
+### ✅ Points forts (à préserver, anti-régression critique)
+
+- **Accessibilité 100/100** sur toutes les routes auditées — score parfait, témoignage de la doctrine WCAG 2.2 AAA appliquée depuis Phase 4c et le sprint mobile recovery THI-152
+- **Best Practices 100/100** Landing + /app + /changelog — CSP, HTTPS, secure cookies, no mixed content : tout est carré
+- **SEO 100/100** Landing + /app — sitemap.xml + robots.txt + Schema.org WebSite + Helmet meta complets. `/changelog` à 92 (probablement meta description manquante sur la page markdown, à corriger en Sprint 1.5 Helmet uniformisé)
+- **CLS 0.001** Landing — quasi parfait, layout stable au paint (THI-118 fix LCP a aussi blindé le CLS)
+- **TBT < 100ms** sur Landing + /app — JavaScript bloquant maîtrisé (gain net post-Sprint Mobile Recovery THI-152 + Bundle optimization THI-87)
+
+### ⚠️ Points d'attention (zones de gains visibles)
+
+- **LCP 2.9-3.0s sur toutes les routes** : zone "needs improvement" (seuil "good" Google = 2.5s). Le LCP synthétique Lighthouse simule Slow 4G — le LCP réel CrUX en field data est probablement meilleur (THI-118 avait confirmé 332ms field data après le fix Sprint 2 étape 1/N). À monitorer après pre-render Vite (Sprint 4).
+- **`/changelog` Performance 74/100 et TBT 701ms 🔴** : confirme l'hypothèse que `react-markdown` parsing client-side bloque le main thread sur les longs fichiers markdown (CHANGELOG.md = ~80kB de markdown rendu au runtime). Cible Sprint 4 : pre-render au build → main thread libre, LCP gain ~1s estimé.
+- **`/changelog` SEO 92/100** : meta description ou structured data manquante. Sera fixé Sprint 1 task 5 (Schema.org + FAQPage) + Sprint 1 task 6 (Helmet uniformisé THI-222).
+
+## Cibles Sprint 2.5 (gains attendus, à valider sur cette baseline)
+
+| Métrique | Baseline 18/05 | Cible post-Sprint 2.5 | Levier |
+|---|---|---|---|
+| Landing Perf | 91 | **≥ 95** | Pre-render Vite (Sprint 4) supprime l'attente JS pour Googlebot |
+| Landing LCP | 2935ms | **≤ 2200ms** | Pre-render = HTML statique servi direct, render bloquant supprimé |
+| /changelog Perf | 74 | **≥ 90** | Pre-render markdown au build |
+| /changelog TBT | 701ms | **≤ 200ms** | Markdown parse moved to build-time |
+| /changelog SEO | 92 | **100** | Helmet meta description + Schema.org |
+| **Nouveau** : `/admin` Perf | n/a | **≥ 90** | À mesurer après Phase 9 skeleton (Sprint 2) |
+| **Nouveau** : `/commandes/<cmd>` × 27 pages | n/a | **≥ 95** | Pre-rendered au build, contenu statique |
+
+## Comparaison historique (référence anti-régression)
+
+| Date | Source | Note |
+|---|---|---|
+| 2026-04-14 | Sentry weekly | Landing LCP **9.31s** 🔴 (poor zone, régression post-shadcn migration) |
+| 2026-04-16 | THI-118 fix livré | Field data prod LCP **332ms** ✅ |
+| 2026-05-16 | Sprint 2 étape 1/N | Lighthouse confirmait gain Sprint 1 |
+| **2026-05-18** | **Cette baseline** | **Landing 2935ms synth / 91 Perf, /changelog 3013ms / 74 Perf** |
+
+**Procédure anti-régression** : après chaque PR touchant `Landing.tsx`, `routes.ts`, `vercel.json`, `index.html`, `MarkdownPage.tsx`, `vite.config.ts`, ou un import lourd sur Landing chunk → re-run Lighthouse sur les 3 routes auditées + comparer aux scores ci-dessus. **Tolérance** : -2 points Perf max. Au-delà → bloquer le merge et investiguer.
+
+## Annexe — commandes de reproduction
+
+```bash
+# Landing
+npx lighthouse https://terminallearning.dev/ \
+  --only-categories=performance,accessibility,best-practices,seo \
+  --output=json \
+  --output-path=docs/perf-history/2026-05-18-landing-prod.json \
+  --chrome-flags="--headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage" \
+  --quiet
+
+# Dashboard
+npx lighthouse https://terminallearning.dev/app \
+  --only-categories=performance,accessibility,best-practices,seo \
+  --output=json \
+  --output-path=docs/perf-history/2026-05-18-app-prod.json \
+  --chrome-flags="--headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage" \
+  --quiet
+
+# Changelog
+npx lighthouse https://terminallearning.dev/changelog \
+  --only-categories=performance,accessibility,best-practices,seo \
+  --output=json \
+  --output-path=docs/perf-history/2026-05-18-changelog-prod.json \
+  --chrome-flags="--headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage" \
+  --quiet
+```
+
+> **Note Lighthouse flags** : le `--headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage` combo est OBLIGATOIRE sur Windows + Node 24 — sans ces flags, `NO_NAVSTART` error sur ~50% des runs.

--- a/docs/perf-history/.gitkeep
+++ b/docs/perf-history/.gitkeep
@@ -1,0 +1,3 @@
+# Lighthouse raw JSON traces are gitignored (too heavy ~500KB-1MB each).
+# Re-run via commands in `docs/perf-baseline-2026-05-18.md` if comparison needed.
+# Only summary markdown files (perf-baseline-*.md, perf-history.md) are committed.

--- a/docs/spike-vercel-analytics-2026-05-18.md
+++ b/docs/spike-vercel-analytics-2026-05-18.md
@@ -1,0 +1,83 @@
+# Spike — Vercel Analytics API access for custom admin dashboard
+
+**Date** : 18 mai 2026 · **Durée** : 30 min · **Sprint 2.5 / S1 task 3**
+
+## Question
+
+Phase 9 Admin Panel (deadline 10 juin) doit afficher des widgets analytics dans un dashboard custom (`/admin` route). Vercel expose-t-il une API REST publique pour récupérer Web Analytics data (page views, top pages, referrers, countries) **côté budget 0€ (Hobby plan)** ?
+
+## Findings
+
+### 1. Pas d'API REST publique Web Analytics direct
+
+Vercel Web Analytics (`/docs/analytics`) n'expose **aucun endpoint REST direct** pour fetch les page views ou top pages. Le seul mécanisme officiel pour accéder à la data programmatiquement est **Drains**.
+
+### 2. Vercel Drains — Pro plan obligatoire ($20/mois)
+
+Source : https://vercel.com/docs/drains#usage-and-pricing (last_updated 2026-03-04)
+
+> "Drains are available to all users on the Pro and Enterprise plans. If you are on the Hobby or Pro Trial plan, you'll need to upgrade to Pro to access drains."
+
+Pricing additionnel : **$0.50 / volume drained** (probablement par GB ou par 1M events selon le contexte — à confirmer si on bascule Pro).
+
+**Flow Drains** : Vercel push event JSON/NDJSON vers endpoint custom HTTPS → on stocke en Supabase → on agrège pour dashboard `/admin`. Schema riche (`vercel.analytics.v2`) : eventType, path, route, country, region, city, OS, browser, deviceType, etc.
+
+### 3. CSV export manuel — limite 250 entries
+
+Source : https://vercel.com/docs/analytics
+
+> "You can export up to 250 entries from the panel as a CSV file."
+
+Manuel, pas adapté à un dashboard live.
+
+### 4. Speed Insights — même contrainte
+
+Speed Insights data accessible aussi via Drains uniquement (`/docs/drains/reference/speed-insights`). Pro plan required.
+
+## Décision — Phase 9 v1 scope révisé pour budget 0€
+
+| Option | Coût | Effort | MVP-ready pour 10 juin ? |
+|---|---|---|---|
+| A. Upgrade Pro Vercel + activer Drains + Supabase store + custom widget | **$20/mois** | 3-4j | ✅ Oui mais hors budget bénévole |
+| B. Embed iframe Vercel dashboard public | 0€ | 30 min | ⚠️ Possible mais auth issues iframe à valider |
+| C. Self-hosted Umami / Plausible | 0€ infra VPS gratuit | 2-3j + maintenance | ⚠️ Réinvente Vercel Analytics |
+| D. Tracking custom event → POST → Supabase | 0€ | 2j + privacy/RGPD à valider | ⚠️ Réinvente Vercel Analytics |
+| **E. Différer analytics intégration → Phase 9 v2 post-deadline** | **0€** | **0** | **✅ Recommandé MVP** |
+
+### Plan révisé Phase 9 v1 (recommandation orchestrateur)
+
+**MVP 10 juin** — widgets disponibles gratuitement et déjà en place :
+
+1. **Supabase health widget** : nb users actifs last 7d, nb lessons completed last 30d, top modules (data déjà dans table `progress` via Supabase REST + RLS service_role read côté admin)
+2. **Sentry events widget** : last 24h errors / warnings (Sentry API gratuit pour les projets open-source, free tier 5K events/mois suffit)
+3. **Application health** : status RLS policies, RPC calls réussis vs erreur, Supabase Auth events count (via supabase-js admin query)
+4. **Vercel dashboard link** (placeholder élégant) : bouton "Voir analytics détaillées sur Vercel" → ouvre `https://vercel.com/thierry-vanmeeterens-projects/terminal-learning/analytics` (les admins TL ont accès, les autres voient un message "Analytics avancées disponibles avec l'édition Établissement")
+5. **THI-77 student heatmap** : data dans Supabase `progress` table, agrégat per day, palette emerald (GitHub-style)
+
+**v2 post-deadline 10 juin** (si écoles paient ou si revenus permettent) :
+- Upgrade Pro Vercel ($20/mois)
+- Endpoint `api/drains/analytics` reçoit Vercel events
+- Table Supabase `analytics_events` (RLS read super_admin only)
+- Agrégats temps réel dans dashboard `/admin/analytics`
+- Migration progressive du placeholder link vers widget natif
+
+### Implications stratégiques
+
+- **Budget 0€ tenu** : la deadline 10 juin reste atteignable
+- **Crédibilité écoles préservée** : Supabase health + Sentry + Vercel link suffisent pour démontrer "plateforme monitorée". Les écoles veulent voir qu'il y a une supervision, pas forcément un dashboard avec 50 KPIs custom
+- **Path d'upgrade clair** : si une école paye à un moment donné, Pro Vercel s'auto-finance instantanément ($20/mois < prix d'une école payante)
+- **Pas de scope creep** : Phase 9 v1 reste à 3-5j effort réalisable, v2 reportée proprement
+
+## Actions immédiates Sprint 1
+
+- ✅ Spike documenté (ce fichier)
+- ⏭️ Mettre à jour issue umbrella Phase 9 Linear avec scope révisé (task 4 Sprint 1)
+- ⏭️ Pas de Drains setup ce Sprint 2.5 — différé Phase 9 v2 post-deadline
+- ⏭️ Vérifier accès Sentry API REST pour widget v1 (task à programmer Sprint 3)
+
+## Références
+
+- Drains overview : https://vercel.com/docs/drains
+- Analytics schema v2 : https://vercel.com/docs/drains/reference/analytics
+- Pricing : https://vercel.com/docs/drains#usage-and-pricing
+- TL plan actuel : Hobby (vérification @thierry possible via dashboard Vercel mais traces existantes suggèrent fortement Hobby)


### PR DESCRIPTION
## Summary
- **sas 48h doctrine retirée** (CLAUDE.md) — décision explicite @thierry 18/05
- **Perf baseline Lighthouse** capturée sur 3 routes prod (Landing 91, /app 92, /changelog 74) — anti-régression mesurable pour Sprint 2.5
- **Spike Vercel Analytics** : Drains = Pro plan ($20/mois) → blocker budget 0€ → Phase 9 v1 révisé avec widgets gratuits uniquement
- **Marketing kit prêt-à-coller** : Class Central + OER Commons + MERLOT descriptions, PRs Awesome lists, templates posts Instagram + LinkedIn
- `.gitignore` : Lighthouse JSON traces ignored (~2MB/snapshot, gros pour repo, reproductibles)

## Voie C — docs-only
- 0 fichier `src/`, `api/`, `supabase/`, `vercel.json`, `package.json` touché
- Scope : `CLAUDE.md` (doctrine cleanup), `docs/marketing/`, `docs/perf-baseline-*.md`, `docs/perf-history/.gitkeep`, `docs/spike-vercel-*.md`, `.gitignore`
- 0 risque deployment

## Refs
- Linear umbrella SEO/GEO/AEO : THI-226
- Linear umbrella Phase 9 Admin Panel : THI-225
- PR #260 mergée juste avant : Schema.org enrichment (feature scope)

## Test plan
- [ ] CI green (lint markdown + markdownLinks gate sur CHANGELOG/STORY non touchés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)