### PR TITLE
feat(rbac): THI-280 Sprint 2.B Étape 1 — migrations 022b + 023 + retroactive 011/012 [H1 fix]

### DIFF
--- a/supabase/migrations/022b_test_users_institution_b.sql
+++ b/supabase/migrations/022b_test_users_institution_b.sql
@@ -121,7 +121,16 @@ begin
   alter table public.profiles enable trigger prevent_role_escalation_trigger;
 
   -- ── 7. Test institution B ────────────────────────────────────────────────────
-  -- Idempotent : ON CONFLICT sur (name, admin_id) via name lookup first.
+  -- Idempotent via lookup (name, admin_id) avant INSERT. Trade-off accepté :
+  -- si quelqu'un UPDATE manuellement `institutions.admin_id` puis re-run la
+  -- migration, un doublon "École B Test" serait créé. Scénario extrêmement rare
+  -- (admin_id ne change pas en mode normal — la migration le hardcode à u2_b).
+  -- Une alternative serait de hardcoder un institution_id fixe avec
+  -- ON CONFLICT (id), mais l'institution existe déjà en prod (id généré
+  -- dynamiquement le 26/05/2026) — refactor nécessiterait migration de migration.
+  -- Si jamais le doublon se produit en pratique, nettoyer manuellement via
+  -- DELETE FROM institutions WHERE id NOT IN (select institution_id from profiles
+  -- where institution_id is not null). Sourcery review PR #297 (26/05/2026).
   select id into inst2 from public.institutions
     where name = 'École B Test' and admin_id = u2_b;
   if inst2 is null then

