### PR TITLE
refactor(landing): roadmap publique groupée par catégories sémantiques — pattern premium 2026

### DIFF
--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -477,54 +477,81 @@ export function Landing() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Available */}
             <div className="p-5 rounded-xl border border-emerald-500/20 bg-emerald-500/5">
-              <div className="flex items-center gap-2 mb-4">
+              <div className="flex items-center gap-2 mb-5">
                 <CheckCircle2 size={16} className="text-emerald-400" aria-hidden="true" />
                 <span className="text-emerald-400 text-sm font-semibold">Disponible</span>
                 <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 font-mono">live</span>
               </div>
-              <ul className="space-y-2">
-                {ROADMAP_AVAILABLE.map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)]">
-                    <span className="text-emerald-400 mt-0.5 shrink-0">✓</span>
-                    {item}
-                  </li>
+              <div className="space-y-4">
+                {ROADMAP_AVAILABLE.map((group) => (
+                  <div key={group.group}>
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-emerald-400/80 mb-1.5">
+                      {group.group}
+                    </h3>
+                    <ul className="space-y-1.5">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)] leading-snug">
+                          <span className="text-emerald-400 mt-0.5 shrink-0">✓</span>
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
 
             {/* In progress */}
             <div className="p-5 rounded-xl border border-blue-500/20 bg-blue-500/5">
-              <div className="flex items-center gap-2 mb-4">
+              <div className="flex items-center gap-2 mb-5">
                 <span className="w-4 h-4 flex items-center justify-center shrink-0" aria-hidden="true">
                   <span className="w-3 h-3 rounded-full bg-blue-400 animate-pulse" />
                 </span>
                 <span className="text-blue-400 text-sm font-semibold">En cours</span>
                 <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-mono">beta</span>
               </div>
-              <ul className="space-y-2">
-                {ROADMAP_IN_PROGRESS.map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)]">
-                    <Zap size={12} className="text-blue-400 mt-0.5 shrink-0" aria-hidden="true" />
-                    {item}
-                  </li>
+              <div className="space-y-4">
+                {ROADMAP_IN_PROGRESS.map((group) => (
+                  <div key={group.group}>
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-blue-400/80 mb-1.5">
+                      {group.group}
+                    </h3>
+                    <ul className="space-y-1.5">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)] leading-snug">
+                          <Zap size={12} className="text-blue-400 mt-0.5 shrink-0" aria-hidden="true" />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
 
             {/* Planned */}
             <div className="p-5 rounded-xl border border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
-              <div className="flex items-center gap-2 mb-4">
+              <div className="flex items-center gap-2 mb-5">
                 <Clock size={16} className="text-amber-400" aria-hidden="true" />
                 <span className="text-[var(--github-text-secondary)] text-sm font-semibold">Plus tard</span>
               </div>
-              <ul className="space-y-2">
-                {ROADMAP_PLANNED.map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)]">
-                    <span className="w-3 h-3 rounded-full border border-[var(--github-border-primary)] mt-0.5 shrink-0" aria-hidden="true" />
-                    {item}
-                  </li>
+              <div className="space-y-4">
+                {ROADMAP_PLANNED.map((group) => (
+                  <div key={group.group}>
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-amber-400/80 mb-1.5">
+                      {group.group}
+                    </h3>
+                    <ul className="space-y-1.5">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2 text-xs text-[var(--github-text-secondary)] leading-snug">
+                          <span className="w-3 h-3 rounded-full border border-[var(--github-border-primary)] mt-0.5 shrink-0" aria-hidden="true" />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
           </div>
         </FadeIn>

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -58,44 +58,116 @@ export const FEATURES = [
 
 // ── Roadmap ───────────────────────────────────────────────────────────────────
 
-export const ROADMAP_AVAILABLE = [
-  '11 modules progressifs (navigation → IA pour dev)',
-  'Terminal interactif avec validation',
-  'Dashboard de progression',
-  'Sauvegarde locale + cloud (optionnel)',
-  `Référence enrichie (${TOTAL_COMMANDS}+ commandes)`,
-  "Sélection d'environnement Linux / macOS / Windows",
-  'Adaptation des commandes par OS',
-  'Parcours guidé par niveaux',
-  'Partage natif (Web Share API)',
-  'Accessibilité mobile & clavier (WCAG 2.2 AAA, safe-area iOS, focus-visible)',
-  'Sécurité durcie — endpoints LTI gated, rate limiting partagé, CSP SHA-256, audit IA security 9.2/10 (24 mai 2026)',
-  'Tuteur IA — multi-rôles cloisonnés (élève / enseignant / institution / super-admin) avec 4 providers BYOK (OpenRouter / Anthropic / OpenAI / Gemini) — Stage B1 eval matrix frontier 2025-2026 + Stage B2 system prompts par rôle',
-  'Onboarding tuteur IA — configuration clé (mode chiffré AES-GCM/PBKDF2 opt-in) + consent RGPD versionné + page /app/settings',
-  'LTI 1.3 Phase 7c — RS256 JWK validation + nonceStore replay protection + audit log Supabase (THI-131)',
-  'Espace enseignant — création de classe, partage code invitation, dashboard élèves (Sprint 2.A)',
-  'Panel super-admin — supervision plateforme + agents Claude Code (20 agents spécialisés sécurité, RBAC, AI, juridique, forensique)',
+/**
+ * Roadmap structure — pattern premium 2026 (Stripe / Linear / Vercel
+ * changelog) avec sous-groupes sémantiques au lieu d'une flat list.
+ *
+ * - `group` : libellé court du pilier (ex: "Tuteur IA")
+ * - `items` : 2-4 features livrées dans ce pilier, chaque item ≤ 1 ligne
+ *   (les détails THI-XXX et versions vont en parenthèses fin de ligne)
+ *
+ * Refonte UX 24/05/2026 soir suite feedback @thierry (PR #295 → screenshot
+ * asymétrie 16/8/7 + items 3-5 lignes pas premium 2026 → cette PR).
+ */
+export interface RoadmapGroup {
+  group: string;
+  items: readonly string[];
+}
+
+export const ROADMAP_AVAILABLE: readonly RoadmapGroup[] = [
+  {
+    group: 'Curriculum',
+    items: [
+      '11 modules progressifs (navigation → IA pour dev)',
+      'Terminal interactif avec validation',
+      `Référence enrichie (${TOTAL_COMMANDS}+ commandes)`,
+      'Parcours guidé par niveaux + Dashboard de progression',
+    ],
+  },
+  {
+    group: 'Multi-OS',
+    items: [
+      'Linux / macOS / Windows — sélection + adaptation par OS',
+      'Partage natif (Web Share API)',
+    ],
+  },
+  {
+    group: 'Tuteur IA',
+    items: [
+      'Multi-rôles cloisonnés (élève / enseignant / institution / super-admin)',
+      '4 providers BYOK (OpenRouter / Anthropic / OpenAI / Gemini)',
+      'Onboarding clé chiffrée (AES-GCM opt-in) + consent RGPD',
+      'Audit IA security 9.2/10 (24 mai 2026)',
+    ],
+  },
+  {
+    group: 'Plateforme B2B',
+    items: [
+      'Espace enseignant — classes, code invitation, dashboard élèves',
+      'Panel super-admin + 20 agents Claude Code spécialisés',
+      'LTI 1.3 Phase 7c — JWK validation + replay protection',
+    ],
+  },
+  {
+    group: 'Qualité',
+    items: [
+      'Accessibilité WCAG 2.2 AAA (safe-area iOS, focus-visible)',
+      'Sécurité durcie (CSP SHA-256, rate limiting, endpoints gated)',
+      'Sauvegarde locale + cloud (optionnel)',
+    ],
+  },
 ];
 
-export const ROADMAP_IN_PROGRESS = [
-  "Extension du curriculum — nouveaux modules & exercices",
-  "Plus d'exercices pratiques & quiz par section",
-  'Guide d\'installation PWA (iOS / Android / Desktop)',
-  'Tuteur IA Stage B3 — picker UI modèle filtré par rôle (whitelist data-driven Stage B1)',
-  'Tuteur IA Stage B1.b — eval matrix multi-turn × 4 rôles (gate audit Opus 7 couches final)',
-  'Phase 9 Admin Panel — widgets analytics gratuits (GitHub Insights + Vercel + Supabase + Sentry, budget 0€)',
-  'Sprint 2.B — institution_admin lite + InstitutionAdminPanel + approve_teacher RPC (deadline 10 juin)',
-  'SEO/GEO/AEO foundation — Schema.org enrichi + landing NL pré-i18n + DPA template B2B écoles (Sprint 2.5)',
+export const ROADMAP_IN_PROGRESS: readonly RoadmapGroup[] = [
+  {
+    group: 'Tuteur IA V1.5',
+    items: [
+      'Stage B3 — picker UI modèle filtré par rôle',
+      'Stage B1.b — eval matrix multi-turn × 4 rôles',
+    ],
+  },
+  {
+    group: 'Plateforme B2B',
+    items: [
+      'Phase 9 Admin Panel — widgets gratuits (GitHub + Vercel + Supabase + Sentry)',
+      'Sprint 2.B — institution_admin (deadline 10 juin)',
+      'SEO/GEO/AEO — Schema.org + landing NL + DPA template écoles',
+    ],
+  },
+  {
+    group: 'Curriculum',
+    items: [
+      'Extension nouveaux modules & exercices',
+      'Plus d\'exercices pratiques & quiz par section',
+      'Guide d\'installation PWA (iOS / Android / Desktop)',
+    ],
+  },
 ];
 
-export const ROADMAP_PLANNED = [
-  'Mode histoire narratif',
-  'Multilingue complet (FR / NL / EN / DE) — Belgique tri-lingue, traductions tuteur IA staff + curriculum',
-  'Badges & Open Badges 3.0 (CEFR + EQF)',
-  'Révisions intelligentes',
-  'Web Worker isolation tuteur IA — vraie défense vs extension navigateur malveillante (V1.5, THI-114)',
-  'Parcours avancés (Docker, scripting, IA augmentée)',
-  'Tuteur IA chat assistant contextualisé par rôle — usage opérationnel teacher/admin pour gestion classes (Phase 9+)',
+export const ROADMAP_PLANNED: readonly RoadmapGroup[] = [
+  {
+    group: 'Internationalisation',
+    items: [
+      'FR / NL / EN / DE — Belgique tri-lingue',
+      'Traductions tuteur IA staff + curriculum',
+    ],
+  },
+  {
+    group: 'Gamification & UX',
+    items: [
+      'Mode histoire narratif',
+      'Badges & Open Badges 3.0 (CEFR + EQF)',
+      'Révisions intelligentes',
+    ],
+  },
+  {
+    group: 'Architecture & V2',
+    items: [
+      'Web Worker isolation tuteur IA (V1.5, THI-114)',
+      'Parcours avancés (Docker, scripting, IA augmentée)',
+      'Tuteur IA chat assistant role-based (Phase 9+)',
+    ],
+  },
 ];
 
 // ── Supporters (Hall of Fame) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Suite feedback @thierry sur PR #295 (« cela ne devient il pas un peu trop long visuellement sur la landing page? ... trouve un moyen plus pro et premium 2026 »). Le screenshot a confirmé :
- Asymétrie démesurée : colonne Disponible 2× plus haute (16 items, certains 5+ lignes)
- Pattern flat list 2020 — pas scalable, ne tient pas 6 mois
- Items 3-5 lignes = lecture pénible, parcours visuel rompu

## Avant / Après

**Avant** : `ROADMAP_AVAILABLE: string[]` — 16 bullets flat, strings 3-5 lignes mélangeant feature + détails THI-XXX + versions Stage B1+B2.

**Après** : `ROADMAP_AVAILABLE: RoadmapGroup[]` — 5 groupes sémantiques × 2-4 items × 1 ligne chacun.

### Disponible (5 groupes au lieu de 16 bullets flat)

- **Curriculum** : 11 modules + Terminal interactif + 27+ commandes + Parcours + Dashboard
- **Multi-OS** : Linux/macOS/Windows + Partage natif
- **Tuteur IA** : Multi-rôles cloisonnés + 4 providers BYOK + Onboarding chiffré + Audit 9.2/10
- **Plateforme B2B** : Espace enseignant + Panel super-admin + 20 agents + LTI Phase 7c
- **Qualité** : WCAG 2.2 AAA + Sécurité durcie + Sauvegarde

### En cours (3 groupes)

- **Tuteur IA V1.5** : Stage B3 picker + Stage B1.b multi-turn
- **Plateforme B2B** : Phase 9 Admin Panel + Sprint 2.B + SEO/GEO/AEO
- **Curriculum** : Extension + Exercices + Guide PWA

### Plus tard (3 groupes)

- **Internationalisation** : FR/NL/EN/DE + Traductions tuteur IA staff
- **Gamification & UX** : Mode histoire + Badges Open Badges 3.0 + Révisions
- **Architecture & V2** : Web Worker isolation + Parcours avancés + Chat assistant role-based

## Pattern premium 2026

Vérifié sur Stripe roadmap, Linear changelog, Vercel changelog, Notion roadmap — tous utilisent grouping sémantique + sous-headers vs flat bullets. Scalable : nouvelle feature → ajout dans un groupe existant, pas nouvelle ligne plat.

## Rendering

`Landing.tsx` nested rendering :
- Header colonne inchangé (Disponible/En cours/Plus tard + badge live/beta)
- Sous-headers groupes : `text-xs uppercase tracking-wider` couleur thème atténuée
- Items `leading-snug` pour densité agréable
- `space-y-4` entre groupes, `space-y-1.5` entre items

## Test plan

- [x] Lint OK · type-check OK · 1701 tests PASS / 0 régression
- [ ] CI verte
- [ ] Smoke Chrome MCP preview Vercel — vérifier alignement 3 colonnes + lisibilité sous-headers
- [ ] Merge → smoke prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)