### PR TITLE
docs(marketing): enrich kit with Google IA insights (souveraineté numérique + LTI June 2026)

### DIFF
--- a/docs/marketing/kit-2026-05-18.md
+++ b/docs/marketing/kit-2026-05-18.md
@@ -14,7 +14,14 @@
 
 **Email contact** : `courses@classcentral.com` (formulaire de soumission en ligne aussi disponible)
 
-### Description courte (255 caractères max)
+### Description courte (255 caractères max) — option B recommandée Google IA 18/05
+```
+Terminal Learning — Plateforme pédagogique interactive Linux/macOS/Windows. 11 modules, 65 leçons, RGPD-conforme (UE), open source. Intégration LTI 1.3 (Moodle/Canvas/Smartschool) en cours pour la rentrée 2026. 100% gratuit, sans inscription.
+```
+
+> Insight Google IA 18/05 : « N'attendez pas que le backend LTI soit 100% fini pour faire les soumissions. Le simple fait d'annoncer 'LTI integration coming June 2026' va attirer l'œil des directeurs de programmes qui préparent la rentrée. » L'angle RGPD + souveraineté numérique différencie aussi des alternatives US (Codecademy, freeCodeCamp).
+
+### Description courte — option A neutre (si tu préfères sans annonce future)
 ```
 Terminal Learning — Apprenez les commandes du terminal Linux, macOS et Windows dans un émulateur interactif. 11 modules progressifs, 65 leçons, 27+ commandes documentées. 100% gratuit, open source, sans inscription requise.
 ```
@@ -284,7 +291,34 @@ Si vous êtes enseignant en informatique, IUT, école d'ingénieurs, lycée pro�
 #EdTech #OpenSource #Cybersecurite #SoloFounder #BelgianTech #IndieHacker #DevTools #Education
 ```
 
-### Template #2 — Story personnelle (à publier 1× par mois)
+### Template #3 — Angle souveraineté numérique (NOUVEAU, retour Google IA 18/05)
+
+> Insight Google IA : « Les enseignants et professionnels de la tech adorent voir un produit gratuit, hautement sécurisé, performant (Lighthouse à 100) et qui respecte la vie privée. L'angle souveraineté numérique parle énormément au public belge/français. »
+
+```
+🇪🇺 Souveraineté numérique éducative — un cas concret
+
+Terminal Learning, mon projet open source pour apprendre les commandes Linux/macOS/Windows, est :
+
+✅ Hébergé en UE (Supabase Frankfurt + Vercel EU + Sentry EU)
+✅ RGPD-conforme par design (mode invité = 0 donnée backend)
+✅ Lighthouse 100/100 sur accessibilité, sécurité, SEO
+✅ Score sécurité audit-grade 9.2/10
+✅ Aucune donnée vendue, aucun tracker tiers, aucun cookie publicitaire
+✅ Open source MIT — auditable, forkable, modifiable
+
+Pourquoi je précise tout ça ? Parce que les outils éducatifs majoritaires (Codecademy, freeCodeCamp, repl.it) sont hébergés aux US sous CLOUD Act, sans DPA public adapté aux écoles européennes.
+
+L'enseignement informatique mérite mieux que l'arbitrage permanent "gratuit US vs payant EU".
+
+Si vous êtes enseignant en informatique, formateur ou DSI école : Terminal Learning est utilisable demain matin, gratuitement, en classe, sans signer de DPA exotique. Et l'intégration LTI 1.3 (Moodle/Smartschool/Canvas) arrive pour la rentrée 2026.
+
+terminallearning.dev
+
+#SouveraineteNumerique #RGPD #EdTech #OpenSource #BelgianTech #FrenchTech #Education #DigitalSovereignty #LTI
+```
+
+### Template #4 — Story personnelle (à publier 1× par mois)
 
 ```
 J'ai 47 ans (à adapter par @thierry), autodidacte, et j'ai mis 30 ans à comprendre que je n'étais pas "pas capable de coder".


### PR DESCRIPTION
## Summary
Retour Google IA Gemini 18/05 fin session a apporté 2 améliorations actionnables au kit marketing initial :

1. **Angle "Souveraineté numérique"** (template LinkedIn #3 nouveau) — différencie TL des alternatives US sous CLOUD Act. Très porteur public BE/FR/EU.
2. **Annonce "LTI integration coming June 2026"** (option B description Class Central) — n'attendre pas le ship pour annoncer dans les catalogs.

3 commentaires d'enrichissement aussi posés sur tickets Linear :
- **THI-227** : Schema.org TechArticle + HowTo combiné pattern
- **THI-229** : dépendance bloquante avec THI-228 (pre-render Vite **AVANT** NL landing pour éviter cannibalisation hreflang)
- **THI-230** : angle SEO "Outil pédagogique RGPD" identifié

## Voie C — docs-only
1 fichier modifié, 0 src/, 0 runtime impact.

## Refs
- Retour Google IA partagé par @thierry 18/05 ~17h CEST
- Umbrella THI-226 SEO/GEO/AEO
- Tickets enfants enrichis : THI-227, THI-229, THI-230

🤖 Generated with [Claude Code](https://claude.com/claude-code)