### PR TITLE
feat(auth): THI-235 Sprint 2.A étape 2.ter — adaptive default route post-login per role

### DIFF
--- a/src/app/components/auth/AuthCallback.tsx
+++ b/src/app/components/auth/AuthCallback.tsx
@@ -29,6 +29,16 @@ export function AuthCallback() {
   const navigate = useNavigate();
   const { session, initialized } = useAuth();
   const redirected = useRef(false);
+  // Track unmount to avoid `navigate()` calls after the component is gone
+  // (security-auditor L1 cleanup — async RPC may resolve after a fast
+  // user navigation; React 18 tolerates but emits a dev warning).
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!initialized || redirected.current) return;
@@ -50,12 +60,16 @@ export function AuthCallback() {
     // 2. No explicit returnTo → adaptive route per role.
     //    Async block : we cannot await directly inside useEffect, so wrap
     //    in an IIFE. The redirected.current guard above already protects
-    //    against double-fires.
+    //    against double-fires; isMounted.current guards against post-unmount navigate.
     void (async () => {
+      const safeNavigate = (target: string) => {
+        if (!isMounted.current) return;
+        navigate(target, { replace: true });
+      };
       try {
         const { supabase } = await import('@/lib/supabase');
         if (!supabase) {
-          navigate('/app', { replace: true });
+          safeNavigate('/app');
           return;
         }
         const { data, error } = await supabase.rpc('get_my_role');
@@ -63,12 +77,12 @@ export function AuthCallback() {
           // RPC failed (RLS recursion, network, etc.) — safe fallback.
           // Don't expose the technical error to the user; AuthContext logs
           // RPC failures separately in useUserRole.
-          navigate('/app', { replace: true });
+          safeNavigate('/app');
           return;
         }
-        navigate(defaultRouteForRole(data as UserRole | null), { replace: true });
+        safeNavigate(defaultRouteForRole(data as UserRole | null));
       } catch {
-        navigate('/app', { replace: true });
+        safeNavigate('/app');
       }
     })();
   }, [initialized, session, navigate]);

--- a/src/app/components/auth/AuthCallback.tsx
+++ b/src/app/components/auth/AuthCallback.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { useAuth } from '../../context/AuthContext';
 import { consumeReturnTo } from '@/lib/auth/returnToStorage';
