### PR TITLE
feat(admin): THI-225 Phase 9 v1 skeleton — /app/admin route + RequireRole wrapper

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Allow: /
 Disallow: /admin
+Disallow: /app/admin
 
 # AI crawlers — explicitly allowed (open-source educational project)
 # Allowing indexing helps learners find this tool via AI-powered search engines.

--- a/src/app/components/AdminPanel.tsx
+++ b/src/app/components/AdminPanel.tsx
@@ -1,0 +1,182 @@
+/**
+ * AdminPanel — THI-225 Phase 9 Admin Panel v1 (skeleton).
+ *
+ * Route `/app/admin` gated par `<RequireRole allowed={['super_admin']}>`.
+ *
+ * Scope v1 (deadline 10 juin 2026) — read-only super_admin only :
+ *   - 4 widgets placeholder skeleton (data réelle en S3 Sprint 2.5)
+ *   - Supabase health (users actifs, lessons completed, agrégats progress)
+ *   - Sentry events (last 24h errors/warnings)
+ *   - Application health (RLS policies status, RPC calls)
+ *   - Student activity heatmap (THI-77, GitHub-style)
+ *
+ * Hors scope v1 (différé v2 post-deadline) :
+ *   - `institution_admin` role (RLS scope creep P=70% identifié agent challenge)
+ *   - Drains Vercel Analytics (Pro plan blocker confirmé spike 18/05)
+ *   - Maintenance mode, in-app tickets, screenshots upload
+ *   - Teacher adoption heatmap (THI-78)
+ *
+ * Le lien vers le dashboard Vercel externe est placé en footer pour les
+ * admins TL eux-mêmes (les autres rôles n'arrivent jamais ici).
+ */
+import { Helmet } from 'react-helmet-async';
+import { Activity, AlertCircle, BarChart3, ExternalLink, ShieldCheck, Users } from 'lucide-react';
+
+import { RequireRole } from './auth/RequireRole';
+
+export function AdminPanel() {
+  return (
+    <RequireRole allowed={['super_admin']}>
+      <AdminPanelContent />
+    </RequireRole>
+  );
+}
+
+function AdminPanelContent() {
+  return (
+    <main className="flex-1 px-6 py-8 max-w-6xl mx-auto w-full">
+      <Helmet>
+        <title>Panneau administrateur — Terminal Learning</title>
+        <meta
+          name="description"
+          content="Tableau de bord supervision Terminal Learning — santé application, événements Sentry, activité utilisateurs, heatmap. Accès réservé super_admin."
+        />
+        <meta name="robots" content="noindex,nofollow" />
+      </Helmet>
+
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--github-text-primary)] mb-2">
+          Panneau administrateur
+        </h1>
+        <p className="text-sm text-[var(--github-text-secondary)]">
+          Supervision et monitoring de la plateforme.{' '}
+          <span className="text-[var(--github-text-secondary)]/70">
+            Édition v1 — données live disponibles bientôt.
+          </span>
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+        <WidgetSupabaseHealth />
+        <WidgetSentryEvents />
+        <WidgetApplicationHealth />
+        <WidgetStudentHeatmap />
+      </div>
+
+      <footer className="pt-6 border-t border-[var(--github-border-primary)]">
+        <a
+          href="https://vercel.com/thierry-vanmeeterens-projects/terminal-learning/analytics"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm font-mono text-[var(--github-text-secondary)] hover:text-emerald-400 transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+        >
+          Voir analytics détaillées sur Vercel
+          <ExternalLink size={12} aria-hidden="true" />
+        </a>
+        <p className="text-xs text-[var(--github-text-secondary)]/70 font-mono mt-2">
+          Drains custom analytics widget : Phase 9 v2 (post-deadline 10 juin).
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+interface WidgetCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  comingIn: string;
+  children?: React.ReactNode;
+}
+
+function WidgetCard({ icon, title, description, comingIn, children }: WidgetCardProps) {
+  return (
+    <section
+      className="px-5 py-5 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)]"
+      aria-labelledby={`widget-${title.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      <header className="flex items-center gap-3 mb-3">
+        <span className="text-emerald-400" aria-hidden="true">
+          {icon}
+        </span>
+        <h2
+          id={`widget-${title.toLowerCase().replace(/\s+/g, '-')}`}
+          className="text-base font-medium text-[var(--github-text-primary)]"
+        >
+          {title}
+        </h2>
+      </header>
+      <p className="text-sm text-[var(--github-text-secondary)] mb-3">{description}</p>
+      {children ?? (
+        <div className="px-4 py-3 rounded-md bg-[var(--github-bg)]/40 border border-dashed border-[var(--github-border-primary)]">
+          <p className="text-xs text-[var(--github-text-secondary)]/70 font-mono">
+            Données live : <span className="text-emerald-400">{comingIn}</span>
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function WidgetSupabaseHealth() {
+  return (
+    <WidgetCard
+      icon={<Users size={20} />}
+      title="Santé Supabase"
+      description="Utilisateurs actifs (7j), leçons complétées (30j), modules populaires, sessions auth."
+      comingIn="Sprint S3 — requêtes Supabase REST sur progress + auth.users"
+    />
+  );
+}
+
+function WidgetSentryEvents() {
+  return (
+    <WidgetCard
+      icon={<AlertCircle size={20} />}
+      title="Événements Sentry"
+      description="Erreurs et warnings des 24 dernières heures (free tier 5K events/mois)."
+      comingIn="Sprint S3 — Sentry REST API integration"
+    />
+  );
+}
+
+function WidgetApplicationHealth() {
+  return (
+    <WidgetCard
+      icon={<ShieldCheck size={20} />}
+      title="Santé application"
+      description="Status RLS policies, RPC calls réussis vs erreur, événements auth Supabase."
+      comingIn="Sprint S3 — Supabase Admin queries via supabase-js"
+    />
+  );
+}
+
+function WidgetStudentHeatmap() {
+  return (
+    <WidgetCard
+      icon={<BarChart3 size={20} />}
+      title="Activité élèves"
+      description="Heatmap GitHub-style des leçons complétées par jour sur 52 semaines (THI-77)."
+      comingIn="Sprint S3 — agrégat progress par date_trunc('day', completed_at)"
+    >
+      {/* Skeleton heatmap placeholder — emerald grid pattern */}
+      <div
+        className="grid grid-cols-13 gap-1 mt-2"
+        role="img"
+        aria-label="Heatmap placeholder — données live disponibles Sprint S3"
+      >
+        {Array.from({ length: 91 }, (_, i) => (
+          <span
+            key={i}
+            className="aspect-square rounded-sm bg-[var(--github-bg)]/40 border border-[var(--github-border-primary)]/40"
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+      <p className="mt-2 text-xs text-[var(--github-text-secondary)]/70 font-mono inline-flex items-center gap-2">
+        <Activity size={12} aria-hidden="true" />
+        Skeleton — 91 jours × 1 cellule
+      </p>
+    </WidgetCard>
+  );
+}

--- a/src/app/components/AdminPanel.tsx
+++ b/src/app/components/AdminPanel.tsx
@@ -23,6 +23,8 @@ import { Helmet } from 'react-helmet-async';
 import { Activity, AlertCircle, BarChart3, ExternalLink, ShieldCheck, Users } from 'lucide-react';
 
 import { RequireRole } from './auth/RequireRole';
+import { Button } from './ui/button';
+import { Card } from './ui/card';
 
 export function AdminPanel() {
   return (
@@ -64,15 +66,16 @@ function AdminPanelContent() {
       </div>
 
       <footer className="pt-6 border-t border-[var(--github-border-primary)]">
-        <a
-          href="https://vercel.com/thierry-vanmeeterens-projects/terminal-learning/analytics"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-sm font-mono text-[var(--github-text-secondary)] hover:text-emerald-400 transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
-        >
-          Voir analytics détaillées sur Vercel
-          <ExternalLink size={12} aria-hidden="true" />
-        </a>
+        <Button asChild variant="ghost-gh" className="min-h-11 gap-2 font-mono text-sm">
+          <a
+            href="https://vercel.com/thierry-vanmeeterens-projects/terminal-learning/analytics"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Voir analytics détaillées sur Vercel
+            <ExternalLink size={12} aria-hidden="true" />
+          </a>
+        </Button>
         <p className="text-xs text-[var(--github-text-secondary)]/70 font-mono mt-2">
           Drains custom analytics widget : Phase 9 v2 (post-deadline 10 juin).
         </p>
@@ -90,23 +93,23 @@ interface WidgetCardProps {
 }
 
 function WidgetCard({ icon, title, description, comingIn, children }: WidgetCardProps) {
+  const headingId = `widget-${title.toLowerCase().replace(/\s+/g, '-')}`;
   return (
-    <section
-      className="px-5 py-5 rounded-lg bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)]"
-      aria-labelledby={`widget-${title.toLowerCase().replace(/\s+/g, '-')}`}
+    <Card
+      variant="tl-surface"
+      className="px-5 py-5 gap-3"
+      role="region"
+      aria-labelledby={headingId}
     >
-      <header className="flex items-center gap-3 mb-3">
+      <header className="flex items-center gap-3">
         <span className="text-emerald-400" aria-hidden="true">
           {icon}
         </span>
-        <h2
-          id={`widget-${title.toLowerCase().replace(/\s+/g, '-')}`}
-          className="text-base font-medium text-[var(--github-text-primary)]"
-        >
+        <h2 id={headingId} className="text-base font-medium text-[var(--github-text-primary)]">
           {title}
         </h2>
       </header>
-      <p className="text-sm text-[var(--github-text-secondary)] mb-3">{description}</p>
+      <p className="text-sm text-[var(--github-text-secondary)]">{description}</p>
       {children ?? (
         <div className="px-4 py-3 rounded-md bg-[var(--github-bg)]/40 border border-dashed border-[var(--github-border-primary)]">
           <p className="text-xs text-[var(--github-text-secondary)]/70 font-mono">
@@ -114,7 +117,7 @@ function WidgetCard({ icon, title, description, comingIn, children }: WidgetCard
           </p>
         </div>
       )}
-    </section>
+    </Card>
   );
 }
 
@@ -161,7 +164,7 @@ function WidgetStudentHeatmap() {
     >
       {/* Skeleton heatmap placeholder — emerald grid pattern */}
       <div
-        className="grid grid-cols-13 gap-1 mt-2"
+        className="grid grid-cols-[repeat(13,minmax(0,1fr))] gap-1 mt-2"
         role="img"
         aria-label="Heatmap placeholder — données live disponibles Sprint S3"
       >

--- a/src/app/components/auth/RequireRole.tsx
+++ b/src/app/components/auth/RequireRole.tsx
@@ -22,6 +22,7 @@ import { Link } from 'react-router';
 import { useAuth } from '../../context/AuthContext';
 import type { UserRole } from '../../types/database';
 import { useUserRole } from '@/lib/hooks/useUserRole';
+import { Button } from '../ui/button';
 
 interface RequireRoleProps {
   /** The component(s) to render when the user is authenticated AND has an allowed role. */
@@ -69,12 +70,12 @@ export function RequireRole({
       <>
         {unauthenticatedFallback ?? (
           <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
-            <p className="text-[var(--github-text-secondary)] text-sm font-mono">
-              Vous devez être connecté pour accéder à cette page.{' '}
-              <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">
-                Retour à l&apos;accueil
-              </Link>
+            <p className="text-[var(--github-text-secondary)] text-sm font-mono mb-4">
+              Vous devez être connecté pour accéder à cette page.
             </p>
+            <Button asChild variant="emerald-soft" className="min-h-11">
+              <Link to="/">Retour à l&apos;accueil</Link>
+            </Button>
           </main>
         )}
       </>
@@ -91,11 +92,11 @@ export function RequireRole({
               Accès réservé
             </h1>
             <p className="text-[var(--github-text-secondary)] text-sm font-mono mb-4">
-              Cette page est accessible aux administrateurs uniquement.{' '}
-              <Link to="/app" className="text-emerald-400 hover:text-emerald-300 underline">
-                Retour au tableau de bord
-              </Link>
+              Cette page est accessible aux administrateurs uniquement.
             </p>
+            <Button asChild variant="emerald-soft" className="min-h-11">
+              <Link to="/app">Retour au tableau de bord</Link>
+            </Button>
           </main>
         )}
       </>

--- a/src/app/components/auth/RequireRole.tsx
+++ b/src/app/components/auth/RequireRole.tsx
@@ -1,0 +1,106 @@
+/**
+ * RequireRole — THI-225 Phase 9 Admin Panel.
+ *
+ * Extension de `<RequireAuth>` (THI-221) qui ajoute le check du rôle utilisateur
+ * via `useUserRole()`. Affiche le children uniquement si l'utilisateur est
+ * authentifié ET possède l'un des rôles autorisés. Sinon, rendu :
+ *   - `!initialized || roleLoading` → loading state
+ *   - `!user` → fallback "Vous devez être connecté"
+ *   - `role not in allowed[]` → fallback "Accès réservé" (ou custom)
+ *
+ * Pattern :
+ *   <RequireRole allowed={['super_admin']}>
+ *     <AdminPanelContent />
+ *   </RequireRole>
+ *
+ * Anonymous-friendly UX préservée : opt-in par route, pas Layout-level
+ * blanket. Cohérent avec la doctrine THI-221.
+ */
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+
+import { useAuth } from '../../context/AuthContext';
+import type { UserRole } from '../../types/database';
+import { useUserRole } from '@/lib/hooks/useUserRole';
+
+interface RequireRoleProps {
+  /** The component(s) to render when the user is authenticated AND has an allowed role. */
+  children: ReactNode;
+  /** List of roles permitted to view the children. */
+  allowed: UserRole[];
+  /**
+   * Optional fallback rendered when the user is authenticated but does NOT
+   * have one of the allowed roles. Defaults to a generic "Accès réservé"
+   * message with a link to /app. Must not contain unsanitised user input.
+   */
+  forbiddenFallback?: ReactNode;
+  /**
+   * Optional fallback rendered when no user is authenticated at all
+   * (separate from forbidden — usually a login prompt). Defaults to
+   * "Vous devez être connecté" with a link to /.
+   */
+  unauthenticatedFallback?: ReactNode;
+}
+
+export function RequireRole({
+  children,
+  allowed,
+  forbiddenFallback,
+  unauthenticatedFallback,
+}: RequireRoleProps) {
+  const { user, initialized } = useAuth();
+  const { role, loading: roleLoading } = useUserRole();
+
+  // Wait for auth and role resolution before deciding. Critical for UX :
+  // without this guard, a legitimate admin sees the "Accès réservé" flash
+  // for ~100-500ms during Supabase + RPC resolution (security-auditor H1
+  // pattern from THI-42 extended to role-gated routes).
+  if (!initialized || (user && roleLoading)) {
+    return (
+      <main className="flex-1 flex items-center justify-center min-h-[40vh]" aria-busy="true">
+        <p className="text-[var(--github-text-secondary)] text-sm font-mono">Chargement…</p>
+      </main>
+    );
+  }
+
+  // No user at all → unauthenticated fallback.
+  if (!user) {
+    return (
+      <>
+        {unauthenticatedFallback ?? (
+          <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
+            <p className="text-[var(--github-text-secondary)] text-sm font-mono">
+              Vous devez être connecté pour accéder à cette page.{' '}
+              <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">
+                Retour à l&apos;accueil
+              </Link>
+            </p>
+          </main>
+        )}
+      </>
+    );
+  }
+
+  // User authenticated but wrong role → forbidden fallback.
+  if (!role || !allowed.includes(role)) {
+    return (
+      <>
+        {forbiddenFallback ?? (
+          <main className="flex-1 px-6 py-12 max-w-4xl mx-auto">
+            <h1 className="text-2xl font-semibold text-[var(--github-text-primary)] mb-4">
+              Accès réservé
+            </h1>
+            <p className="text-[var(--github-text-secondary)] text-sm font-mono mb-4">
+              Cette page est accessible aux administrateurs uniquement.{' '}
+              <Link to="/app" className="text-emerald-400 hover:text-emerald-300 underline">
+                Retour au tableau de bord
+              </Link>
+            </p>
+          </main>
+        )}
+      </>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -71,6 +71,9 @@ const AiSettings = lazyWithRetry(() =>
 const ProfilePage = lazyWithRetry(() =>
   import('./components/ProfilePage').then(({ ProfilePage }) => ({ default: ProfilePage }))
 );
+const AdminPanel = lazyWithRetry(() =>
+  import('./components/AdminPanel').then(({ AdminPanel }) => ({ default: AdminPanel }))
+);
 const Changelog = lazyWithRetry(() =>
   import('./components/Changelog').then(({ Changelog }) => ({ default: Changelog }))
 );
@@ -99,6 +102,7 @@ export const router = createBrowserRouter([
       { path: 'reference', Component: CommandReference },
       { path: 'settings', Component: AiSettings },
       { path: 'profile', Component: ProfilePage },
+      { path: 'admin', Component: AdminPanel },
     ],
   },
 

--- a/src/lib/hooks/useUserRole.ts
+++ b/src/lib/hooks/useUserRole.ts
@@ -1,0 +1,101 @@
+/**
+ * useUserRole — THI-225 Phase 9 Admin Panel.
+ *
+ * Fetches the authenticated user's role via the `get_my_role()` Supabase
+ * RPC (security definer, bypasses RLS recursion). Returns the role + a
+ * loading flag so callers can wait for resolution before deciding what
+ * to render.
+ *
+ * RBAC source of truth : `public.profiles.role` column (migration
+ * `005_rbac_roles.sql`). Roles in increasing privilege order :
+ *   student → pending_teacher → teacher → institution_admin → super_admin
+ *
+ * Caching strategy : in-memory promise cache per session. The RPC is
+ * cheap (one-row read with RLS bypass via security definer) but caching
+ * avoids re-fetching on every <RequireRole> remount.
+ *
+ * Reset : the cache is cleared on signOut via `clearUserRoleCache()`
+ * exported alongside, called from `AuthContext.signOut()` next session.
+ */
+import { useEffect, useState } from 'react';
+
+import { useAuth } from '@/app/context/AuthContext';
+import type { UserRole } from '@/app/types/database';
+
+let cachedRolePromise: Promise<UserRole | null> | null = null;
+let cachedRoleUserId: string | null = null;
+
+/**
+ * Clear the in-memory role cache. Must be called from `AuthContext.signOut()`
+ * to prevent the next user inheriting the previous user's role on the same
+ * device (same defense-in-depth class as THI-207 AI session data wipe).
+ */
+export function clearUserRoleCache(): void {
+  cachedRolePromise = null;
+  cachedRoleUserId = null;
+}
+
+async function fetchRole(userId: string): Promise<UserRole | null> {
+  // Re-use the cached promise if same user — avoids parallel RPC calls
+  // from multiple <RequireRole> instances mounting simultaneously.
+  if (cachedRoleUserId === userId && cachedRolePromise) {
+    return cachedRolePromise;
+  }
+  cachedRoleUserId = userId;
+  cachedRolePromise = (async () => {
+    const { supabase } = await import('@/lib/supabase');
+    if (!supabase) return null;
+    const { data, error } = await supabase.rpc('get_my_role');
+    if (error) {
+      // Don't expose the user-facing error here — the calling component
+      // will render a fallback. Logging the technical error is enough.
+      console.error('[useUserRole] get_my_role RPC failed:', error.message);
+      return null;
+    }
+    return data as UserRole | null;
+  })();
+  return cachedRolePromise;
+}
+
+export interface UseUserRoleResult {
+  role: UserRole | null;
+  loading: boolean;
+}
+
+export function useUserRole(): UseUserRoleResult {
+  const { user, initialized } = useAuth();
+  const [role, setRole] = useState<UserRole | null>(null);
+  // Track which user.id the current `role` state corresponds to. The derived
+  // `loading` flag is true whenever auth is unresolved OR there is a user
+  // but the RPC has not yet resolved for that specific user.id (handles
+  // user switching on the same device without a synchronous setState
+  // inside the effect — eslint react-hooks/set-state-in-effect).
+  const [resolvedForUserId, setResolvedForUserId] = useState<string | null>(null);
+  const loading = !initialized || (!!user && resolvedForUserId !== user.id);
+
+  useEffect(() => {
+    if (!initialized) return;
+    if (!user) {
+      // No user → reset role + resolved sentinel. Synchronous setState
+      // here is intentional: required to clear stale state from a previous
+      // authenticated session on the same device (defense-in-depth
+      // alignment with THI-207 signout wipe + THI-221 RequireAuth pattern).
+      /* eslint-disable react-hooks/set-state-in-effect -- defense-in-depth signout reset */
+      setRole(null);
+      setResolvedForUserId(null);
+      /* eslint-enable react-hooks/set-state-in-effect */
+      return;
+    }
+    let cancelled = false;
+    fetchRole(user.id).then((fetchedRole) => {
+      if (cancelled) return;
+      setRole(fetchedRole);
+      setResolvedForUserId(user.id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, initialized]);
+
+  return { role, loading };
+}

--- a/src/test/adminPanel.test.tsx
+++ b/src/test/adminPanel.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for AdminPanel — THI-225 Phase 9 v1 skeleton.
+ *
+ * Couvre :
+ *  - render skeleton (heading + 4 widgets + footer lien Vercel) when super_admin
+ *  - fallback "Accès réservé" pour les 4 autres rôles (institution_admin /
+ *    teacher / pending_teacher / student)
+ *  - fallback "Vous devez être connecté" anonymous
+ *  - meta robots noindex,nofollow (admin panel n'est pas pour Google)
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+type AuthState = {
+  user: { id: string } | null;
+  initialized: boolean;
+};
+
+type RoleState = {
+  role: 'super_admin' | 'institution_admin' | 'teacher' | 'pending_teacher' | 'student' | null;
+  loading: boolean;
+};
+
+const authState: AuthState = { user: null, initialized: true };
+const roleState: RoleState = { role: null, loading: false };
+
+vi.mock('../app/context/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user, initialized: authState.initialized }),
+}));
+
+vi.mock('@/lib/hooks/useUserRole', () => ({
+  useUserRole: () => ({ role: roleState.role, loading: roleState.loading }),
+}));
+
+import { AdminPanel } from '../app/components/AdminPanel';
+
+function renderAdmin() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <AdminPanel />
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+}
+
+beforeEach(() => {
+  authState.user = null;
+  authState.initialized = true;
+  roleState.role = null;
+  roleState.loading = false;
+});
+
+describe('AdminPanel — auth & role guard', () => {
+  it('renders "Vous devez être connecté" fallback when anonymous', () => {
+    authState.user = null;
+    renderAdmin();
+    expect(screen.getByText(/vous devez être connecté/i)).toBeInTheDocument();
+    expect(screen.queryByText('Panneau administrateur')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['student' as const],
+    ['pending_teacher' as const],
+    ['teacher' as const],
+    ['institution_admin' as const],
+  ])('renders "Accès réservé" fallback for role=%s (not super_admin)', (currentRole) => {
+    authState.user = { id: 'user-123' };
+    roleState.role = currentRole;
+    renderAdmin();
+    expect(screen.getByText(/accès réservé/i)).toBeInTheDocument();
+    expect(screen.queryByText('Panneau administrateur')).not.toBeInTheDocument();
+  });
+});
+
+describe('AdminPanel — super_admin render', () => {
+  beforeEach(() => {
+    authState.user = { id: 'super-123' };
+    roleState.role = 'super_admin';
+  });
+
+  it('renders header "Panneau administrateur"', () => {
+    renderAdmin();
+    expect(screen.getByRole('heading', { name: 'Panneau administrateur', level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders 4 widget sections', () => {
+    renderAdmin();
+    expect(screen.getByText('Santé Supabase')).toBeInTheDocument();
+    expect(screen.getByText('Événements Sentry')).toBeInTheDocument();
+    expect(screen.getByText('Santé application')).toBeInTheDocument();
+    expect(screen.getByText('Activité élèves')).toBeInTheDocument();
+  });
+
+  it('renders external link to Vercel analytics dashboard', () => {
+    renderAdmin();
+    const link = screen.getByRole('link', { name: /voir analytics détaillées sur vercel/i });
+    expect(link).toHaveAttribute('href', expect.stringContaining('vercel.com'));
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('mentions widget data coming in Sprint S3 (placeholder transparency)', () => {
+    renderAdmin();
+    // At least one widget mentions Sprint S3 timing (we don't want to over-spec the exact text)
+    const sprintMentions = screen.getAllByText(/Sprint S3/i);
+    expect(sprintMentions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('mentions Phase 9 v2 for Drains in footer (transparency)', () => {
+    renderAdmin();
+    expect(screen.getByText(/Phase 9 v2/i)).toBeInTheDocument();
+  });
+
+  it('student heatmap renders 91 placeholder cells', () => {
+    renderAdmin();
+    const heatmap = screen.getByRole('img', { name: /heatmap placeholder/i });
+    expect(heatmap).toBeInTheDocument();
+    const cells = heatmap.querySelectorAll('span');
+    expect(cells.length).toBe(91);
+  });
+});

--- a/src/test/requireRole.test.tsx
+++ b/src/test/requireRole.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Tests for RequireRole — THI-225 Phase 9 Admin Panel.
+ *
+ * Couvre :
+ *  - loading state pendant !initialized ou roleLoading (pas de flash fallback)
+ *  - fallback "Vous devez être connecté" si pas d'user
+ *  - fallback "Accès réservé" si user mais role non autorisé
+ *  - custom fallbacks (forbiddenFallback, unauthenticatedFallback) override
+ *  - children rendus si user + role dans allowed[]
+ *  - multi-role allowed[] support (super_admin OR institution_admin)
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+type AuthState = {
+  user: { id: string } | null;
+  initialized: boolean;
+};
+
+type RoleState = {
+  role: 'super_admin' | 'institution_admin' | 'teacher' | 'pending_teacher' | 'student' | null;
+  loading: boolean;
+};
+
+const authState: AuthState = { user: null, initialized: true };
+const roleState: RoleState = { role: null, loading: false };
+
+vi.mock('../app/context/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user, initialized: authState.initialized }),
+}));
+
+vi.mock('@/lib/hooks/useUserRole', () => ({
+  useUserRole: () => ({ role: roleState.role, loading: roleState.loading }),
+}));
+
+import { RequireRole } from '../app/components/auth/RequireRole';
+import type { UserRole } from '../app/types/database';
+
+function renderGuarded(
+  allowed: UserRole[],
+  children: React.ReactNode,
+  forbiddenFallback?: React.ReactNode,
+  unauthenticatedFallback?: React.ReactNode,
+) {
+  return render(
+    <MemoryRouter>
+      <RequireRole
+        allowed={allowed}
+        forbiddenFallback={forbiddenFallback}
+        unauthenticatedFallback={unauthenticatedFallback}
+      >
+        {children}
+      </RequireRole>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  authState.user = null;
+  authState.initialized = true;
+  roleState.role = null;
+  roleState.loading = false;
+});
+
+describe('RequireRole — loading state', () => {
+  it('renders "Chargement…" while auth is initialising', () => {
+    authState.user = null;
+    authState.initialized = false;
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+    expect(screen.queryByText(/accès réservé/i)).not.toBeInTheDocument();
+  });
+
+  it('renders "Chargement…" while role RPC is resolving for authenticated user', () => {
+    authState.user = { id: 'user-123' };
+    authState.initialized = true;
+    roleState.role = null;
+    roleState.loading = true;
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+    expect(screen.queryByText(/accès réservé/i)).not.toBeInTheDocument();
+  });
+
+  it('sets aria-busy on loading container', () => {
+    authState.initialized = false;
+    const { container } = renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+});
+
+describe('RequireRole — unauthenticated fallback', () => {
+  it('renders default "Vous devez être connecté" when no user', () => {
+    authState.user = null;
+    authState.initialized = true;
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText(/vous devez être connecté/i)).toBeInTheDocument();
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+  });
+
+  it('uses custom unauthenticated fallback when provided', () => {
+    authState.user = null;
+    renderGuarded(
+      ['super_admin'],
+      <p>Admin content</p>,
+      undefined,
+      <p>Custom login prompt</p>,
+    );
+    expect(screen.getByText('Custom login prompt')).toBeInTheDocument();
+    expect(screen.queryByText(/vous devez être connecté/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('RequireRole — forbidden fallback (wrong role)', () => {
+  it.each([
+    ['student' as UserRole],
+    ['pending_teacher' as UserRole],
+    ['teacher' as UserRole],
+    ['institution_admin' as UserRole],
+  ])('renders "Accès réservé" when role is %s but allowed is [super_admin]', (currentRole) => {
+    authState.user = { id: 'user-123' };
+    roleState.role = currentRole;
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText(/accès réservé/i)).toBeInTheDocument();
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+  });
+
+  it('default fallback links to /app', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = 'student';
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    const link = screen.getByRole('link', { name: /retour au tableau de bord/i });
+    expect(link).toHaveAttribute('href', '/app');
+  });
+
+  it('uses custom forbidden fallback when provided', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = 'student';
+    renderGuarded(['super_admin'], <p>Admin content</p>, <p>Custom upgrade CTA</p>);
+    expect(screen.getByText('Custom upgrade CTA')).toBeInTheDocument();
+    expect(screen.queryByText(/accès réservé/i)).not.toBeInTheDocument();
+  });
+
+  it('forbids when role is null (RPC failed, defensive)', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = null;
+    roleState.loading = false;
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText(/accès réservé/i)).toBeInTheDocument();
+  });
+});
+
+describe('RequireRole — authorized render', () => {
+  it('renders children when role is super_admin and allowed=[super_admin]', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = 'super_admin';
+    renderGuarded(['super_admin'], <p>Admin content</p>);
+    expect(screen.getByText('Admin content')).toBeInTheDocument();
+    expect(screen.queryByText(/accès réservé/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Chargement…')).not.toBeInTheDocument();
+  });
+
+  it('renders children when role matches any of multi-role allowed[]', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = 'institution_admin';
+    renderGuarded(['super_admin', 'institution_admin'], <p>Admin content</p>);
+    expect(screen.getByText('Admin content')).toBeInTheDocument();
+  });
+
+  it('forbids when role is teacher but allowed is [super_admin, institution_admin]', () => {
+    authState.user = { id: 'user-123' };
+    roleState.role = 'teacher';
+    renderGuarded(['super_admin', 'institution_admin'], <p>Admin content</p>);
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+    expect(screen.getByText(/accès réservé/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Route `/app/admin` accessible aux super_admin uniquement (v1 read-only)
- New hook `useUserRole()` fetch role via RPC `get_my_role()` Supabase
- New wrapper `<RequireRole>` extension THI-221 avec role whitelist
- AdminPanel skeleton avec 4 widgets placeholder (data live S3)
- 26 nouveaux tests (requireRole 17 + adminPanel 9)
- robots.txt fix `/app/admin` disallow (M2 security-auditor)

## Closes / Refs
- Part of THI-225 umbrella Phase 9 Admin Panel
- Follow-up tracé : THI-232 clearUserRoleCache integration AuthContext.signOut() (gate S3)

## Files
- `src/lib/hooks/useUserRole.ts` (new) — RPC fetch + cache + clearUserRoleCache()
- `src/app/components/auth/RequireRole.tsx` (new) — role-gated wrapper
- `src/app/components/AdminPanel.tsx` (new) — route content + 4 widgets skeleton
- `src/app/routes.ts` — route `/app/admin` enfant + lazyWithRetry
- `src/test/requireRole.test.tsx` (new) — 17 tests
- `src/test/adminPanel.test.tsx` (new) — 9 tests
- `public/robots.txt` — Disallow `/app/admin`

## Audits cascade
- **security-auditor** : ⚠️ APPROVE 9.1/10 (delta -0.1 vs baseline 9.2 — H1 clearUserRoleCache non encore intégré signOut, tracé THI-232 prerequisite S3). M2 robots.txt → fixé dans ce commit. L1-L5 LOW notes (defense-in-depth validé)

## Anonymous-friendly UX préservée
RequireRole est opt-in per route, pas Layout blanket. Cohérent avec doctrine THI-221. Dashboard / Reference / Settings / Profile inchangés (toujours accessibles aux invités / autres rôles).

## Test plan
- [ ] CI green (1479+26 = 1505 tests / type-check / lint / build)
- [ ] Voie A Chrome MCP iPhone + desktop sur `/app/admin` :
  - [ ] test.superadmin → render panel + 4 widgets + lien Vercel ✅
  - [ ] test.institutionadmin → fallback "Accès réservé" + lien `/app` ✅
  - [ ] test.teacher → fallback "Accès réservé" ✅
  - [ ] test.pendingt → fallback "Accès réservé" ✅
  - [ ] test.student → fallback "Accès réservé" ✅
  - [ ] anonymous → fallback "Vous devez être connecté" ✅
- [ ] 0 console error
- [ ] 0 fuite data sensible pour non-super_admin (DOM inspection)
- [ ] Lighthouse `/app/admin` super_admin baseline capturé

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajout d’une route de panneau d’administration, protégée par rôle, pour les utilisateurs super_admin ainsi que d’utilitaires de gestion d’accès basés sur les rôles.

Nouvelles fonctionnalités :
- Introduction d’une route `/app/admin` rendant un squelette d’`AdminPanel` avec quatre widgets de monitoring factices, réservés uniquement aux utilisateurs super_admin.
- Ajout d’un composant `RequireRole` pour restreindre l’accès à des routes et composants en fonction des rôles utilisateur autorisés, avec des comportements de repli configurables.
- Ajout d’un hook `useUserRole` pour récupérer et mettre en cache le rôle de l’utilisateur courant via la RPC Supabase `get_my_role`.

Améliorations :
- Mise à jour du routeur de l’application pour charger paresseusement (lazy load) le composant `AdminPanel` sous la route `/app`.
- Interdiction du crawl du chemin `/app/admin` via les métadonnées `robots` afin de garder le panneau d’administration hors des index des moteurs de recherche.

Tests :
- Ajout de tests unitaires pour `RequireRole` couvrant les scénarios de chargement, non authentifié, accès interdit et multi-rôles.
- Ajout de tests unitaires pour `AdminPanel` vérifiant la protection basée sur les rôles, le squelette de mise en page, les liens externes et le comportement des données factices.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a role-gated admin panel route for super_admin users and supporting role-based access utilities.

New Features:
- Introduce a /app/admin route rendering an AdminPanel skeleton with four placeholder monitoring widgets for super_admin users only.
- Add a RequireRole component to gate routes and components based on allowed user roles with configurable fallbacks.
- Add a useUserRole hook to fetch and cache the current user role via the get_my_role Supabase RPC.

Enhancements:
- Update the application router to lazily load the AdminPanel component under the /app route.
- Disallow crawling of the /app/admin path via robots metadata to keep the admin panel out of search indexes.

Tests:
- Add unit tests for RequireRole covering loading, unauthenticated, forbidden, and multi-role scenarios.
- Add unit tests for AdminPanel verifying role-based gating, layout skeleton, external links, and placeholder data behavior.

</details>