### PR TITLE
chore(agents): F-B (E2E cleanup) + F-C (RLS via REST API) cross-agent + Sourcery typos FR

### DIFF
--- a/.claude/agents/classroom-workflow-auditor.md
+++ b/.claude/agents/classroom-workflow-auditor.md
@@ -35,7 +35,13 @@ PROJECT_ID=jdnukbpkjyyyjpuwgxhv
 
 Fixture class: `Terminal 101`, id `43960369-ad83-49dd-87a8-8627d45b2410`, teacher_id 103, invitation_code `a4368184d202`.
 
-## Impersonation pattern (Supabase MCP)
+## Impersonation pattern (Supabase MCP) — caveat critique
+
+> ⚠ **Caveat F-C empirique 26/05/2026** : le pattern `set_config('role', 'authenticated', true)` ci-dessous fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `join_class_by_code`, `approve_teacher`), mais **n'est PAS fiable pour tester les RLS SELECT isolation purs**. Le `session_user` reste `postgres`, et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs ("semble voir cross-institution alors qu'en réalité non").
+>
+> **Pour tester RLS isolation, OBLIGATOIRE utiliser REST API + JWT réel** (cf. mémoire CC `feedback_rls_isolation_test_rest_only.md`). Le pattern CLI ci-dessous reste valide UNIQUEMENT pour les tests d'RPC.
+
+### Pour tester RPC functions (CLI OK)
 
 ```sql
 DO $$
@@ -48,13 +54,43 @@ BEGIN
   );
   PERFORM set_config('role', 'authenticated', true);
 
-  -- Now call the RPC / SELECT as this user
-  -- Any auth.uid() resolves to <USER_UUID>
-  -- Any RLS policy checks against this identity
+  -- Now call the RPC — auth.uid() resolves to <USER_UUID>
+  PERFORM public.join_class_by_code('<code>');
 END $$;
 ```
 
-Always wrap state mutations in a transaction with rollback OR DELETE the test rows after the test (the prod DB has 1 fixture row — never accept polluting it with E2E test data).
+### Pour tester RLS SELECT isolation (REST API + JWT obligatoire)
+
+```bash
+# 1. Login persona via REST API
+body=$(python -c "import json,sys; print(json.dumps({'email':sys.argv[1],'password':sys.argv[2]}))" "$EMAIL" "$PWD")
+curl -sS -X POST "${VITE_SUPABASE_URL}/auth/v1/token?grant_type=password" \
+  -H "apikey: ${VITE_SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  --data "$body" > .tmp/session.json
+
+# 2. Extract token without dumping to stdout
+token=$(python -c "import json,sys; print(json.load(sys.stdin).get('access_token',''))" < .tmp/session.json)
+
+# 3. SELECT under that persona's RLS scope
+curl -sS "${VITE_SUPABASE_URL}/rest/v1/classes?select=*" \
+  -H "apikey: ${VITE_SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer $token"
+
+# 4. Cleanup token file
+rm .tmp/session.json
+```
+
+## E2E test data cleanup (mandatory)
+
+> **Pattern F-B codifié 26/05/2026** suite à 4 classes orphelines détectées au début du run (`E2E_TEST_*`, `E2E_DEBUG_*` polluant la DB).
+
+1. **Naming convention** : tout test data créé par cet agent doit commencer par `E2E_` (ex : `E2E_AUDITOR_<timestamp>`, `E2E_CROSS_INSTITUTION_<scenario>`)
+2. **Cleanup startup** : avant de créer les fixtures, `DELETE FROM public.classes WHERE name LIKE 'E2E_%'` (idempotent re-run safe)
+3. **Cleanup teardown** : fin de run, même `DELETE` pour ne pas laisser de traces
+4. **Crash safety** : utiliser BEGIN..EXCEPTION..ROLLBACK ou guard DELETE au startup
+
+Always wrap state mutations in a transaction with rollback OR DELETE the test rows after the test (the prod DB has 1 fixture row `Terminal 101` — never accept polluting it with E2E test data).
 
 ## Test plan (14 checks)
 