+import { defaultRouteForRole } from '@/lib/auth/defaultRouteForRole';
+import type { UserRole } from '../../types/database';
 
 /**
  * Handles OAuth PKCE callback — waits for AuthContext to resolve the session
@@ -13,13 +15,15 @@ import { consumeReturnTo } from '@/lib/auth/returnToStorage';
  * `redirected` ref guarantees at most one navigation even if `initialized` or
  * `session` change again after the first redirect fires.
  *
- * Post-login redirect (THI-235 Sprint 2.A étape 2.bis) :
- *   - On successful login, read sessionStorage `auth_return_to` (stored by
- *     RequireRole/RequireAuth fallback when guest tried a gated route).
- *   - validateReturnTo() rejects anything outside the `/app/*` allowlist —
- *     prevents open-redirect attacks via stored XSS payloads.
- *   - Default to `/app` if storage is empty or value invalid.
- *   - On failed login (no session), send back to landing.
+ * Post-login redirect precedence (THI-235 Sprint 2.A étape 2.bis + 2.ter) :
+ *   1. consumeReturnTo() returns a valid path → respect user explicit intent
+ *      (came from a gated route fallback "Se connecter" click).
+ *      validateReturnTo() guarantees `/app/*` allowlist — open-redirect safe.
+ *   2. Otherwise, look up role via `get_my_role()` RPC and apply
+ *      `defaultRouteForRole(role)` (THI-235 étape 2.ter adaptive routing) :
+ *      super_admin → /app/admin, teacher → /app/teacher, others → /app.
+ *   3. RPC failure or no session → safe fallback `/app` (student-style).
+ *   4. On failed login (no session at all), send back to landing.
  */
 export function AuthCallback() {
   const navigate = useNavigate();
@@ -29,14 +33,44 @@ export function AuthCallback() {
   useEffect(() => {
     if (!initialized || redirected.current) return;
     redirected.current = true;
-    if (session) {
-      // consumeReturnTo() reads + clears + validates in one atomic step
-      const target = consumeReturnTo();
-      navigate(target, { replace: true });
-    } else {
-      // Exchange failed (expired code, wrong redirect URL, etc.) — send back to landing
+
+    if (!session) {
+      // Exchange failed (expired code, wrong redirect URL, etc.) — back to landing
       navigate('/', { replace: true });
+      return;
     }
+
+    // 1. Explicit returnTo (user came from a gated route) takes priority.
+    const stored = consumeReturnTo();
+    if (stored !== null) {
+      navigate(stored, { replace: true });
+      return;
+    }
+
+    // 2. No explicit returnTo → adaptive route per role.
+    //    Async block : we cannot await directly inside useEffect, so wrap
+    //    in an IIFE. The redirected.current guard above already protects
+    //    against double-fires.
+    void (async () => {
+      try {
+        const { supabase } = await import('@/lib/supabase');
+        if (!supabase) {
+          navigate('/app', { replace: true });
+          return;
+        }
+        const { data, error } = await supabase.rpc('get_my_role');
+        if (error) {
+          // RPC failed (RLS recursion, network, etc.) — safe fallback.
+          // Don't expose the technical error to the user; AuthContext logs
+          // RPC failures separately in useUserRole.
+          navigate('/app', { replace: true });
+          return;
+        }
+        navigate(defaultRouteForRole(data as UserRole | null), { replace: true });
+      } catch {
+        navigate('/app', { replace: true });
+      }
+    })();
   }, [initialized, session, navigate]);
 
   return (

--- a/src/lib/auth/defaultRouteForRole.ts
+++ b/src/lib/auth/defaultRouteForRole.ts
@@ -1,0 +1,49 @@
+/**
+ * defaultRouteForRole — THI-235 Sprint 2.A étape 2.ter post-login adaptive routing.
+ *
+ * After successful login (AuthCallback), if no explicit returnTo was stored,
+ * navigate the user to the most useful default route for their role.
+ *
+ * Industry pattern 2026 (DAR Design) : "preference, not restriction" — the
+ * default view adapts to the role naturally, without onboarding wizard or
+ * setup prompt. A super_admin landing on /app/admin saves 1-2 clicks per
+ * session vs landing on the student dashboard.
+ *
+ * Validated empirically 19/05/2026 : @thierry as super_admin landed on /app
+ * post-GitHub OAuth and had to manually click "Mes classes" / sidebar entries
+ * to reach his control panels. The role-aware default closes that gap.
+ *
+ * Precedence in AuthCallback :
+ *   1. consumeReturnTo() returns a valid path → use it (user-explicit intent
+ *      from a gated route fallback "Se connecter" click)
+ *   2. role available → defaultRouteForRole(role)
+ *   3. role lookup failed → '/app' (safe fallback, dashboard student-style)
+ *
+ * Sprint 2.B will add /app/institution + /app/teacher/pending routes — when
+ * those exist, this map will redirect those roles there. Today they fall
+ * back to /app to avoid 404 routes (defensive).
+ */
+import type { UserRole } from '@/app/types/database';
+
+const ROLE_DEFAULT_ROUTES: Record<UserRole, string> = {
+  // super_admin lands on the supervision panel — that's their "home"
+  super_admin: '/app/admin',
+  // teacher lands on Mes classes — the create-class + share-code flow
+  teacher: '/app/teacher',
+  // institution_admin will land on /app/institution once Sprint 2.B ships it.
+  // Today fallback to /app (student dashboard) — they still see role-gated
+  // entries in the Sidebar + cards in StaffQuickActions if applicable.
+  institution_admin: '/app',
+  // pending_teacher will land on /app/teacher/pending once Sprint 2.B ships
+  // the verification status page. Today fallback to /app.
+  pending_teacher: '/app',
+  // student lands on the standard Dashboard — modules, progression, terminal
+  student: '/app',
+};
+
+const SAFE_FALLBACK = '/app';
+
+export function defaultRouteForRole(role: UserRole | null | undefined): string {
+  if (!role) return SAFE_FALLBACK;
+  return ROLE_DEFAULT_ROUTES[role] ?? SAFE_FALLBACK;
+}

--- a/src/lib/auth/returnToStorage.ts
+++ b/src/lib/auth/returnToStorage.ts
@@ -43,19 +43,38 @@ export function setReturnTo(path: string): void {
 
 /**
  * Read AND immediately clear the stored returnTo path. Validates against
- * the open-redirect allowlist before returning. Returns the safe fallback
- * (`/app`) if the stored value is missing, invalid, or storage is unavailable.
+ * the open-redirect allowlist before returning.
+ *
+ * Returns :
+ *   - `string` : a validated safe path (`/app/...`) the caller should
+ *     navigate to. Indicates the user had an explicit returnTo intent.
+ *   - `null` : no value stored, value rejected by validation (XSS scenario),
+ *     or storage unavailable. The caller should apply its own default
+ *     (e.g. adaptive route per role via `defaultRouteForRole`).
  *
  * Read-and-clear (single call) is intentional : a returnTo is one-shot,
  * we never want it to survive multiple login flows.
+ *
+ * Defense-in-depth : a rejected value is treated as `null` (not the
+ * `/app` fallback) so the caller cannot conflate "user intended to go to
+ * /app" with "an XSS-injected malicious value was stripped". This lets
+ * AuthCallback apply role-based adaptive routing in the latter case.
  */
-export function consumeReturnTo(): string {
-  if (typeof window === 'undefined') return '/app';
+export function consumeReturnTo(): string | null {
+  if (typeof window === 'undefined') return null;
   try {
     const stored = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
     window.sessionStorage.removeItem(STORAGE_KEY);
-    return validateReturnTo(stored);
+    const validated = validateReturnTo(stored);
+    // validateReturnTo returns '/app' as its safe fallback for invalid input.
+    // If the stored value was literally '/app' the user genuinely wanted /app
+    // (preserve their intent). If the stored value was anything else AND came
+    // back as '/app', validation rejected it — return null so the caller
+    // applies the role-adaptive default instead of the bare fallback.
+    if (validated === '/app' && stored !== '/app') return null;
+    return validated;
   } catch {
-    return '/app';
+    return null;
   }
 }

--- a/src/test/defaultRouteForRole.test.ts
+++ b/src/test/defaultRouteForRole.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for defaultRouteForRole — THI-235 Sprint 2.A étape 2.ter.
+ *
+ * Covers the role → default landing route mapping used post-login when
+ * no explicit returnTo was stored. Sprint 2.B will extend the institution_admin
+ * + pending_teacher mappings to /app/institution + /app/teacher/pending
+ * once those routes ship; today both fallback to /app (safe).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { defaultRouteForRole } from '../lib/auth/defaultRouteForRole';
+
+describe('defaultRouteForRole — staff roles get role-specific landing', () => {
+  it('super_admin → /app/admin (supervision panel)', () => {
+    expect(defaultRouteForRole('super_admin')).toBe('/app/admin');
+  });
+
+  it('teacher → /app/teacher (Mes classes)', () => {
+    expect(defaultRouteForRole('teacher')).toBe('/app/teacher');
+  });
+});
+
+describe('defaultRouteForRole — Sprint 2.B placeholder roles fallback to /app', () => {
+  it('institution_admin → /app (until Sprint 2.B ships /app/institution)', () => {
+    expect(defaultRouteForRole('institution_admin')).toBe('/app');
+  });
+
+  it('pending_teacher → /app (until Sprint 2.B ships /app/teacher/pending)', () => {
+    expect(defaultRouteForRole('pending_teacher')).toBe('/app');
+  });
+});
+
+describe('defaultRouteForRole — student + missing role get safe fallback', () => {
+  it('student → /app (standard Dashboard)', () => {
+    expect(defaultRouteForRole('student')).toBe('/app');
+  });
+
+  it('null role (RPC failed, defensive) → /app', () => {
+    expect(defaultRouteForRole(null)).toBe('/app');
+  });
+
+  it('undefined role → /app', () => {
+    expect(defaultRouteForRole(undefined)).toBe('/app');
+  });
+});
+
+describe('defaultRouteForRole — defensive against future role additions', () => {
+  it('unknown role (TypeScript bypass) → /app fallback, never throws', () => {
+    // @ts-expect-error - deliberately passing an unknown role to test the defensive fallback
+    expect(defaultRouteForRole('future_role_not_yet_defined')).toBe('/app');
+  });
+
+  it('empty string role → /app fallback', () => {
+    // @ts-expect-error - empty string is not a valid UserRole
+    expect(defaultRouteForRole('')).toBe('/app');
+  });
+});

--- a/src/test/returnToStorage.test.ts
+++ b/src/test/returnToStorage.test.ts
@@ -1,18 +1,18 @@
 /**
- * Tests for returnToStorage — THI-235 Sprint 2.A étape 2.bis.
+ * Tests for returnToStorage — THI-235 Sprint 2.A étape 2.bis + 2.ter.
  *
  * Covers :
  *   - setReturnTo writes to sessionStorage
  *   - consumeReturnTo reads + clears + validates atomically
- *   - returns safe fallback on invalid stored value (attacker XSS scenario)
- *   - silently no-ops when sessionStorage is unavailable (SSR / private browsing)
- *   - one-shot semantics : second consume returns fallback (cleared by first)
+ *   - returns null when no value, invalid value, or storage unavailable
+ *   - returns the validated path when stored value is safe
+ *   - one-shot semantics : second consume returns null (cleared by first)
+ *   - special case : if stored value is literally '/app', return it (don't
+ *     conflate with the validateReturnTo `/app` rejection fallback)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setReturnTo, consumeReturnTo } from '../lib/auth/returnToStorage';
-
-const SAFE_FALLBACK = '/app';
 
 beforeEach(() => {
   window.sessionStorage.clear();
@@ -31,50 +31,55 @@ describe('setReturnTo + consumeReturnTo — happy path', () => {
   it('clears the storage after consume (one-shot semantics)', () => {
     setReturnTo('/app/admin');
     expect(consumeReturnTo()).toBe('/app/admin');
-    // second call returns fallback because storage was cleared
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    // second call returns null because storage was cleared
+    expect(consumeReturnTo()).toBeNull();
   });
 
-  it('stores and consumes /app (the safe fallback path itself)', () => {
+  it('stores and consumes literal /app (the safe fallback path itself)', () => {
+    // Edge case : the user explicitly stored '/app' as their returnTo.
+    // Validate that we preserve this intent (not conflate with the
+    // validateReturnTo `/app` rejection fallback).
     setReturnTo('/app');
     expect(consumeReturnTo()).toBe('/app');
   });
 });
 
-describe('consumeReturnTo — validation at read time', () => {
-  it('returns safe fallback when no value stored', () => {
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+describe('consumeReturnTo — returns null when no explicit intent', () => {
+  it('returns null when no value stored', () => {
+    expect(consumeReturnTo()).toBeNull();
   });
 
-  it('returns safe fallback when malicious value is in storage (XSS scenario)', () => {
+  it('returns null when malicious value is in storage (XSS scenario)', () => {
     // Simulate an XSS attack that wrote a malicious value directly to sessionStorage
     window.sessionStorage.setItem('auth_return_to', 'https://evil.com');
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    expect(consumeReturnTo()).toBeNull();
     // storage is still cleared even on rejection
     expect(window.sessionStorage.getItem('auth_return_to')).toBeNull();
   });
 
-  it('returns safe fallback on protocol-relative URL', () => {
+  it('returns null on protocol-relative URL', () => {
     window.sessionStorage.setItem('auth_return_to', '//evil.com/app');
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    expect(consumeReturnTo()).toBeNull();
   });
 
-  it('returns safe fallback on javascript: URI', () => {
+  it('returns null on javascript: URI', () => {
     window.sessionStorage.setItem('auth_return_to', 'javascript:alert(1)');
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    expect(consumeReturnTo()).toBeNull();
   });
 
-  it('returns safe fallback on path traversal', () => {
+  it('returns null on path traversal', () => {
     window.sessionStorage.setItem('auth_return_to', '/app/../etc/passwd');
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    expect(consumeReturnTo()).toBeNull();
+  });
+
+  it('returns null on empty string', () => {
+    window.sessionStorage.setItem('auth_return_to', '');
+    expect(consumeReturnTo()).toBeNull();
   });
 });
 
 describe('setReturnTo — defensive when storage unavailable', () => {
   it('silently no-ops when sessionStorage.setItem throws', () => {
-    // We test the contract "does not throw"; spy invocation is implementation
-    // detail (vitest jsdom may proxy through globalThis.sessionStorage which
-    // is not the same instance as window.sessionStorage in some setups).
     const proto = Object.getPrototypeOf(window.sessionStorage) as Storage;
     vi.spyOn(proto, 'setItem').mockImplementation(() => {
       throw new Error('QuotaExceededError');
@@ -84,11 +89,11 @@ describe('setReturnTo — defensive when storage unavailable', () => {
 });
 
 describe('consumeReturnTo — defensive when storage unavailable', () => {
-  it('returns safe fallback when sessionStorage.getItem throws', () => {
+  it('returns null when sessionStorage.getItem throws', () => {
     vi.spyOn(window.sessionStorage, 'getItem').mockImplementation(() => {
       throw new Error('SecurityError');
     });
-    expect(consumeReturnTo()).toBe(SAFE_FALLBACK);
+    expect(consumeReturnTo()).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #269 (étape 2.bis) : @thierry empirically validated a UX gap during his GitHub OAuth login flow as super_admin — he landed on `/app` (student dashboard) instead of `/app/admin` (his supervision panel). This was decision E (adaptive routing per role) initially deferred to Sprint 2.B as "opinionated v2", but his empirical validation confirms it should ship in Sprint 2.A.

Industry pattern 2026 alignment : DAR Design "preference, not restriction" — default view adapts to role naturally.

## Redirect precedence in AuthCallback

1. **`consumeReturnTo()` returns valid path** → use it (user came from a gated route fallback "Se connecter" click, their explicit intent)
2. **No explicit returnTo** → lookup role via `get_my_role()` RPC + `defaultRouteForRole(role)`:
   - `super_admin` → `/app/admin` (supervision panel)
   - `teacher` → `/app/teacher` (Mes classes)
   - `institution_admin` → `/app` (Sprint 2.B will extend to `/app/institution`)
   - `pending_teacher` → `/app` (Sprint 2.B will extend to `/app/teacher/pending`)
   - `student` → `/app` (standard Dashboard)
3. **RPC failure / no role** → safe fallback `/app`

## Files

### New
- `src/lib/auth/defaultRouteForRole.ts` — role → default route mapping (`Record<UserRole, string>` + null fallback)
- `src/test/defaultRouteForRole.test.ts` — 9 tests : staff routes, fallbacks, null/undefined role, defensive against unknown future roles

### Modified
- `src/lib/auth/returnToStorage.ts` — `consumeReturnTo()` API refactor : returns `string | null`. The caller can now distinguish "user had explicit returnTo intent" from "no intent / invalid value → apply role-adaptive default"
- `src/app/components/auth/AuthCallback.tsx` — new redirect precedence (returnTo prime + adaptive fallback async IIFE wrapped, `redirected.current` ref protects against double-fires)
- `src/test/returnToStorage.test.ts` — full rewrite for the new `string | null` API. Edge case preserved : if user genuinely stored `/app`, return `/app` (not null)

## Threat model — open-redirect protection PRESERVED

The `validateReturnTo` allowlist regex + 7 defense layers from PR #269 are unchanged. The API refactor only changes how AuthCallback DISTINGUISHES "no intent" from "invalid intent" — both lead to the safe role-adaptive default, never to an attacker-controlled path.

**XSS scenario** : attacker writes malicious value to sessionStorage → `consumeReturnTo` returns `null` → AuthCallback falls through to adaptive route per role → worst case student lands on /app (their default anyway). **No privilege escalation possible.**

## Cascade pré-merge

| Check | Verdict |
|---|---|
| Type-check | ✅ Clean |
| Lint | ✅ Clean |
| Test | ✅ 1604 passed / 20 skipped |
| Build | ✅ Clean in 4.35s, no new chunks |
| Self-review | ✅ Voir summary |

## Test plan

- [ ] CI green
- [ ] Sourcery review
- [ ] Vercel preview deployed
- [ ] Voie A Chrome MCP : anonymous + super_admin flow
- [ ] Tests E2E multi-personas (via rbac-flow-tester agent + Supabase MCP SQL impersonation)
- [x] **Merge autonome** (carte blanche @thierry ce soir — il a validé en avance, je ship sans nouvelle validation visuelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Met en place un routage par défaut après connexion tenant compte du rôle, tout en préservant les protections contre les redirections ouvertes.

Nouvelles fonctionnalités :
- Rediriger les utilisateurs vers une page par défaut spécifique à leur rôle après connexion lorsqu’aucun `returnTo` explicite n’est présent (par exemple, `super_admin` vers `/app/admin`, `teacher` vers `/app/teacher`, les autres vers `/app`).

Améliorations :
- Affiner l’API de stockage de `returnTo` pour distinguer entre l’intention explicite de l’utilisateur et les valeurs manquantes ou invalides, permettant une logique de redirection adaptative plus claire dans le callback d’authentification.

Tests :
- Ajouter des tests unitaires pour `defaultRouteForRole` couvrant tous les rôles et le comportement de repli, et mettre à jour les tests de `returnToStorage` pour couvrir le nouveau contrat de retour `null` ainsi que les scénarios XSS / valeurs invalides.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement role-aware default post-login routing while preserving open-redirect protections.

New Features:
- Route users to a role-specific default page after login when no explicit returnTo is present (e.g. super_admin to /app/admin, teacher to /app/teacher, others to /app).

Enhancements:
- Refine the returnTo storage API to distinguish between explicit user intent and missing or invalid values, enabling cleaner adaptive redirect logic in the auth callback.

Tests:
- Add unit tests for defaultRouteForRole covering all roles and fallback behavior, and update returnToStorage tests to cover the new null-return contract and XSS/invalid-value scenarios.

</details>