### PR TITLE
chore(docs): Sourcery review fixup PR #302 — 3 typos FR + doctrine pointer mémoire CC

### DIFF
--- a/.claude/agents/classroom-workflow-auditor.md
+++ b/.claude/agents/classroom-workflow-auditor.md
@@ -37,9 +37,11 @@ Fixture class: `Terminal 101`, id `43960369-ad83-49dd-87a8-8627d45b2410`, teache
 
 ## Impersonation pattern (Supabase MCP) — caveat critique
 
-> ⚠ **Caveat F-C empirique 26/05/2026** : le pattern `set_config('role', 'authenticated', true)` ci-dessous fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `join_class_by_code`, `approve_teacher`), mais **n'est PAS fiable pour tester les RLS SELECT isolation purs**. Le `session_user` reste `postgres`, et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs ("semble voir cross-institution alors qu'en réalité non").
+> 📌 **Source canonique cross-agent** : mémoire CC `feedback_rls_isolation_test_rest_only.md`. Cette section résume le caveat applicable à cet agent ; pour la doctrine complète (autres agents, exemples shell complets, anti-leak combiné), se référer à la mémoire.
+
+> ⚠ **Caveat F-C empirique 26/05/2026** : le pattern `set_config('role', 'authenticated', true)` ci-dessous fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `join_class_by_code`, `approve_teacher`), mais **n'est PAS fiable pour tester l'isolation RLS SELECT pure**. Le `session_user` reste `postgres`, et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs ("semble voir cross-institution alors qu'en réalité non").
 >
-> **Pour tester RLS isolation, OBLIGATOIRE utiliser REST API + JWT réel** (cf. mémoire CC `feedback_rls_isolation_test_rest_only.md`). Le pattern CLI ci-dessous reste valide UNIQUEMENT pour les tests d'RPC.
+> **Pour tester RLS isolation, OBLIGATOIRE utiliser REST API + JWT réel**. Le pattern CLI ci-dessous reste valide UNIQUEMENT pour les tests d'RPC.
 
 ### Pour tester RPC functions (CLI OK)
 
@@ -85,7 +87,7 @@ rm .tmp/session.json
 
 > **Pattern F-B codifié 26/05/2026** suite à 4 classes orphelines détectées au début du run (`E2E_TEST_*`, `E2E_DEBUG_*` polluant la DB).
 
-1. **Naming convention** : tout test data créé par cet agent doit commencer par `E2E_` (ex : `E2E_AUDITOR_<timestamp>`, `E2E_CROSS_INSTITUTION_<scenario>`)
+1. **Naming convention** : toute donnée de test créée par cet agent doit commencer par `E2E_` (ex : `E2E_AUDITOR_<timestamp>`, `E2E_CROSS_INSTITUTION_<scenario>`)
 2. **Cleanup startup** : avant de créer les fixtures, `DELETE FROM public.classes WHERE name LIKE 'E2E_%'` (idempotent re-run safe)
 3. **Cleanup teardown** : fin de run, même `DELETE` pour ne pas laisser de traces
 4. **Crash safety** : utiliser BEGIN..EXCEPTION..ROLLBACK ou guard DELETE au startup

--- a/.claude/agents/institution-rbac-auditor.md
+++ b/.claude/agents/institution-rbac-auditor.md
@@ -51,7 +51,9 @@ Si ces 3 users + l'institution École B n'existent pas en prod, **bloque l'audit
 
 ## Impersonation pattern (Supabase MCP) — caveat critique
 
-> ⚠ **Caveat F-C empirique 26/05/2026** (cross-agent doctrine codifiée par `classroom-workflow-auditor` premier break-in) : le pattern `set_config('role', 'authenticated', true)` fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `approve_teacher`, `get_my_role`, `get_my_institution_id`), MAIS **n'est PAS fiable pour tester les RLS SELECT isolation purs**. Le `session_user` reste `postgres` et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs.
+> 📌 **Source canonique cross-agent** : mémoire CC `feedback_rls_isolation_test_rest_only.md`. Cette section résume le caveat applicable à cet agent ; pour la doctrine complète (autres agents, exemples shell complets, anti-leak combiné), se référer à la mémoire.
+
+> ⚠ **Caveat F-C empirique 26/05/2026** (cross-agent doctrine codifiée par `classroom-workflow-auditor` premier break-in) : le pattern `set_config('role', 'authenticated', true)` fonctionne pour tester les **RPC functions** (qui re-lisent `auth.uid()` dans leur body — `approve_teacher`, `get_my_role`, `get_my_institution_id`), MAIS **n'est PAS fiable pour tester l'isolation RLS SELECT pure**. Le `session_user` reste `postgres` et selon PG privilege resolution order, certaines tables peuvent bypass RLS via session owner → faux positifs.
 >
 > **Symptôme empirique mesuré 26/05** : via CLI impersonation institution_admin_b → `SELECT * FROM classes` retourne 7 classes (faux positif). Via REST API + JWT réel → 0 classes (correct). Ground truth = REST API.
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -181,7 +181,7 @@ Verifier dans vercel.json :
 Lister toutes les tables depuis src/app/types/database.ts et vérifier :
 - RLS active sur chaque table ?
 - Politiques couvrant SELECT, INSERT, UPDATE, DELETE ?