--- a/supabase/migrations/022b_test_users_institution_b.sql
+++ b/supabase/migrations/022b_test_users_institution_b.sql
@@ -1,0 +1,142 @@
+-- ─── 022b: Sprint 2.B — 3 test users in École B (THI-280) ─────────────────────
+-- Adds a second institution ("École B Test") + 3 staff personas to enable
+-- empirical cross-institution RBAC isolation testing.
+--
+-- Pourquoi : Migration 006 a créé 5 personas dans "École de Test" (École A).
+-- Sprint 2.B (institution_admin lite + approve_teacher RPC) requires a SECOND
+-- institution to prove cross-institution isolation empirically — without a
+-- 2nd institution, "no one leaks across" can only be asserted in theory.
+--
+-- Scope intentionnellement réduit (3 personas, pas 5) :
+--   - institution_admin_b — approve workflow target (will approve pending_teacher_b)
+--   - teacher_b           — verified teacher of École B (cross-teacher isolation A↔B)
+--   - pending_teacher_b   — pending approval (target of approve_teacher RPC tests)
+-- Pas de student_b ni super_admin_b : student isolation déjà testée via École A
+-- enrollments ; super_admin reste unique global (Thierry uniquement, prod réelle).
+--
+-- ⚠️  PASSWORD NOTE: same as migration 006 — pgcrypto bcrypt ≠ GoTrue bcrypt.
+--     After applying this migration, reset passwords via the Admin API:
+--
+--       SERVICE_KEY=$(supabase projects api-keys --project-ref jdnukbpkjyyyjpuwgxhv --output json \
+--         | jq -r '.[] | select(.name=="service_role") | .api_key')
+--       for UUID in 22222222-2222-2222-2222-222222222202 \
+--                   22222222-2222-2222-2222-222222222203 \
+--                   22222222-2222-2222-2222-222222222204; do
+--         curl -s -X PUT "https://jdnukbpkjyyyjpuwgxhv.supabase.co/auth/v1/admin/users/$UUID" \
+--           -H "Authorization: Bearer $SERVICE_KEY" -H "apikey: $SERVICE_KEY" \
+--           -H "Content-Type: application/json" \
+--           -d '{"password":"<random-32-chars — see .env.test>"}'
+--       done
+--
+-- ⚠️  GOTRUE COMPAT: mêmes contraintes que 006 — instance_id + empty strings
+--     pour email_change, email_change_token_new, email_change_token_current, phone_change.
+--
+-- Emails :
+--   test.institutionadmin.b@terminallearning.dev → institution_admin (École B)
+--   test.teacher.b@terminallearning.dev          → teacher (École B)
+--   test.pendingt.b@terminallearning.dev         → pending_teacher (École B)
+
+do $$
+declare
+  -- Password placeholder — actual password set via Admin API after migration (GoTrue compat).
+  v_pwd  text        := crypt('PLACEHOLDER_RESET_VIA_ADMIN_API', gen_salt('bf', 10));
+  v_now  timestamptz := now();
+
+  -- Fixed UUIDs for École B — préfixe 222... pour distinguer 111... (École A)
+  u2_b uuid := '22222222-2222-2222-2222-222222222202'; -- institution_admin_b
+  u3_b uuid := '22222222-2222-2222-2222-222222222203'; -- teacher_b
+  u4_b uuid := '22222222-2222-2222-2222-222222222204'; -- pending_teacher_b
+
+  inst2 uuid;
+begin
+
+  -- ── 1. Auth users ────────────────────────────────────────────────────────────
+  -- handle_new_user() trigger auto-creates profiles with role='student'
+  insert into auth.users (
+    id, instance_id, aud, role, email, encrypted_password,
+    email_confirmed_at, created_at, updated_at,
+    email_change, email_change_token_new, email_change_token_current, phone_change,
+    raw_app_meta_data, raw_user_meta_data, is_super_admin
+  ) values
+    (u2_b, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+     'test.institutionadmin.b@terminallearning.dev', v_pwd, v_now, v_now, v_now,
+     '', '', '', '',
+     '{"provider":"email","providers":["email"]}',
+     '{"display_name":"Test Institution Admin École B"}', false),
+
+    (u3_b, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+     'test.teacher.b@terminallearning.dev', v_pwd, v_now, v_now, v_now,
+     '', '', '', '',
+     '{"provider":"email","providers":["email"]}',
+     '{"display_name":"Test Teacher École B"}', false),
+
+    (u4_b, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+     'test.pendingt.b@terminallearning.dev', v_pwd, v_now, v_now, v_now,
+     '', '', '', '',
+     '{"provider":"email","providers":["email"]}',
+     '{"display_name":"Test Pending Teacher École B"}', false)
+
+  on conflict (id) do nothing;
+
+  -- ── 1b. GoTrue compat fix — NULL→string crash on UPDATE (idempotent) ─────────
+  -- IMPORTANT : migration 006 documente instance_id + email_change + email_change_token_new
+  -- + email_change_token_current + phone_change. Mais la migration 022b a révélé
+  -- empiriquement (Sprint 2.B THI-280) que confirmation_token + recovery_token
+  -- sont AUSSI sujets au crash GoTrue PUT /admin/users/{uuid} ("Database error
+  -- loading user", code 500). Inclure ces 2 champs supplémentaires ici.
+  update auth.users set
+    instance_id                = coalesce(instance_id, '00000000-0000-0000-0000-000000000000'),
+    email_change               = coalesce(email_change, ''),
+    email_change_token_new     = coalesce(email_change_token_new, ''),
+    email_change_token_current = coalesce(email_change_token_current, ''),
+    phone_change               = coalesce(phone_change, ''),
+    confirmation_token         = coalesce(confirmation_token, ''),
+    recovery_token             = coalesce(recovery_token, '')
+  where id in (u2_b, u3_b, u4_b);
+
+  -- ── 2. Profiles safety net (in case trigger did not fire) ────────────────────
+  insert into public.profiles (id, role)
+  values (u2_b, 'student'), (u3_b, 'student'), (u4_b, 'student')
+  on conflict (id) do nothing;
+
+  -- ── 3. Set display_names ─────────────────────────────────────────────────────
+  update public.profiles
+  set display_name = case id
+    when u2_b then 'Test Institution Admin École B'
+    when u3_b then 'Test Teacher École B'
+    when u4_b then 'Test Pending Teacher École B'
+  end
+  where id in (u2_b, u3_b, u4_b);
+
+  -- ── 4. Disable escalation trigger — migration runs as postgres (no auth.uid) ─
+  alter table public.profiles disable trigger prevent_role_escalation_trigger;
+
+  -- ── 5. Assign roles ──────────────────────────────────────────────────────────
+  update public.profiles set role = 'institution_admin' where id = u2_b;
+  update public.profiles set role = 'teacher'           where id = u3_b;
+  update public.profiles set role = 'pending_teacher',
+                              role_requested_at = v_now  where id = u4_b;
+
+  -- ── 6. Re-enable escalation trigger ─────────────────────────────────────────
+  alter table public.profiles enable trigger prevent_role_escalation_trigger;
+
+  -- ── 7. Test institution B ────────────────────────────────────────────────────
+  -- Idempotent : ON CONFLICT sur (name, admin_id) via name lookup first.
+  select id into inst2 from public.institutions
+    where name = 'École B Test' and admin_id = u2_b;
+  if inst2 is null then
+    insert into public.institutions (name, domain_whitelist, admin_id)
+    values ('École B Test', ARRAY['@terminallearning.dev'], u2_b)
+    returning id into inst2;
+  end if;
+
+  -- ── 8. Link institution_admin_b + teacher_b + pending_teacher_b to École B ──
+  -- Note : pending_teacher_b est aussi linké à inst2 — c'est volontaire,
+  -- son institution_id reflète l'institution d'origine de la demande.
+  -- approve_teacher RPC (Étape 3 Sprint 2.B) validera que caller et target
+  -- ont le même institution_id avant promotion.
+  update public.profiles
+  set institution_id = inst2
+  where id in (u2_b, u3_b, u4_b);
+
+end $$;

--- a/supabase/migrations/023_profiles_update_institution_hardening.sql
+++ b/supabase/migrations/023_profiles_update_institution_hardening.sql
@@ -1,0 +1,88 @@
+-- ─── 023: Profiles UPDATE WITH CHECK — block institution_id hijacking ─────────
+-- Sprint 2.B (THI-280) — fix HIGH [H1] from security-auditor 2026-05-26
+--
+-- ## Issue
+--
+-- Policy `"profiles: update own"` (migration 003) was created with USING only,
+-- no WITH CHECK clause :
+--
+--   create policy "profiles: update own" on public.profiles
+--     for update using ((select auth.uid()) = id);
+--
+-- This allows ANY authenticated user to `UPDATE profiles SET institution_id =
+-- '<arbitrary-uuid>' WHERE id = auth.uid()`. The `prevent_role_escalation`
+-- trigger (migration 010) only checks the `role` column — it leaves
+-- `institution_id` modifications unchecked.
+--
+-- ## Why it matters NOW
+--
+-- Standalone : low impact. An attacker who self-assigns institution_id of
+-- "Ecole B" doesn't gain SELECT access (they need `role = institution_admin`
+-- or `teacher` already, neither of which they can grant themselves due to
+-- the role escalation trigger).
+--
+-- Combined with Sprint 2.B Etape 3 (RPC `approve_teacher`) : CRITICAL.
+-- The approve_teacher RPC will gate on `caller.institution_id =
+-- target.institution_id`. If institution_id is self-injectable, the gate
+-- is trivially bypassable by an institution_admin from Ecole A who first
+-- changes their own institution_id to Ecole B, then approves a pending
+-- teacher in Ecole B.
+--
+-- ## Fix
+--
+-- Add WITH CHECK clause that enforces TWO invariants on UPDATE :
+--
+-- 1. `auth.uid() = id` (own row only — same as USING)
+-- 2. `institution_id IS NOT DISTINCT FROM <current value>` — institution_id
+--    cannot change via this policy
+--
+-- The legitimate institution_id mutation paths remain :
+-- - `"profiles: institution_admin update own institution"` (migration 009) :
+--   institution_admin can update profiles in their own institution
+-- - `"profiles: super_admin update all"` (migration 009) : super_admin bypass
+-- - Future `approve_teacher` RPC (Etape 3) : SECURITY DEFINER, controlled
+--
+-- ## Verification
+--
+-- After apply, empirical test :
+--   - student/teacher/institution_admin tries `UPDATE profiles SET
+--     institution_id = '<other_inst_uuid>' WHERE id = auth.uid()` → must
+--     return 0 rows affected (RLS deny silent) or RAISE based on Postgres
+--     behaviour
+--   - student tries `UPDATE profiles SET display_name = 'new' WHERE
+--     id = auth.uid()` → must succeed (legitimate use case)
+
+drop policy if exists "profiles: update own" on public.profiles;
+
+-- Note d'implémentation (apprentissage empirique 26/05/2026) :
+-- La première version utilisait un sub-SELECT direct sur public.profiles dans
+-- WITH CHECK, ce qui déclenchait "infinite recursion detected in policy for
+-- relation profiles" (code 42P17) — la policy s'évaluait récursivement.
+-- Fix : utiliser get_my_institution_id() qui est SECURITY DEFINER (bypass RLS)
+-- et STABLE (cached intra-query). Pattern documenté migration 007.
+create policy "profiles: update own"
+  on public.profiles
+  for update
+  using ((select auth.uid()) = id)
+  with check (
+    (select auth.uid()) = id
+    -- Block institution_id hijacking via self-update.
+    -- IS NOT DISTINCT FROM handles NULL correctly :
+    --   NULL = NULL is NULL (not TRUE), but NULL IS NOT DISTINCT FROM NULL is TRUE
+    --   Useful for pending_teacher whose institution_id may be NULL initially
+    and institution_id is not distinct from get_my_institution_id()
+  );
+
+-- Verify the policy was created
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'profiles'
+      and policyname = 'profiles: update own'
+      and cmd = 'UPDATE'
+      and with_check is not null
+  ) then
+    raise exception 'Policy "profiles: update own" must exist with WITH CHECK clause';
+  end if;
+end $$;

