### PR TITLE
docs(claude): refactor session protocol — invoquer session-orchestrator + /obsidian-session-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,27 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - **`vercel-firewall-auditor`** — lit la config Vercel Firewall active (WAF, managed rules, custom rules) et exécute une batterie de tests HTTP live contre `terminallearning.dev` pour confirmer que les rules bloquent bien les patterns d'attaque et laissent passer les users légitimes. Nécessite `$VERCEL_TOKEN` en session. Lancer avant chaque release majeure ou après toute modification firewall. Détails : `docs/vercel-firewall.md`.
 - **`prompt-guardrail-auditor`** — audit sécurité LLM (OWASP LLM Top 10) du Tuteur IA (BYOK OpenRouter — ADR-002 + ADR-005) : prompt injection, jailbreaks, prompt leaks, role enforcement, bypass sanitizer, XSS sur rendu réponse, fuite clé API. **Obligatoire avant toute PR touchant `src/lib/ai/*` ou `src/app/components/ai/*`.** CRITICAL = bloque le merge. Créé AVANT implémentation (THI-109, gate zéro ADR-005) pour éviter la surprise en fin de chantier.
 - **`route-attack-auditor`** — audit HTTP-level black-hat des endpoints `api/*` : status code fingerprinting, verb tampering, cache poisoning via 503, slowloris, side-channel timing, header smuggling, CORS edge cases, body guards, rate limit bypass, info disclosure. Tests live via `curl`. **Obligatoire avant toute PR touchant `api/*` ou après création d'un nouvel endpoint.** Complémentaire à `security-auditor` (qui couvre l'app layer) et `vercel-firewall-auditor` (qui couvre WAF). Créé suite au sprint sécurité 1-2 mai (lacune route-level identifiée).
+- **`session-orchestrator`** — orchestrateur de session, exécute les phases startup et shutdown dans son contexte isolé (économie tokens main agent). Lit les memos CC `session_startup_process.md` et `session_shutdown_process.md`, fait les checks d'état (git + GitHub + Linear + health check prod + banner scan plan.md/ROADMAP.md + freshness markers), met à jour les .md vitaux en shutdown, et produit un rapport structuré 8 sections avec recommandation des sous-agents à lancer ensuite par le main agent. **À invoquer en début de chaque session (mode `startup`) ET en fin (mode `shutdown`)**. Ne peut pas invoquer d'autres agents (limitation runtime CC) — il RECOMMANDE leurs prompts prêts-à-coller.
 
 ### Début de chaque session
+**Méthode primaire (en parallèle)** :
+1. Invoquer l'agent **`session-orchestrator`** mode `startup`. Il lit `session_startup_process.md`, exécute les Phases 0→4 (model check + contexte/mémoire + état projet + **health check prod** + **banner scan plan/ROADMAP** + challenge personnel), recommande `linear-sync` au main agent, et produit un rapport go/no-go.
+2. Invoquer le skill **`/obsidian-session-sync`** mode startup. Il lit le vault Athenaeum via MCP `claude-code-mcp` : daily note + sources of truth + handoffs @cowork pending. Critique en mode trio binôme (@cowork ↔ @cc-tl ↔ @thierry).
+
+**Méthode dégradée** (fallback si les outils ne sont pas invoqués) :
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés
-2. `git status` + `git log --oneline -5` → état de la branche courante
-3. Lire l'issue Linear active avant d'écrire la moindre ligne
+2. `git status` + `git log --oneline -5` + `gh pr list --state open` → état de la branche courante + scope projet
+3. Health check prod (4× `curl https://terminallearning.dev/...`) + CI main (`gh run list --branch main --limit 3`)
+4. Read **lignes 1-5 uniquement** de `docs/plan.md` + `docs/ROADMAP.md` (banner statut)
+5. Lire l'issue Linear active avant d'écrire la moindre ligne
+6. Si vault Athenaeum accessible : lire daily note + handoffs @cowork manuellement (fallback du skill Obsidian)
 
 ### Fin de chaque session — récap obligatoire avant "stop"
