### PR TITLE
fix(ai): Haiku 4.5 → Sonnet 4.6 default model + AI tutor reactivation prod

### DIFF
--- a/src/lib/ai/providers/anthropic.ts
+++ b/src/lib/ai/providers/anthropic.ts
@@ -20,7 +20,7 @@ import { safeCancel, streamSseEvents } from './_sse';
 
 export const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
 export const ANTHROPIC_VERSION = '2023-06-01';
-export const ANTHROPIC_DEFAULT_MODEL = 'claude-haiku-4-5';
+export const ANTHROPIC_DEFAULT_MODEL = 'claude-sonnet-4-6';
 export const ANTHROPIC_MAX_TOKENS = 1024;
 
 interface ContentBlockDelta {

--- a/src/test/ai/providers/anthropic.test.ts
+++ b/src/test/ai/providers/anthropic.test.ts
@@ -61,7 +61,7 @@ describe('Anthropic chat — request shape', () => {
     await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -76,7 +76,7 @@ describe('Anthropic chat — request shape', () => {
     await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -95,7 +95,7 @@ describe('Anthropic chat — request shape', () => {
     await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'SYS',
         messages: [
           { role: 'user', content: 'q1' },
@@ -125,7 +125,7 @@ describe('Anthropic chat — request shape', () => {
     await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -152,7 +152,7 @@ describe('Anthropic chat — streaming + errors', () => {
     const out = await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -171,7 +171,7 @@ describe('Anthropic chat — streaming + errors', () => {
     const out = await collect(
       await chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -184,7 +184,7 @@ describe('Anthropic chat — streaming + errors', () => {
     await expect(
       chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),
@@ -196,7 +196,7 @@ describe('Anthropic chat — streaming + errors', () => {
     await expect(
       chat({
         apiKey: FAKE_KEY,
-        model: 'claude-haiku-4-5',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'hi' }],
       }),


### PR DESCRIPTION
## Contexte

Issue #225 (P3 cosmétique) signalait un glitch streaming "je je" spécifique à Haiku 4.5.
Décision @thierry 21/05 : éviter Haiku 4.5 (perçu non fiable pour pédagogie FR), bascule Sonnet 4.6.

**Découverte parallèle** : le tuteur IA était DÉSACTIVÉ en prod depuis ~17 jours
(`VITE_AI_TUTOR_ENABLED=""`) — oubli rollout post-ship PR #188 (THI-111 livré 4/05),
pas de désactivation explicite traçable. Réactivation simultanée avec le changement modèle.

## Audit `prompt-guardrail-auditor` — Verdict GO 9.4/10 (inchangé)

1. ✅ **Constants change** : pas de risque sécurité, amélioration probable robustesse guardrail (Sonnet meilleure adhérence system prompt vs Haiku)
2. ✅ **System prompt** : v1.1.0 model-agnostic (XML delimiters), aucune re-calibration requise
3. ✅ **Issue #225 hypothèse 2 INFIRMÉE** par lecture code : `sanitizeModelChunk` stateless ne peut pas produire de préfixe orphelin. Bug = artefact Haiku 4.5, disparait mécaniquement avec Sonnet.
4. ✅ **Réactivation safe** : défenses identiques à état ALL CLEAR du 16/05 (sanitizer + system prompt + Sentry scrubber + rate-limit soft)

## Changes

### Code
- `src/lib/ai/providers/anthropic.ts:23` :
  `ANTHROPIC_DEFAULT_MODEL = 'claude-haiku-4-5'` → `'claude-sonnet-4-6'`
- `src/test/ai/providers/anthropic.test.ts` : 8 occurrences mises à jour

### Vercel env (production) — déjà appliqué
- `VITE_AI_TUTOR_ENABLED` : `""` → `"true"` (réactivation)
- `VITE_AI_TUTOR_OPENROUTER_MODEL` : `""` → `"anthropic/claude-sonnet-4-6"`

### Memos
- `feedback_llm_hallucinations_inter_phrase.md` : ajout section décision 21/05 (Llama 70B → Haiku 4.5 → Sonnet 4.6 = 3 itérations qualité tuteur IA)

## Test plan

- [x] vitest 1635 passed (1635 / 1655 incl. skipped)
- [x] type-check clean
- [x] lint clean
- [x] sentry-tunnel prod actif (HTTP 400 sur POST vide, endpoint vivant)
- [x] `prompt-guardrail-auditor` PASS 9.4/10
- [ ] CI verte (post-push)
- [ ] Voie A Chrome MCP : preview Vercel → AI tutor visible + drawer ouvre + sélection provider Anthropic affiche claude-sonnet-4-6

## Issue #225 fermeture (post-merge)

Verdict à publier sur l'issue :
- Hypothèse 1 (artefact Haiku) : confirmée vraisemblable
- Hypothèse 2 (sanitizer concat) : **INFIRMÉE** par audit lecture code
- Hypothèse 3 (hallucination Haiku) : confirmée vraisemblable
- Action : bascule Sonnet 4.6 → bug attendu disparu mécaniquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)