### PR TITLE
docs(landing): refresh public roadmap — Stage B1+B2 livrés + scope 2026 actuel

### DIFF
--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -69,27 +69,33 @@ export const ROADMAP_AVAILABLE = [
   'Parcours guidé par niveaux',
   'Partage natif (Web Share API)',
   'Accessibilité mobile & clavier (WCAG 2.2 AAA, safe-area iOS, focus-visible)',
-  'Sécurité durcie — endpoints LTI gated, rate limiting partagé, CSP SHA-256 (THI-133/134/135)',
-  'Audit sécurité fresh — score 8.1/10, 0 critique (1 mai 2026)',
-  'Tuteur IA V1 (BYOK OpenRouter / Anthropic / Gemini, sanitizer + 287 tests, derrière feature flag) — THI-111',
+  'Sécurité durcie — endpoints LTI gated, rate limiting partagé, CSP SHA-256, audit IA security 9.2/10 (24 mai 2026)',
+  'Tuteur IA — multi-rôles cloisonnés (élève / enseignant / institution / super-admin) avec 4 providers BYOK (OpenRouter / Anthropic / OpenAI / Gemini) — Stage B1 eval matrix frontier 2025-2026 + Stage B2 system prompts par rôle',
+  'Onboarding tuteur IA — configuration clé (mode chiffré AES-GCM/PBKDF2 opt-in) + consent RGPD versionné + page /app/settings',
+  'LTI 1.3 Phase 7c — RS256 JWK validation + nonceStore replay protection + audit log Supabase (THI-131)',
+  'Espace enseignant — création de classe, partage code invitation, dashboard élèves (Sprint 2.A)',
+  'Panel super-admin — supervision plateforme + agents Claude Code (20 agents spécialisés sécurité, RBAC, AI, juridique, forensique)',
 ];
 
 export const ROADMAP_IN_PROGRESS = [
   "Extension du curriculum — nouveaux modules & exercices",
   "Plus d'exercices pratiques & quiz par section",
   'Guide d\'installation PWA (iOS / Android / Desktop)',
-  'Tuteur IA V1.5 — picker modèle (allow-list curated) + onboarding clé chiffrée + AiKeySetup tutoriel — THI-112',
-  'Terminal Sentinel — audit sécurité automatisé',
-  'LTI 1.3 — Phase 7c (RS256 JWK validation, persistence Supabase, grade passback)',
+  'Tuteur IA Stage B3 — picker UI modèle filtré par rôle (whitelist data-driven Stage B1)',
+  'Tuteur IA Stage B1.b — eval matrix multi-turn × 4 rôles (gate audit Opus 7 couches final)',
+  'Phase 9 Admin Panel — widgets analytics gratuits (GitHub Insights + Vercel + Supabase + Sentry, budget 0€)',
+  'Sprint 2.B — institution_admin lite + InstitutionAdminPanel + approve_teacher RPC (deadline 10 juin)',
+  'SEO/GEO/AEO foundation — Schema.org enrichi + landing NL pré-i18n + DPA template B2B écoles (Sprint 2.5)',
 ];
 
 export const ROADMAP_PLANNED = [
   'Mode histoire narratif',
-  'Multilingue (FR / NL / EN / DE) — Belgique tri-lingue',
+  'Multilingue complet (FR / NL / EN / DE) — Belgique tri-lingue, traductions tuteur IA staff + curriculum',
   'Badges & Open Badges 3.0 (CEFR + EQF)',
   'Révisions intelligentes',
-  'Dashboards par rôle — étudiant / professeur / formateur / institution / super-admin',
+  'Web Worker isolation tuteur IA — vraie défense vs extension navigateur malveillante (V1.5, THI-114)',
   'Parcours avancés (Docker, scripting, IA augmentée)',
+  'Tuteur IA chat assistant contextualisé par rôle — usage opérationnel teacher/admin pour gestion classes (Phase 9+)',
 ];
 
 // ── Supporters (Hall of Fame) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Refresh de la **roadmap publique** sur `terminallearning.dev` (section "Roadmap publique" en bas de la landing). Accumulait ~7 jours de drift par rapport à la réalité projet — audience B2B écoles regarde cette section pour évaluer la maturité, signal de fraîcheur important.

## Drift identifié (avant)

**"Disponible"** :
- Score audit sécurité figé à « 8.1/10 (1 mai 2026) » → réalité 9.2/10 post-Stage B1
- Tuteur IA V1 mentionné « derrière feature flag » → en réalité actif en production
- **Manquaient** : Stage B1+B2 multi-rôle, LTI Phase 7c (livré 16 mai), Espace enseignant Sprint 2.A, panel super-admin + 20 agents

**"En cours"** :
- ❌ THI-112 « onboarding clé chiffrée + AiKeySetup » = **Done depuis le 16 mai** (PR #228)
- ❌ LTI Phase 7c = **Done depuis le 16 mai** (PR #236+237)
- Manquaient : Stage B3 picker, Stage B1.b multi-turn, Phase 9 Admin Panel, Sprint 2.B, SEO Sprint 2.5

**"Plus tard"** :
- « Dashboards par rôle » raffiné (Sprint 2.A déjà livré Teacher Dashboard + super_admin)
- Ajouts : Web Worker isolation tuteur IA (THI-114 V1.5), Tuteur IA chat assistant role-based Phase 9+
- Multilingue : précisé « traductions tuteur IA staff + curriculum » (cohérent avec FR-only Stage B2)

## Scope

- 1 fichier modifié : `src/app/data/landingContent.ts` (3 arrays exportés)
- 0 logique runtime modifiée (juste contenu affiché)
- Aucun test pinné sur le wording exact (les tests landing checkent les compteurs lessons/commands)

## Test plan

- [x] Lint OK · type-check OK · 1701 tests PASS / 0 régression
- [ ] CI verte
- [ ] Smoke test Chrome MCP preview Vercel — scroll bas landing pour visuel 3 colonnes Disponible/En cours/Plus tard
- [ ] Merge → smoke prod

## Voie A obligatoire

PR touche `src/` (contenu affiché publiquement sur la landing). Voie A Chrome MCP recommandée pour vérifier rendu 3 colonnes + lisibilité items longs (certaines lignes Disponible sont plus verbeuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)