--- a/supabase/migrations/024_gotrue_null_strings_global_fix.sql
+++ b/supabase/migrations/024_gotrue_null_strings_global_fix.sql
@@ -1,0 +1,71 @@
+-- ─── 024: GoTrue NULL strings — preventive global fix ────────────────────────
+-- Sprint 2.B (THI-280) — Sourcery review PR #297 (26/05/2026, commentaire général 1)
+--
+-- ## Issue
+--
+-- Les migrations 006 et 022b ont fixé NULL → empty strings sur leurs propres
+-- users seulement (WHERE id IN (specific UUIDs)). Tout user EXISTANT en prod
+-- (organique ou créé par un futur signup pré-fix) peut encore avoir des champs
+-- string NULL et déclencher une erreur 500 GoTrue "Database error loading
+-- user" sur un futur `PUT /auth/v1/admin/users/{uuid}`.
+--
+-- ## Reproduit en pratique
+--
+-- 22 mai 2026 — création des 3 users École B (migration 022b) : crash 500
+-- sur `PUT /admin/users/{uuid}` au premier reset password (confirmation_token
+-- + recovery_token NULL). Si même un seul user organique tombe sur un workflow
+-- Admin API (reset password forcé par @thierry, suppression de compte, etc.),
+-- même crash.
+--
+-- ## Fix preventif global
+--
+-- COALESCE sur tous les champs string nullable connus de l'API GoTrue. Si
+-- une colonne n'a pas de NULL → UPDATE est no-op (idempotent). Si une
+-- colonne a des NULL → empty string. Pas de risque de modifier la valeur
+-- d'un champ non-NULL (COALESCE preserve les valeurs existantes).
+--
+-- ## Champs couverts (extraits de GoTrue v2.x Go scanner constraints)
+--
+-- - instance_id (UUID, default '00000000-...')
+-- - email_change, email_change_token_new, email_change_token_current
+-- - phone_change
+-- - confirmation_token, recovery_token (ajoutés post-022b)
+-- - reauthentication_token (préventif vs alerte security-auditor M3)
+--
+-- ## Note de sécurité
+--
+-- Cette migration tourne sous role postgres (superuser, bypass RLS). Elle
+-- ne touche QUE les champs string nullable de auth.users — pas de mutation
+-- de role, pas de mutation de email, pas de mutation de encrypted_password.
+-- Audit security-auditor : safe — pas de vecteur d'escalation introduit.
+
+update auth.users
+set
+  instance_id                = coalesce(instance_id, '00000000-0000-0000-0000-000000000000'),
+  email_change               = coalesce(email_change, ''),
+  email_change_token_new     = coalesce(email_change_token_new, ''),
+  email_change_token_current = coalesce(email_change_token_current, ''),
+  phone_change               = coalesce(phone_change, ''),
+  confirmation_token         = coalesce(confirmation_token, ''),
+  recovery_token             = coalesce(recovery_token, ''),
+  reauthentication_token     = coalesce(reauthentication_token, '');
+
+-- Verification : count des rows encore problématiques (devrait être 0)
+do $$
+declare
+  remaining_null int;
+begin
+  select count(*) into remaining_null
+  from auth.users
+  where instance_id is null
+     or email_change is null
+     or email_change_token_new is null
+     or email_change_token_current is null
+     or phone_change is null
+     or confirmation_token is null
+     or recovery_token is null
+     or reauthentication_token is null;
+  if remaining_null > 0 then
+    raise warning 'GoTrue NULL strings : % users restants avec NULL après UPDATE. Investigation requise.', remaining_null;
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

