### PR TITLE
fix(ai): cohérence Settings ↔ Drawer model + transparence header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,9 @@ SENTRY_VERCEL_LOG_DRAIN_URL=https://your-log-drain-url
 VITE_AI_TUTOR_ENABLED=false
 
 # Default model for first-time users (they can override per-message in UI).
-# Production uses Anthropic Claude Haiku 4.5 via OpenRouter (cf. ADR-005).
-VITE_AI_TUTOR_OPENROUTER_MODEL=anthropic/claude-haiku-4-5
+# Production uses Anthropic Claude Sonnet 4.6 via OpenRouter (cf. ADR-005,
+# PR #279 model upgrade decision 21 mai 2026).
+VITE_AI_TUTOR_OPENROUTER_MODEL=anthropic/claude-sonnet-4-6
 
 # ─── Resend (Phase 9 Sprint 2.C — Support emails) ─────────────────────────────
 # Server-side only, **NEVER** in client bundle. Production scope only by

--- a/src/app/components/AiSettings.tsx
+++ b/src/app/components/AiSettings.tsx
@@ -34,7 +34,7 @@ import {
   isEncrypted as kmIsEncrypted,
   type Provider,
 } from '@/lib/ai/keyManager';
-import { DEFAULT_MODELS } from '@/lib/ai/providers';
+import { resolveModel } from '@/lib/ai/providers';
 import { PROVIDER_LABELS } from '@/lib/ai/providers/meta';
 import {
   CONSENT_KEY,
@@ -199,9 +199,9 @@ export function AiSettings() {
                   <div className="min-w-0">
                     <p className="font-medium">{PROVIDER_LABELS[s.provider]}</p>
                     <p className="mt-1 text-xs text-[var(--github-text-secondary)]">
-                      Modèle par défaut :{' '}
+                      Modèle utilisé :{' '}
                       <code className="rounded bg-[var(--github-bg-tertiary)] px-1 py-0.5">
-                        {DEFAULT_MODELS[s.provider]}
+                        {resolveModel(s.provider)}
                       </code>
                     </p>
                     <p className="mt-2 text-sm">

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -26,7 +26,7 @@ import {
   PROVIDER_KEY,
   type Provider,
 } from '@/lib/ai/keyManager';
-import { DEFAULT_MODELS } from '@/lib/ai/providers';
+import { getModelLabel, resolveModel } from '@/lib/ai/providers';
 import { PROVIDER_LABELS } from '@/lib/ai/providers/meta';
 import type { TutorLang } from '@/lib/ai/systemPrompt';
 import { useAiTutor } from '@/lib/ai/useAiTutor';
@@ -70,23 +70,11 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
-  // Allow each provider's default model to be overridden at deploy time via
-  // a Vercel env var, e.g. `VITE_AI_TUTOR_OPENROUTER_MODEL=meta-llama/llama-
-  // 3.3-70b-instruct` to escape the `:free` rate-limit pool. Falls back to
-  // DEFAULT_MODELS when the var is unset. The full picker UI lands in
-  // THI-112 V1.5 — this is the V1 escape hatch.
-  const envOverride = useMemo<string | undefined>(() => {
-    switch (provider) {
-      case 'openrouter':
-        return import.meta.env.VITE_AI_TUTOR_OPENROUTER_MODEL as string | undefined;
-      case 'anthropic':
-        return import.meta.env.VITE_AI_TUTOR_ANTHROPIC_MODEL as string | undefined;
-      case 'openai':
-        return import.meta.env.VITE_AI_TUTOR_OPENAI_MODEL as string | undefined;
-      case 'gemini':
-        return import.meta.env.VITE_AI_TUTOR_GEMINI_MODEL as string | undefined;
-    }
-  }, [provider]);
+  // Single source of truth for "which model is actually used" — `resolveModel`
+  // reads the Vercel env override `VITE_AI_TUTOR_<PROVIDER>_MODEL` first and
+  // falls back to `DEFAULT_MODELS` only when the var is unset. Same helper is
+  // used by `AiSettings` so the two surfaces never disagree.
+  const model = useMemo(() => resolveModel(provider), [provider]);
 
   // THI-148 V1.0.1 — static, public-only platform overview injected as
   // <platform_context>. Same trust class as lessonContext (curriculum data,
@@ -96,7 +84,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
 
   const tutor = useAiTutor({
     provider,
-    model: envOverride && envOverride.length > 0 ? envOverride : DEFAULT_MODELS[provider],
+    model,
     lang,
     lessonContext,
     platformContext,
@@ -242,7 +230,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
                 // close button off-screen.
                 className="min-w-0 truncate text-sm font-semibold text-[var(--github-text-primary)]"
               >
-                Tuteur IA — {PROVIDER_LABELS[provider]}
+                Tuteur IA — {PROVIDER_LABELS[provider]} • {getModelLabel(model)}
               </h2>
               <div className="flex shrink-0 items-center gap-2">
                 <RateLimitBadge

--- a/src/lib/ai/providers/index.ts
+++ b/src/lib/ai/providers/index.ts
@@ -37,6 +37,57 @@ export const DEFAULT_MODELS: Readonly<Record<Provider, string>> = {
   gemini: GEMINI_DEFAULT_MODEL,
 };
 
+/**
+ * Single source of truth for "which model is actually used" — reads the
+ * deploy-time Vercel env override `VITE_AI_TUTOR_<PROVIDER>_MODEL` first,
+ * falls back to `DEFAULT_MODELS` only when the env var is unset/empty.
+ *
+ * Settings page and Drawer panel must use this helper to avoid the bug
+ * where Settings showed the hardcoded fallback (e.g. Llama 3.3 70B free)
+ * while the Drawer used the env override (e.g. Sonnet 4.6 paid).
+ */
+export function resolveModel(provider: Provider): string {
+  const envKeys: Readonly<Record<Provider, string>> = {
+    openrouter: 'VITE_AI_TUTOR_OPENROUTER_MODEL',
+    anthropic: 'VITE_AI_TUTOR_ANTHROPIC_MODEL',
+    openai: 'VITE_AI_TUTOR_OPENAI_MODEL',
+    gemini: 'VITE_AI_TUTOR_GEMINI_MODEL',
+  };
+  const override = import.meta.env[envKeys[provider]] as string | undefined;
+  return override && override.length > 0 ? override : DEFAULT_MODELS[provider];
+}
+
+/**
+ * Normalises a provider model id (e.g. `anthropic/claude-sonnet-4-6`) to a
+ * short, human-friendly label (e.g. `Sonnet 4.6`) for display in the Drawer
+ * header. Falls back to the raw id when the pattern is unknown — keeps the
+ * UI honest rather than hiding mysterious models behind a generic label.
+ *
+ * Transparency principle: every authenticated or anonymous user must see
+ * which model is actually answering their prompts (BYOK consent, EU AI Act,
+ * RGPD, CNIL Éducation). No role gating.
+ */
+export function getModelLabel(modelId: string): string {
+  const lower = modelId.toLowerCase();
+  // Claude family
+  if (lower.includes('sonnet-4-6')) return 'Sonnet 4.6';
+  if (lower.includes('sonnet-4-5')) return 'Sonnet 4.5';
+  if (lower.includes('haiku-4-5')) return 'Haiku 4.5';
+  if (lower.includes('opus-4-7')) return 'Opus 4.7';
+  // OpenAI family
+  if (lower.includes('gpt-4o-mini')) return 'GPT-4o mini';
+  if (lower.includes('gpt-4o')) return 'GPT-4o';
+  // Gemini family
+  if (lower.includes('gemini-2.0-flash')) return 'Gemini 2.0 Flash';
+  if (lower.includes('gemini-1.5-pro')) return 'Gemini 1.5 Pro';
+  if (lower.includes('gemini-1.5-flash')) return 'Gemini 1.5 Flash';
+  // Llama family
+  if (lower.includes('llama-3.3-70b')) return 'Llama 3.3 70B';
+  if (lower.includes('llama-3.1-70b')) return 'Llama 3.1 70B';
+  // Fallback: return raw id so the user still sees something honest.
+  return modelId;
+}
+
 export function chat(provider: Provider, params: ChatParams): Promise<ChatStream> {
   switch (provider) {
     case 'openrouter':

--- a/src/test/ai/AiTutorPanel.test.tsx
+++ b/src/test/ai/AiTutorPanel.test.tsx
@@ -231,3 +231,34 @@ describe('AiTutorPanel — conversation', () => {
     expect(localStorage.getItem('ai_key_openrouter')).toBeNull();
   });
 });
+
+// Transparency: every user (any role, even anonymous) must see which model
+// is actually answering their prompts. No gating. The model secret is not a
+// security boundary — the guardrail is system prompt + sanitizer + post-filter.
+describe('AiTutorPanel — header displays the active model (transparency)', () => {
+  it('header includes the model label when an env override is set', async () => {
+    vi.stubEnv('VITE_AI_TUTOR_ENABLED', 'true');
+    vi.stubEnv('VITE_AI_TUTOR_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4-6');
+
+    const user = userEvent.setup();
+    render(<AiTutorPanel />);
+    await user.click(screen.getByLabelText(/Ouvrir le tuteur IA/));
+
+    const heading = await screen.findByRole('heading', { level: 2 });
+    expect(heading.textContent).toContain('OpenRouter');
+    expect(heading.textContent).toContain('Sonnet 4.6');
+  });
+
+  it('header falls back to the default model label when no env override is set', async () => {
+    vi.stubEnv('VITE_AI_TUTOR_ENABLED', 'true');
+
+    const user = userEvent.setup();
+    render(<AiTutorPanel />);
+    await user.click(screen.getByLabelText(/Ouvrir le tuteur IA/));
+
+    const heading = await screen.findByRole('heading', { level: 2 });
+    expect(heading.textContent).toContain('OpenRouter');
+    // The OpenRouter default is the free Llama; label = "Llama 3.3 70B".
+    expect(heading.textContent).toContain('Llama 3.3 70B');
+  });
+});

--- a/src/test/ai/providers/resolveModel.test.ts
+++ b/src/test/ai/providers/resolveModel.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ANTHROPIC_DEFAULT_MODEL,
+  DEFAULT_MODELS,
+  GEMINI_DEFAULT_MODEL,
+  OPENAI_DEFAULT_MODEL,
+  OPENROUTER_DEFAULT_MODEL,
+  getModelLabel,
+  resolveModel,
+} from '@/lib/ai/providers';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('resolveModel — env override > fallback', () => {
+  it('returns the OpenRouter env override when set', () => {
+    vi.stubEnv('VITE_AI_TUTOR_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4-6');
+    expect(resolveModel('openrouter')).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('returns the Anthropic env override when set', () => {
+    vi.stubEnv('VITE_AI_TUTOR_ANTHROPIC_MODEL', 'claude-opus-4-7');
+    expect(resolveModel('anthropic')).toBe('claude-opus-4-7');
+  });
+
+  it('returns the OpenAI env override when set', () => {
+    vi.stubEnv('VITE_AI_TUTOR_OPENAI_MODEL', 'gpt-4o');
+    expect(resolveModel('openai')).toBe('gpt-4o');
+  });
+
+  it('returns the Gemini env override when set', () => {
+    vi.stubEnv('VITE_AI_TUTOR_GEMINI_MODEL', 'gemini-1.5-pro');
+    expect(resolveModel('gemini')).toBe('gemini-1.5-pro');
+  });
+
+  it('falls back to DEFAULT_MODELS when env override is empty string', () => {
+    vi.stubEnv('VITE_AI_TUTOR_OPENROUTER_MODEL', '');
+    expect(resolveModel('openrouter')).toBe(OPENROUTER_DEFAULT_MODEL);
+  });
+
+  it('falls back to DEFAULT_MODELS when env override is unset', () => {
+    // No stubEnv call — the var is undefined in the test environment.
+    expect(resolveModel('anthropic')).toBe(ANTHROPIC_DEFAULT_MODEL);
+  });
+
+  it('DEFAULT_MODELS map matches the per-provider constants', () => {
+    expect(DEFAULT_MODELS.openrouter).toBe(OPENROUTER_DEFAULT_MODEL);
+    expect(DEFAULT_MODELS.anthropic).toBe(ANTHROPIC_DEFAULT_MODEL);
+    expect(DEFAULT_MODELS.openai).toBe(OPENAI_DEFAULT_MODEL);
+    expect(DEFAULT_MODELS.gemini).toBe(GEMINI_DEFAULT_MODEL);
+  });
+});
+
+describe('getModelLabel — short human-friendly labels', () => {
+  it('normalises Claude Sonnet 4.6', () => {
+    expect(getModelLabel('anthropic/claude-sonnet-4-6')).toBe('Sonnet 4.6');
+    expect(getModelLabel('claude-sonnet-4-6')).toBe('Sonnet 4.6');
+  });
+
+  it('normalises Claude Haiku 4.5', () => {
+    expect(getModelLabel('anthropic/claude-haiku-4-5')).toBe('Haiku 4.5');
+    expect(getModelLabel('claude-haiku-4-5')).toBe('Haiku 4.5');
+  });
+
+  it('normalises Claude Opus 4.7', () => {
+    expect(getModelLabel('claude-opus-4-7')).toBe('Opus 4.7');
+  });
+
+  it('normalises GPT-4o and GPT-4o mini (mini before generic gpt-4o)', () => {
+    expect(getModelLabel('gpt-4o-mini')).toBe('GPT-4o mini');
+    expect(getModelLabel('openai/gpt-4o')).toBe('GPT-4o');
+  });
+
+  it('normalises Gemini variants', () => {
+    expect(getModelLabel('gemini-2.0-flash')).toBe('Gemini 2.0 Flash');
+    expect(getModelLabel('google/gemini-1.5-pro')).toBe('Gemini 1.5 Pro');
+  });
+
+  it('normalises Llama 3.3 70B', () => {
+    expect(getModelLabel('meta-llama/llama-3.3-70b-instruct:free')).toBe('Llama 3.3 70B');
+  });
+
+  it('returns the raw id when the pattern is unknown (honest fallback)', () => {
+    expect(getModelLabel('unknown/mystery-model-v2')).toBe('unknown/mystery-model-v2');
+  });
+});

--- a/src/test/app/AiSettings.test.tsx
+++ b/src/test/app/AiSettings.test.tsx
@@ -8,7 +8,7 @@
  * what the test runner already pre-loads.
  */
 import 'fake-indexeddb/auto';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
@@ -18,6 +18,7 @@ import {
   forgetKey as kmForgetKey,
   saveKey as kmSaveKey,
 } from '@/lib/ai/keyManager';
+import { OPENROUTER_DEFAULT_MODEL } from '@/lib/ai/providers';
 import { CONSENT_KEY, CONSENT_TTL_MS, CONSENT_VERSION } from '@/lib/ai/useAiTutor';
 
 const FAKE_OPENROUTER = 'sk-or-v1-FAKE_TEST_KEY_DO_NOT_USE_0123456789';
@@ -176,5 +177,42 @@ describe('AiSettings — accessibility landmarks', () => {
     await screen.findByText('OpenRouter');
     const region = screen.getByRole('region', { name: /Clés API par provider/i });
     expect(within(region).getByText('OpenRouter')).toBeInTheDocument();
+  });
+});
+
+// Regression test for the Settings ↔ Drawer model inconsistency bug.
+// Pre-fix: AiSettings read DEFAULT_MODELS[provider] (hardcoded fallback,
+// e.g. Llama 3.3 70B free for OpenRouter) while AiTutorPanel used the
+// Vercel env override (e.g. Sonnet 4.6 paid). A user could read the
+// Settings page, believe they were paying for the free fallback, and be
+// billed for the paid model the Drawer was actually calling.
+// Post-fix: both surfaces resolve the same model via `resolveModel()`.
+describe('AiSettings — Settings/Drawer model consistency (regression)', () => {
+  it('displays the env override value when set (not the hardcoded fallback)', async () => {
+    vi.stubEnv('VITE_AI_TUTOR_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4-6');
+    try {
+      renderSettings();
+      await screen.findByText('OpenRouter');
+      // The env override must be visible inside the OpenRouter row.
+      expect(await screen.findByText('anthropic/claude-sonnet-4-6')).toBeInTheDocument();
+      // The hardcoded fallback must NOT be visible when override is set.
+      expect(screen.queryByText(OPENROUTER_DEFAULT_MODEL)).not.toBeInTheDocument();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('falls back to the hardcoded default when no env override is set', async () => {
+    renderSettings();
+    await screen.findByText('OpenRouter');
+    expect(await screen.findByText(OPENROUTER_DEFAULT_MODEL)).toBeInTheDocument();
+  });
+
+  it('uses the "Modèle utilisé" label (transparency wording, not "défaut")', async () => {
+    renderSettings();
+    await screen.findByText('OpenRouter');
+    expect(screen.getAllByText(/Modèle utilisé/i).length).toBeGreaterThan(0);
+    // The pre-fix wording must NOT appear anymore on the page.
+    expect(screen.queryByText(/Modèle par défaut/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Bug racine

@thierry a découvert via `/app/settings` que le « Modèle par défaut » affiché pour OpenRouter = `meta-llama/llama-3.3-70b-instruct:free` (fallback hardcoded), alors que le drawer AI Tutor utilise en prod `anthropic/claude-sonnet-4-6` (Vercel env override, PR #279).

**Conséquence** : surprise facturation BYOK (user croit Llama free, paie Sonnet ~$3/M tokens), perte de confiance.

**Cause** : `AiSettings.tsx:204` et `AiTutorPanel.tsx:99` lisaient deux sources différentes.

## Fix racine — Single source of truth

Nouveau helper exporté `resolveModel(provider)` dans `src/lib/ai/providers/index.ts` :
```ts
export function resolveModel(provider: Provider): string {
  const override = import.meta.env[envKeys[provider]];
  return override && override.length > 0 ? override : DEFAULT_MODELS[provider];
}
```

Les deux composants utilisent maintenant cet helper (DRY).

## Bonus — Transparence header drawer

Header drawer : `Tuteur IA — OpenRouter` → `Tuteur IA — OpenRouter • Sonnet 4.6`

**Pour tous les rôles** (pas de gating). Décision produit verrouillée @thierry 21/05 :
- Le modèle n'est pas un secret (visible DevTools, bundle JS)
- Security through obscurity = anti-pattern
- BYOK = droit éthique de savoir ce qu'on paye
- Compliance EU AI Act + RGPD + CNIL Éducation pour pitch institutions/écoles

Le guardrail anti-prompt-injection reste backend (system prompt + sanitizer + post-filter — audit `prompt-guardrail-auditor` 9.4/10 du 16/05 inchangé).

## Changes

| Fichier | Modif |
|---|---|
| `src/lib/ai/providers/index.ts` | +`resolveModel()` +`getModelLabel()` |
| `src/app/components/AiSettings.tsx` | DRY refactor + wording "Modèle utilisé" |
| `src/app/components/ai/AiTutorPanel.tsx` | DRY refactor + header label modèle |
| `.env.example` ligne 42 | Haiku 4.5 → Sonnet 4.6 |
| `src/test/ai/providers/resolveModel.test.ts` | NEW (14 tests) |
| `src/test/app/AiSettings.test.tsx` | +3 tests régression |
| `src/test/ai/AiTutorPanel.test.tsx` | +2 tests header transparence |

## Hors scope (différé PR-B post-merge)

- Constantes `<PROVIDER>_MODELS: ModelOption[]` curées
- Picker UI inline drawer (user-side choice)
- Persistence localStorage par provider
- Tests reliability per modèle (peut nécessiter API real calls)

## Test plan

- [x] vitest **1654 passed** (+19 vs main, 0 failed)
- [x] type-check clean
- [x] lint clean
- [x] build 3.88s clean
- [ ] CI verte (post-push)
- [ ] Sourcery silent ou findings traités
- [ ] Voie A Chrome MCP : confirme Settings + Drawer affichent tous deux Sonnet 4.6
- [ ] Voie A multi-personas : student / teacher / super_admin → tous voient ` • Sonnet 4.6` (transparence universelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)