### PR TITLE
fix(ui): tooltip header drawer Tuteur IA — révéler modèle tronqué

### DIFF
--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -227,8 +227,11 @@ export function AiTutorPanel({ lang = 'fr', lessonContext }: Props) {
                 // THI-152 brick 6/9: `min-w-0 truncate` lets the title
                 // shrink and clip on narrow viewports (iPhone SE) when
                 // the provider label is long, instead of pushing the
-                // close button off-screen.
+                // close button off-screen. The `title` attribute exposes
+                // the full string on hover (desktop) / long-press (mobile)
+                // so the model name stays discoverable when truncated.
                 className="min-w-0 truncate text-sm font-semibold text-[var(--github-text-primary)]"
+                title={`Tuteur IA — ${PROVIDER_LABELS[provider]} • ${getModelLabel(model)}`}
               >
                 Tuteur IA — {PROVIDER_LABELS[provider]} • {getModelLabel(model)}
               </h2>

--- a/src/test/ai/AiTutorPanel.test.tsx
+++ b/src/test/ai/AiTutorPanel.test.tsx
@@ -261,4 +261,20 @@ describe('AiTutorPanel — header displays the active model (transparency)', () 
     // The OpenRouter default is the free Llama; label = "Llama 3.3 70B".
     expect(heading.textContent).toContain('Llama 3.3 70B');
   });
+
+  it('header `title` attribute exposes the full string for truncated viewports', async () => {
+    vi.stubEnv('VITE_AI_TUTOR_ENABLED', 'true');
+    vi.stubEnv('VITE_AI_TUTOR_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4-6');
+
+    const user = userEvent.setup();
+    render(<AiTutorPanel />);
+    await user.click(screen.getByLabelText(/Ouvrir le tuteur IA/));
+
+    const heading = await screen.findByRole('heading', { level: 2 });
+    // Tooltip mirrors the visible text so hover/long-press reveals the full
+    // model name when the title is clipped by `truncate`.
+    expect(heading.getAttribute('title')).toBe(
+      'Tuteur IA — OpenRouter • Sonnet 4.6',
+    );
+  });
 });


### PR DESCRIPTION
## Bug observé @thierry

Sur viewport étroit (Brave compact), le header drawer post-PR #280 `Tuteur IA — OpenRouter • Sonnet 4.6` est tronqué en `Sonn...` par le CSS `truncate` THI-152 brick 6/9 (préserver le bouton X dans le viewport).

L'info reste visible dans /app/settings mais perd la lisibilité dans le drawer.

## Fix mini (~10 lignes)

Attribut HTML `title={...}` sur le `<h2>`. Comportement natif browser :
- Desktop : tooltip on hover ~1s
- Mobile : long-press révèle
- Screen readers : annoncé

Zéro impact layout, zéro nouvelle dépendance.

## Test plan

- [x] vitest 15/15 passed (AiTutorPanel scope)
- [x] type-check clean
- [x] lint clean
- [ ] CI verte
- [ ] Voie A Chrome MCP : confirmer tooltip visible au hover sur preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)