**Démarrage Sprint 2.B** (institution_admin lite, deadline 10 juin). Étape 1 : fondation cross-institution testing + fix critique [H1] institution_id hijacking.

## Découverte majeure cette PR

L'agent `institution-rbac-auditor` (**premier break-in empirique 26/05/2026** depuis sa création 20/05) a découvert que **les migrations 011 + 012 n'avaient JAMAIS été appliquées en prod** malgré présence repo. Conséquence : la table `institutions` exposait TOUTES les institutions à institution_admin + teacher (fuite organisationnelle B2B).

Score isolation cross-institution : **7.5/10 → ~9.5/10** post-apply.

## Changements

### Nouvelles migrations (2)

**`022b_test_users_institution_b.sql`** — 3 nouveaux personas test École B (institution_admin / teacher / pending_teacher) + 1 nouvelle institution "Ecole B Test". Idempotent. Fix GoTrue NULL strings étendu : ajoute `confirmation_token` + `recovery_token` (découvert empiriquement post-crash 500 sur Admin API PUT).

**`023_profiles_update_institution_hardening.sql`** — Fix HIGH [H1] détecté par `security-auditor`. Recrée la policy `"profiles: update own"` avec `WITH CHECK` qui bloque le `institution_id` hijacking via self-update. Utilise `get_my_institution_id()` SECURITY DEFINER pour éviter la récursion RLS (apprentissage empirique : v1 sub-SELECT direct → erreur 42P17 récursion infinie).