+**Méthode primaire (en parallèle)** :
+1. Invoquer l'agent **`session-orchestrator`** mode `shutdown`. Il lit `session_shutdown_process.md`, exécute les 10 phases (état local + PRs ouvertes début ET final + audit agents par fichier modifié + mémoires CC + Linear sync exhaustif + .md vitaux + freshness markers + ADR libre + rapport 8 sections).
+2. Invoquer le skill **`/obsidian-session-sync`** mode shutdown. Il écrit dans le vault Athenaeum : décisions/learnings/blockers, crée des Zettels si pattern réutilisable, dépose un rapport pour @cowork (symbiose multi-agents).
+
+**Méthode dégradée** (fallback) :
 1. ✅ `git status` clean (rien d'uncommit ou stagé sans raison documentée)
 2. ✅ `gh pr list --state open` → **lister TOUTES les PRs ouvertes**, pas seulement celles de la session
 3. Pour chaque PR ouverte > 7 jours : la mentionner explicitement avec date + statut CI/Sourcery/Vercel + action attendue (validation utilisateur, merge, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 1. Invoquer l'agent **`linear-sync`** → analyser son rapport, corriger les statuts Linear signalés
 2. `git status` + `git log --oneline -5` + `gh pr list --state open` → état de la branche courante + scope projet
 3. Health check prod (4× `curl https://terminallearning.dev/...`) + CI main (`gh run list --branch main --limit 3`)
-4. Read **lignes 1-5 uniquement** de `docs/plan.md` + `docs/ROADMAP.md` (banner statut)
+4. Lire **lignes 1-5 uniquement** de `docs/plan.md` + `docs/ROADMAP.md` (banner statut)
 5. Lire l'issue Linear active avant d'écrire la moindre ligne
 6. Si vault Athenaeum accessible : lire daily note + handoffs @cowork manuellement (fallback du skill Obsidian)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,11 +198,14 @@ Toute PR DOIT être validée visuellement avant merge, SAUF exception explicite 
 - Durée : 30 secondes max, pas de babysitting
 - Limite : pas adaptée si scope PR > 1-2 pages à tester en profondeur
 
-**Voie C — Skip validation visuelle (exceptionnel, conditions cumulatives)**
+**Voie C — Skip validation visuelle PROFONDE (exceptionnel, conditions cumulatives)**
 - PR 100% docs (`*.md` seulement, ou `docs/`)
 - 0 fichier `src/`, `api/`, `supabase/`, `package.json`, `vercel.json`, ou tout fichier impactant runtime
 - CI verte + Sourcery vert (ou SKIPPED rate-limit acceptable)
-- Mention obligatoire dans le message merge : "Voie C — docs-only, scope vérifié, 0 risque runtime"
+- **Smoke test preview OBLIGATOIRE** (≠ validation visuelle profonde) — codifié 23 mai 2026 : `curl` HTTP 200 sur 4-8 endpoints clés (`/`, `/app`, `/sitemap.xml` + page modifiée si applicable) via pattern bypass header. Confirme que le deploy n'a pas cassé l'app et qu'aucune régression silencieuse n'est introduite (cf. PR #283 où sitemap servi ≠ sitemap committé à cause d'un script prebuild caché).
+- Mention obligatoire dans le message merge : "Voie C — docs-only, scope vérifié, 0 risque runtime, smoke test preview PASS"
+
+**Règle d'or préview** : TOUJOURS vérifier la preview Vercel quand cela se justifie, même en Voie C. Le smoke test minimal (`curl` HTTP 200 + spot-check du contenu modifié) prend 10 secondes et attrape des régressions silencieuses qu'aucun check CI ne détecte (cf. incident sitemap PR #283 — CI verte + Vercel SUCCESS mais contenu obsolète servi à cause d'un build script qui écrasait le fichier).
 
 ### Sécurité tokens bypass — input ET output side (codifié 17 mai 2026)
 - **JAMAIS `curl -I`** sur URL Vercel protégée : la response `Set-Cookie: _vercel_jwt=<JWT>` contient le RAW bypass token dans son payload base64-décodable. Capter ce header en tool result = compromission du contexte de conversation.


### PR DESCRIPTION
## Summary

Refactor de la section **Protocole de session** dans `CLAUDE.md` pour pointer vers les outils orchestrateurs existants au lieu de répéter les checklists en clair.

**Motivation** : session 23 mai 2026 — j'ai oublié d'invoquer `session-orchestrator` au démarrage et exécuté les checks à la main. @thierry m'a aussi rappelé que :
- Le **health check projet** (`curl` prod + CI main) n'était PAS dans le protocole startup, alors qu'il détecte les régressions silencieuses entre 2 sessions
- Le **scan banner** `plan.md` / `ROADMAP.md` (lignes 1-5 seulement) n'était PAS codifié
- La **sync Obsidian Athenaeum** (skill `/obsidian-session-sync`) n'était pas mentionnée dans le protocole de session

Incident type que cette PR évite : `VITE_AI_TUTOR_ENABLED=""` est resté désactivé 17 jours en prod sans détection après PR #188 (mai 2026). Un health check au démarrage attrape ça en 30 sec.

## Changes

### `CLAUDE.md`
- **Ajout `session-orchestrator`** dans la liste des agents disponibles (description complète : orchestrateur startup/shutdown isolé qui recommande les sous-agents au main agent)
- **Section "Début de chaque session"** : méthode primaire = invoquer `session-orchestrator` + skill `/obsidian-session-sync` en parallèle. Méthode dégradée préservée comme fallback (6 étapes enrichies : linear-sync, git status + gh pr list, **health check prod**, **banner scan plan/ROADMAP**, Linear actif, Obsidian manuel)
- **Section "Fin de chaque session"** : méthode primaire = `session-orchestrator` mode shutdown + `/obsidian-session-sync` mode shutdown. Méthode dégradée préservée

### Memo local CC (`session_startup_process.md`, hors repo)
Refonte v2 en parallèle :
- **Phase 1.bis NEW** : Sync Obsidian Athenaeum
- **Phase 2.bis NEW** : Health check projet (4× curl prod + CI main + LTI/AI Tutor flags)
- **Phase 2.ter NEW** : Banner scan plan.md/ROADMAP.md/docs-README (lignes 1-5 uniquement)
- **Phase 3 enrichie** : nouvelle question sur fichiers générés au build (cf. incident PR #283 du même jour)
- **Rapport startup attendu** structuré 7 sections
- **Fallback** documenté si orchestrator pas invoqué

## Bénéfices

- ✅ **Une seule règle d'or** à retenir : "invoquer session-orchestrator au démarrage ET en fin"
- ✅ **Sub-agent isolé** : tous les checks tournent dans son contexte, pas dans le main agent (économie tokens)
- ✅ **Single source of truth** : le memo `session_startup_process.md` détaille tout, `CLAUDE.md` reste léger
- ✅ **Health check intégré** : impossible d'oublier de vérifier la prod entre 2 sessions
- ✅ **Symbiose Obsidian** : `/obsidian-session-sync` codifié comme partie intégrante du protocole
- ✅ **Métrique de succès** : @thierry n'aura plus à expliquer manuellement quelle étape a été oubliée

## Test plan

- [ ] CI green (type-check + lint + test + build)
- [ ] Sourcery review clean (ou skipped rate-limit)
- [ ] **Voie C éligible — docs-only**
  - 1 fichier modifié : `CLAUDE.md`
  - 0 `src/`, 0 `api/`, 0 `supabase/`, 0 `package.json`, 0 `vercel.json`
  - 0 risque runtime (purement documentation des process humain↔agent)
- [ ] Test fonctionnel post-merge : prochaine session, vérifier que session-orchestrator est bien invoqué dès le démarrage (et que `/obsidian-session-sync` tourne en parallèle)

## Related

- Memo local enrichi en parallèle : `session_startup_process.md` v2 (hors repo, dans la mémoire CC de @thierry)
- Agent référencé : `.claude/agents/session-orchestrator.md` (déjà dans le repo, design intentionnel mais non invoqué par défaut jusqu'à cette PR)
- Skill référencé : `/obsidian-session-sync` (disponible via plugin Obsidian-Claude)
- Incident motivant : session 23 mai 2026 — health check manqué + protocole startup sous-utilisé

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Met à jour la documentation du protocole de session afin de s’appuyer sur l’orchestrateur de session dédié et les outils de synchronisation Obsidian pour les workflows de démarrage et d’arrêt.

Documentation :
- Documenter l’agent `session-orchestrator` comme point d’entrée principal pour le démarrage et l’arrêt des sessions.
- Réviser les sections « Début/Fin de chaque session » pour décrire les principaux flux orchestrés avec la synchronisation Obsidian et conserver une checklist manuelle de secours concise.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the session protocol documentation to rely on the dedicated session orchestrator and Obsidian sync tools for startup and shutdown workflows.

Documentation:
- Document the `session-orchestrator` agent as the primary entry point for session startup and shutdown.
- Revise the "Début/Fin de chaque session" sections to describe primary orchestrated flows with Obsidian sync and retain a concise manual fallback checklist.

</details>