### PR TITLE
chore(agents): night stress-test fixes — typo CHANGELOG + sustain tools + Haiku→Sonnet upgrades

### DIFF
--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -2,7 +2,7 @@
 name: content-auditor
 description: Full pedagogical content audit — checks env coverage, curriculum↔terminalEngine consistency, test coverage, external link validity, narrative markdown internal links, prerequisite chain logic, and validate() function quality. Run on demand or before major releases. Returns a structured report.
 tools: Read, Grep, Glob, WebFetch
-model: haiku
+model: sonnet
 ---
 
 Tu es un auditeur de contenu pédagogique pour Terminal Learning.

--- a/.claude/agents/sustain-auditor.md
+++ b/.claude/agents/sustain-auditor.md
@@ -1,6 +1,7 @@
 ---
 name: sustain-auditor
 description: Quarterly sustainability health check for solo maintainer — document freshness, git pattern analysis (weekend/night commits, streaks), Sentry alert load, memory drift. Outputs 1-10 health score + warnings + recommendations. Trigger manual (comment) or scheduled quarterly.
+tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -2,7 +2,7 @@
 name: test-runner
 description: Run vitest + type-check + lint, detect leaked .only/.skip isolation, flag code-vs-test delta imbalance, and surface missing coverage (commands & validators). Invoke after any modification to curriculum.ts, terminalEngine.ts, validators.ts, or test files. Filters verbose output — only surfaces failures and gaps.
 tools: Bash, Read, Grep
-model: haiku
+model: sonnet
 ---
 
 Tu es un analyseur de résultats de tests + qualité statique pour Terminal Learning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Voie A Chrome MCP empirique post-fix : clic « Se connecter » depuis `/app/join
 
 **Sprint 2.A — toutes étapes Done** : PRs #266 (étape 1) + #268 (étape 2) + #269 (étape 2.bis) + #270 (étape 2.ter) + **#274 (étape 3)**.
 
-**Cf.** PR [#274](https://github.com/thierryvm/teerminalLearning/pull/274), [THI-235](https://linear.app/thierryvm/issue/THI-235) umbrella, [STORY.md](STORY.md) chapitre Sprint 2.A étape 3 narratif 1ère personne.
+**Cf.** PR [#274](https://github.com/thierryvm/TerminalLearning/pull/274), [THI-235](https://linear.app/thierryvm/issue/THI-235) umbrella, [STORY.md](STORY.md) chapitre Sprint 2.A étape 3 narratif 1ère personne.
 
 ---
 


### PR DESCRIPTION
## Summary

Suite à l'audit complet des 17 agents `.claude/agents/*` lancé par @cc-tl en autonomie nocturne 23/05 ~22h-23h CEST. **4 fixes triviaux groupés** issus des findings cross-agents.

## Audit context

7 agents invoqués empiriquement (security-auditor, ui-auditor, content-auditor, test-runner, llm-security-auditor, sustain-auditor, vercel-firewall-auditor) — tous claims file:line challengés contre Linear + GitHub + filesystem. **Pattern majeur observé** : Haiku 4.5 produit des claims qualitatifs fiables MAIS hallucine sur les dénombrements (test counts off by 38%, "356+ describes" alors que réel = 62, etc.).

## Changes

### 1. `CHANGELOG.md` L114 — typo URL GitHub
`teerminalLearning` → `TerminalLearning` (URL cassée 404, finding `content-auditor`)

### 2. `.claude/agents/sustain-auditor.md` — frontmatter `tools:` ajouté
Ajout `tools: Bash, Read, Grep, Glob` (bug doctrine : champ absent avant cette PR, hérité implicitement par runtime). Auto-identifié par `sustain-auditor` lui-même en self-critique de son rapport — preuve que la méthode "self-critique Couche 7" fonctionne.

### 3. `.claude/agents/content-auditor.md` — upgrade Haiku → Sonnet
**Justification** : `content-auditor` (Haiku) a annoncé "356+ describe blocks" alors que réel = **62** (off by 5.7×). Counts de lignes off by 1. Son scope inclut dénombrement (env coverage, count leçons, count tests) → besoin de précision chiffrée → Sonnet justifié.

### 4. `.claude/agents/test-runner.md` — upgrade Haiku → Sonnet
**Justification** : `test-runner` (Haiku) a annoncé "56 test files" alors que réel = **77** (off by -38%). Scope = count vitest + count untested commands + delta analysis = dénombrement constant → Sonnet justifié.

## Distinction Haiku-OK vs Haiku-KO codifiée

| Scope | Haiku adapté ? | Exemple |
|---|---|---|
| **Cite file:line exact** | ✅ OK | `ui-auditor` (Haiku) cite Sidebar.tsx:124, NotFound.tsx:105-107 — TOUS exacts |
| **Dénombrement avec extrapolation** | ❌ KO | `content-auditor` "356+ describes" (réel 62), `test-runner` "56 files" (réel 77) |

Donc `ui-auditor` conserve son modèle Haiku 4.5 (scope cite, pas count). Pattern d'upgrade cohérent avec PR #276 du 20/05 sur `prompt-guardrail-auditor` et `rbac-flow-tester`.

## Tickets connexes créés cette nuit

- **THI-263** [HIGH] AI Tutor encrypted mode BROKEN — `AiTutorPanel` ne passe pas passphrase à `useAiTutor`. **A1 HIGH VERIFIED inédit** trouvé par `llm-security-auditor` Opus 7 couches (raté par les 3 audits du 16/05).
- **THI-264** [MEDIUM] Vercel Firewall docs drift — `case-sensitive` incorrect dans `docs/vercel-firewall.md:58` + faux positifs UA non documentés (W2).

## Test plan

- [ ] CI green (type-check + lint + test + build)
- [ ] Sourcery review clean (ou skipped rate-limit)
- [ ] **Smoke test preview obligatoire** (Voie C codifiée 23/05) : `curl` HTTP 200 sur 4-8 endpoints + sitemap regression
- [ ] Voie C éligible : 1 fichier CHANGELOG.md (docs) + 3 fichiers `.claude/agents/` (instructions agents — pas runtime), 0 risque exec
- [ ] Mention merge : "Voie C — docs+agents-only, scope vérifié, 0 risque runtime, smoke test preview PASS"

## Audit complet déposé

Rapport consolidé `terminal-learning/cc-handoffs/2026-05-23-NNNN-agents-stress-test-night.md` dans Obsidian (déposé après merge de cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Correction de l’URL de la documentation et ajustement de la configuration des agents Claude suite aux conclusions de l’audit.

Corrections de bugs :
- Correction d’un lien de dépôt GitHub cassé dans le changelog.

Améliorations :
- Mise à niveau des agents `content-auditor` et `test-runner` pour utiliser le modèle Sonnet afin d’obtenir une analyse quantitative plus précise.
- Déclaration explicite des outils Bash, Read, Grep et Glob dans la configuration de l’agent `sustain-auditor`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix documentation URL and adjust Claude agents configuration following audit findings.

Bug Fixes:
- Correct a broken GitHub repository link in the changelog.

Enhancements:
- Upgrade the content-auditor and test-runner agents to use the Sonnet model for more accurate quantitative analysis.
- Explicitly declare Bash, Read, Grep, and Glob tools in the sustain-auditor agent configuration.

</details>