--- a/.claude/agents/institution-rbac-auditor.md
+++ b/.claude/agents/institution-rbac-auditor.md
@@ -87,7 +87,7 @@ Cf. mémoire CC `feedback_rls_isolation_test_rest_only.md` pour la doctrine comp
 > **Pattern F-B codifié 26/05/2026** suite à 4 classes orphelines `E2E_*` détectées par `classroom-workflow-auditor`.
 
 Toute donnée de test créée par cet agent doit :
-1. **Naming convention** : préfix `E2E_` obligatoire (ex : `E2E_INST_RBAC_<timestamp>`)
+1. **Naming convention** : préfixe `E2E_` obligatoire (ex : `E2E_INST_RBAC_<timestamp>`)
 2. **Cleanup startup** : `DELETE FROM <table> WHERE name LIKE 'E2E_%'` AVANT de créer les fixtures
 3. **Cleanup teardown** : même `DELETE` en fin de run
 4. **Crash safety** : BEGIN..EXCEPTION..ROLLBACK ou guard DELETE au startup

--- a/.claude/agents/institution-rbac-auditor.md
+++ b/.claude/agents/institution-rbac-auditor.md
@@ -49,9 +49,48 @@ PROJECT_ID=jdnukbpkjyyyjpuwgxhv
 
 Si ces 3 users + l'institution École B n'existent pas en prod, **bloque l'audit** avec verdict `🔴 BLOCK — pre-requisite missing : 3 test users École B`. Ne génère JAMAIS ces users via un INSERT dans `auth.users` automatique — c'est une opération sensible qui doit passer par une migration auditée (cf. pattern THI-76 migration 006).
 
-## Impersonation pattern (Supabase MCP)
+## Impersonation pattern (Supabase MCP) — caveat critique
 
-Identique au pattern documenté dans `classroom-workflow-auditor.md` (set_config request.jwt.claims + role authenticated, scope local transaction).
+> ⚠ **Caveat F-C empirique 26/05/2026** (cross-agent doctrine codifiée par `classroom-workflow-auditor` premier break-in) : le pattern `set_config('role', 'authenticated', true)` fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `approve_teacher`, `get_my_role`, `get_my_institution_id`), MAIS **n'est PAS fiable pour tester les RLS SELECT isolation purs**. Le `session_user` reste `postgres` et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs.
+>
+> **Symptôme empirique mesuré 26/05** : via CLI impersonation institution_admin_b → `SELECT * FROM classes` retourne 7 classes (faux positif). Via REST API + JWT réel → 0 classes (correct). Ground truth = REST API.
+
+### Pour tester les RPC functions (CLI Supabase MCP OK)
+
+Pattern identique à `classroom-workflow-auditor.md` : `set_config('request.jwt.claims', ...)` + `set_config('role', 'authenticated', true)` scopé local transaction. Les fonctions `SECURITY DEFINER` checkent `auth.uid()` indépendamment → résultats fiables.
+
+### Pour tester RLS SELECT isolation cross-institution (REST API + JWT obligatoire)
+
+Le scope de cet agent (cross-institution data leak detection) est précisément le cas où le CLI génère des faux positifs. **OBLIGATOIRE** utiliser REST API :
+
+```bash
+# Login institution_admin_b via REST API
+body=$(python -c "import json,sys; print(json.dumps({'email':sys.argv[1],'password':sys.argv[2]}))" "$TEST_INSTITUTIONADMIN_B_EMAIL" "$TEST_INSTITUTIONADMIN_B_PASSWORD")
+curl -sS -X POST "${VITE_SUPABASE_URL}/auth/v1/token?grant_type=password" \
+  -H "apikey: ${VITE_SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" --data "$body" > .tmp/session.json
+
+token=$(python -c "import json,sys; print(json.load(sys.stdin).get('access_token',''))" < .tmp/session.json)
+
+# Test cross-institution SELECT — DOIT retourner 0 rows pour École A data
+curl -sS "${VITE_SUPABASE_URL}/rest/v1/profiles?select=id&institution_id=eq.<école_A_uuid>" \
+  -H "apikey: ${VITE_SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer $token"
+
+rm .tmp/session.json
+```
+
+Cf. mémoire CC `feedback_rls_isolation_test_rest_only.md` pour la doctrine complète.
+
+## E2E test data cleanup (mandatory)
+
+> **Pattern F-B codifié 26/05/2026** suite à 4 classes orphelines `E2E_*` détectées par `classroom-workflow-auditor`.
+
+Toute donnée de test créée par cet agent doit :
+1. **Naming convention** : préfix `E2E_` obligatoire (ex : `E2E_INST_RBAC_<timestamp>`)
+2. **Cleanup startup** : `DELETE FROM <table> WHERE name LIKE 'E2E_%'` AVANT de créer les fixtures
+3. **Cleanup teardown** : même `DELETE` en fin de run
+4. **Crash safety** : BEGIN..EXCEPTION..ROLLBACK ou guard DELETE au startup
 
 ## Test plan (16 checks)
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -135,7 +135,7 @@ Executer : npm audit --audit-level=high 2>/dev/null
 
 ## Content Security Policy (CSP Level 3)
 