-- Utilisation de auth.uid() (jamais d'un parametre client) ?
+- Utilisation de auth.uid() (jamais d'un paramètre client) ?
 - CRITICAL si une table est lisible/modifiable par anon sans restriction
 
 ---

--- a/docs/audits/classroom-workflow-auditor-2026-05-26.md
+++ b/docs/audits/classroom-workflow-auditor-2026-05-26.md
@@ -124,7 +124,7 @@ Le pattern Supabase CLI `set_config('role', 'authenticated', true)` documenté d
 
 **Ground truth = REST API**.
 
-**Impact** : Le pattern CLI fonctionne bien pour tester les **RPC functions** (qui ont des `auth.uid()` explicites dans leur body, comme `join_class_by_code` ou `approve_teacher`), mais **n'est pas fiable** pour tester les **RLS SELECT isolation** purs.
+**Impact** : Le pattern CLI fonctionne bien pour tester les **RPC functions** (qui ont des `auth.uid()` explicites dans leur body, comme `join_class_by_code` ou `approve_teacher`), mais **n'est pas fiable** pour tester l'**isolation RLS SELECT pure**.
 
 **Fix — codifier dans les agents** :
 


### PR DESCRIPTION
## Summary

Suite Sourcery review sur PR #302 (déjà mergée) — 3 typos individuels + 2 suggestions architecturales valides traitées.

## 3 typos FR fixés

| Fichier | Avant | Après |
|---|---|---|
| `.claude/agents/classroom-workflow-auditor.md` L40 | "RLS SELECT isolation purs" | "isolation RLS SELECT pure" |
| `.claude/agents/classroom-workflow-auditor.md` L88 | "tout test data créé" | "toute donnée de test créée" |
| `.claude/agents/security-auditor.md` L184 | "parametre" | "paramètre" |

Drive-by : même typo "isolation purs" dans `institution-rbac-auditor.md` L54 + `docs/audits/classroom-workflow-auditor-2026-05-26.md` L127 → corrigés.

## Suggestions architecturales traitées

### Duplication doctrine RLS/JWT

Sourcery : "envisage d'en faire un seul fichier de doctrine partagé et d'y faire référence depuis chaque agent pour réduire la dérive lors de futures mises à jour".

**Implementation** : pattern "pointer + résumé local" plutôt qu'extraction d'un troisième fichier `.claude/agents/_shared.md` :

```markdown
> 📌 **Source canonique cross-agent** : mémoire CC `feedback_rls_isolation_test_rest_only.md`. 
> Cette section résume le caveat applicable à cet agent ; pour la doctrine complète 
> (autres agents, exemples shell complets, anti-leak combiné), se référer à la mémoire.
```

Ajouté dans `classroom-workflow-auditor.md` + `institution-rbac-auditor.md`. **Single source of truth** = mémoire CC ; les agents gardent un résumé local contextuel à leur scope.

### Prérequis python bash snippets

Sourcery : "soit mentionne explicitement ce prérequis, soit bascule vers un outil JSON CLI plus standard (par ex. `jq`)".

**Implementation** : note prérequis ajoutée dans `feedback_rls_isolation_test_rest_only.md` (source canonique) :

```
**Prérequis shell** : `python` (3.x) disponible dans le PATH pour parser/construire 
JSON en évitant les pièges d'échappement de `--data`. `jq` est une alternative valide 
si dispo (sur Terminal Learning local Bash via Git Bash : pas dispo par défaut, on 
utilise donc `python`). Adapter au runtime cible (Linux/macOS prod CI : `python3` + 
`jq` typiquement OK).
```

## Test plan

- [x] 4 fichiers modifiés : 3 agents + 1 audit report
- [x] `grep` confirms ZERO typo restant (`purs\b`, `tout test data`, `parametre`)
- [ ] CI verte sur push
- [ ] Sourcery PASS attendu (suggestions traitées)
- [ ] Voie C-eligible smoke prod post-merge (docs only, 0 fichier runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Aligner la doctrine de test RLS/JWT entre les agents tout en corrigeant quelques fautes mineures dans la documentation française.

Documentation :
- Ajouter une référence canonique partagée à la doctrine de test RLS/JWT dans la documentation des agents concernés, tout en conservant des résumés locaux propres à chaque agent.
- Préciser que l’isolation RLS doit être testée via l’API REST avec de vrais JWT et ajuster le libellé concernant l’isolation RLS des requêtes SELECT dans la documentation d’audit et des agents.
- Corriger plusieurs fautes mineures de français et problèmes de formulation dans la documentation sur la sécurité et les workflows de classe.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align RLS/JWT testing doctrine across agents while fixing minor French documentation typos.

Documentation:
- Add a shared canonical reference to the RLS/JWT testing doctrine in relevant agent docs, keeping local summaries per agent.
- Clarify that RLS isolation must be tested via REST API with real JWTs and adjust wording around RLS SELECT isolation in audit and agent docs.
- Fix several minor French typos and phrasing issues in security and classroom workflow documentation.

</details>