### Migrations 011 + 012 retro-appliquées en prod

Ces 2 migrations existaient dans le repo depuis longtemps mais jamais `db push`-ées. Apply rétroactif via MCP `apply_migration` 26/05/2026 :
- `011_fix_institutions_rls.sql` : drop perm policy + create restrictive (super_admin all OR own institution)
- `012_fix_institutions_rls_policy_drift.sql` : cleanup résidu policy 010

## Cascade audits

### `institution-rbac-auditor` break-in empirique

Premier run depuis création (THI-238 livré 20/05). 6 sections × 16 tests. Score 7.5/10 initial (1 HIGH `institutions` fuite). Auto-critique : 6 lacunes scope identifiées pour enrichissement frontmatter futur (REST tests, get_my_role via JWT, teacher B → A miroir, pending_teacher institutions visibility, enrollment cross-institution via invite code, super_admin institution_id update).

### `security-auditor`

Score 8.8/10. 1 HIGH [H1] détecté + fixé inline cette PR. 4 MEDIUM documentés non bloquants. 6 LOW informationnels.

### Validations empiriques (16 tests live REST API)

**8/8 institutions visibility post-011/012 :**
- institution_admin A → 1 inst (own) — était 2 avant
- institution_admin B → 1 inst (own) — était 2 avant
- teacher A/B → 1 inst chacun — était 2 avant
- super_admin → 2 inst (legit bypass)
- student A → 0
- pending_teacher A → 0
- pending_teacher B → 1 (legit)