-Analyser vercel.json et verifier chaque directive :
+Analyser vercel.json et vérifier chaque directive :
 
 | Directive           | Verification                                           |
 |---------------------|-------------------------------------------------------|
@@ -178,7 +178,7 @@ Verifier dans vercel.json :
 
 ## Supabase RLS
 
-Lister toutes les tables depuis src/app/types/database.ts et verifier :
+Lister toutes les tables depuis src/app/types/database.ts et vérifier :
 - RLS active sur chaque table ?
 - Politiques couvrant SELECT, INSERT, UPDATE, DELETE ?
 - Utilisation de auth.uid() (jamais d'un parametre client) ?

--- a/docs/audits/classroom-workflow-auditor-2026-05-26.md
+++ b/docs/audits/classroom-workflow-auditor-2026-05-26.md
@@ -101,7 +101,7 @@ Toutes avec `institution_id = NULL`, polluant la DB de test fixtures non-cleané
 
 **Fix — pattern à codifier cross-agent** :
 
-1. **Naming convention** : préfix `E2E_` obligatoire pour toute donnée de test créée par un agent
+1. **Naming convention** : préfixe `E2E_` obligatoire pour toute donnée de test créée par un agent
 2. **Cleanup startup** : début de chaque run, `DELETE FROM <table> WHERE name LIKE 'E2E_%'` AVANT de créer les fixtures (idempotent re-run safe)
 3. **Cleanup teardown** : fin de chaque run, même `DELETE` pour ne pas laisser de traces
 4. **Crash safety** : utiliser `BEGIN ... EXCEPTION ... ROLLBACK` ou guard `DELETE` au startup même si crash mid-run
@@ -135,7 +135,7 @@ Le pattern Supabase CLI `set_config('role', 'authenticated', true)` documenté d
 **Files à update** :
 - `.claude/agents/classroom-workflow-auditor.md` — ajouter caveat dans section impersonation pattern
 - `.claude/agents/institution-rbac-auditor.md` — ajouter caveat (ce pattern a possiblement aussi des faux positifs dans son scope)
-- `.claude/agents/rbac-flow-tester.md` — verifier que le pattern utilise déjà REST API
+- `.claude/agents/rbac-flow-tester.md` — vérifier que le pattern utilise déjà REST API
 - Mémoire CC : `feedback_rls_isolation_test_rest_only.md`
 
 ### F-D — INFO : Classe `Bash 101` manuelle de @thierry
@@ -155,6 +155,6 @@ L'agent `classroom-workflow-auditor` dormant 6 jours a généré **2 findings ME
 
 C'est la 2ème validation empirique cross-session de la doctrine `feedback_agent_dormant_full_audit.md` (la 1ère étant `institution-rbac-auditor` qui avait trouvé 1 HIGH drift au premier break-in le 26 mai matin).
 
-**Renforcement de la doctrine** : tout nouvel agent créé doit être invoqué empiriquement dans les 48h max post-création, ET les agents existants doivent être audités récurremment (trimestriel ou par cycle Sprint).
+**Renforcement de la doctrine** : tout nouvel agent créé doit être invoqué empiriquement dans les 48h max post-création, ET les agents existants doivent être audités de façon récurrente (trimestriel ou par cycle Sprint).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Suite findings `classroom-workflow-auditor` 26 mai 2026 (rapport [`docs/audits/classroom-workflow-auditor-2026-05-26.md`](docs/audits/classroom-workflow-auditor-2026-05-26.md) via PR #301), 2 patterns cross-agent codifiés directement dans les `.md` agents pour gain immédiat.

## F-C — Doctrine RLS isolation via REST API obligatoire

Pattern Supabase CLI `set_config('role', 'authenticated', true)` :
- ✅ Fiable pour tester les RPC functions (re-lecture `auth.uid()` dans le body)
- ❌ **PAS fiable** pour tester les RLS SELECT isolation purs : `session_user` reste `postgres`, peut bypass RLS selon PG privilege resolution order

Symptôme empirique 26/05 : institution_admin_b via CLI → 7 classes (faux positif), via REST API + JWT réel → 0 classes (correct). Ground truth = REST API.

Caveat ajouté dans 2 agents : `classroom-workflow-auditor.md` + `institution-rbac-auditor.md`.

## F-B — Pattern E2E cleanup mandatory cross-agent

4 classes orphelines `E2E_TEST_*` / `E2E_DEBUG_*` détectées en début de run classroom-workflow-auditor 26/05 (pollution agents runs précédents).

Pattern codifié :
1. Naming convention : **préfixe `E2E_`** obligatoire
2. Cleanup startup : `DELETE WHERE name LIKE 'E2E_%'` avant fixtures (idempotent)
3. Cleanup teardown : même DELETE en fin de run
4. Crash safety : BEGIN..EXCEPTION..ROLLBACK ou guard startup

## Drive-by Sourcery typos FR

Sourcery review sur PR #301 (déjà mergée) a remonté 3 typos dans le rapport audit :
- ligne 104 : "préfix" → "préfixe"
- ligne 138 : "verifier" → "vérifier"
- ligne 158 : "récurremment" → "de façon récurrente"

Le même texte avait été copié dans `.claude/agents/institution-rbac-auditor.md` (1 occurrence "préfix") et `security-auditor.md` (2 occurrences "verifier" lignes 138+181, drive-by hors scope strict mais 2 caractères + cohérence FR garde la doctrine propre).

## Test plan

- [x] 4 files modifiés : 2 audits agents + 1 audit report + 1 security-auditor drive-by
- [x] `grep` confirms zero typo restant
- [ ] CI verte sur push
- [ ] Sourcery PASS attendu
- [ ] Voie C-eligible smoke test post-merge (pure docs, 0 fichier runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documenter des modèles plus stricts entre agents pour l’usurpation d’identité Supabase et le nettoyage des données de tests E2E, et corriger de petites fautes de français dans la documentation d’audit et les guides d’agents.

Améliorations :
- Clarifier que l’usurpation d’identité via Supabase CLI avec `set_config` n’est fiable que pour les tests RPC, et imposer l’utilisation de l’API REST + de vrais JWT pour les vérifications d’isolation RLS SELECT dans les agents concernés.
- Introduire une convention de nettoyage des données de tests E2E à l’échelle des agents, avec un préfixe `E2E_`, des suppressions au démarrage/à l’arrêt, et des recommandations de sécurité en cas de crash dans la documentation de l’agent auditeur.

Documentation :
- Mettre à jour le rapport d’audit du workflow de la classe pour l’aligner sur la nouvelle doctrine d’usurpation d’identité et de nettoyage E2E, et corriger plusieurs problèmes de formulation en français.
- Corriger de petites fautes d’orthographe et de formulation en français dans la documentation de l’agent auditeur RBAC pour les établissements et de l’agent auditeur de sécurité.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document stricter cross-agent patterns for Supabase impersonation and E2E test data cleanup, and fix minor French typos in audit docs and agent guides.

Enhancements:
- Clarify that Supabase CLI impersonation via set_config is only reliable for RPC tests and mandate REST API + real JWT for RLS SELECT isolation checks in relevant agents.
- Introduce a cross-agent E2E test data cleanup convention with E2E_ naming, startup/teardown deletes, and crash-safety guidance in auditor agent docs.

Documentation:
- Update the classroom workflow audit report to align with the new impersonation and E2E cleanup doctrine and correct several French wording issues.
- Fix minor French spelling and wording errors in the institution RBAC auditor and security auditor agent documentation.

</details>