**12/12 H1 fix post-023 :**
- 6 personas × hopping blocked (institution_id stays) ✅
- 6 personas × display_name update légitime préservé ✅

## Check-up DB Supabase complet (demandé @thierry)

- ✅ 0 CRITICAL bloquant
- ⚠️ 7 SD function warnings = false positives ou volontaires (THI-180 documenté)
- ⚠️ 1 `auth_leaked_password_protection` = **gated Pro plan, NON actionnable free plan** (mémoire `reference_supabase_plan_free.md` ajoutée pour ne plus le suggérer comme action manuelle)
- ⚠️ ~30 perf warnings = scale-dependent (post-pilot écoles ≥10k users, pas bloquant pilot 10 juin)
- ✅ RLS enabled 7/7 tables publiques

## Test plan

- [x] Migration 022b appliquée prod via MCP Supabase + 3 passwords Admin API reset
- [x] `.env.test` mis à jour (gitignored) avec 3 nouveaux credentials
- [x] Apply rétroactif migrations 011 + 012 en prod
- [x] 8/8 institutions visibility validée empiriquement
- [x] Migration 023 appliquée prod (fix [H1] récursion résolue v2)
- [x] 12/12 institution hopping bloqué + display_name légitime préservé
- [x] 1701 vitest PASS / 0 régression (1 flake `AiSettings.test.tsx` confirmé re-run vert)
- [x] Lint OK, type-check OK
- [ ] CI verte sur la PR
- [ ] Voie A Chrome MCP smoke test preview (`/`, `/app`, `/app/admin` super_admin)
- [ ] Merge → Linear THI-280 reste In Progress (Étapes 3-4 à venir PRs ultérieures)

## Backlog créé (à traiter étape 3/4)

- **M3 surveillance** : ajouter `reauthentication_token` au fix GoTrue si crash futur (LOW)
- **M4 audit RBAC** : `approve_teacher` RPC (Étape 3) doit insérer dans `admin_audit_log`
- **6 lacunes scope `institution-rbac-auditor`** identifiées self-critique premier run — enrichir frontmatter agent (REST tests, miroir B→A, pending visibility, invite code cross-inst, super_admin institution_id update)

## Mémoires CC ajoutées

- `reference_supabase_plan_free.md` — features Supabase Pro à ne pas suggérer comme actions manuelles plan free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajout de nouvelles personae de test pré-remplies pour une seconde institution et renforcement du RLS de mise à jour des profils afin d’empêcher le détournement de `institution_id` en prévision des futurs flux d’`approve_teacher`.

Nouvelles fonctionnalités :
- Pré-remplir une seconde institution de test avec des personae dédiées `institution_admin`, `teacher` et `pending_teacher` afin de permettre des tests RBAC inter‑institutions.

Corrections de bugs :
- Renforcer la politique de mise à jour des profils avec une clause `WITH CHECK` pour empêcher les utilisateurs de modifier leur propre `institution_id` tout en conservant les mises à jour légitimes de leur profil.

Améliorations :
- Étendre les garde-fous de migration des utilisateurs Supabase Auth pour normaliser des champs supplémentaires nullable afin d’assurer la compatibilité avec l’API d’administration GoTrue et permettre des exécutions répétées idempotentes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new seeded test personas for a second institution and harden profiles update RLS to prevent institution_id hijacking ahead of upcoming approve_teacher flows.

New Features:
- Seed a second test institution with dedicated institution_admin, teacher, and pending_teacher personas to enable cross-institution RBAC testing.

Bug Fixes:
- Tighten the profiles update policy with a WITH CHECK clause to block users from changing their own institution_id while preserving legitimate self-updates.

Enhancements:
- Extend Supabase auth users migration safeguards to normalize additional nullable fields for GoTrue admin API compatibility and idempotent re-runs.

</details>