### PR TITLE
fix(rbac): Sprint 2.B hotfix — super_admin can approve teachers (cross-institution supervision)

### DIFF
--- a/src/test/approveTeacher.integration.test.ts
+++ b/src/test/approveTeacher.integration.test.ts
@@ -17,6 +17,9 @@
  *   5. Audit log integrity — happy path inserts a clean admin_audit_log row
  *   6. Anonymous EXECUTE blocked at GRANT layer (F-002 institution-rbac-auditor)
  *   7. Direct REST PATCH still produces audit row via trigger (F-001 audit bypass closure)
+ *   8. super_admin approves pending_teacher_b (hotfix migration 027 — cross-role)
+ *   9. super_admin approves pending_teacher_a cross-institution (hotfix 027 — supervision scope)
+ *   10. Audit log enriched with caller_role + target_institution_id (hotfix 027)
  */
 
 import { config as loadEnv } from 'dotenv';
@@ -41,7 +44,10 @@ const TEACHER_B_PASSWORD = process.env.TEST_TEACHER_B_PASSWORD ?? '';
 const TEACHER_B_UUID     = process.env.TEST_TEACHER_B_UUID     ?? '';
 
 const PENDING_B_UUID = process.env.TEST_PENDINGTEACHER_B_UUID ?? '';
-const PENDING_A_UUID = '11111111-1111-1111-1111-111111111104'; // École A pending_teacher
+// École A pending_teacher — from .env.test (fallback to migration 006 fixture UUID
+// for backward compatibility). security-auditor L2 decoupling.
+const PENDING_A_UUID =
+  process.env.TEST_PENDINGTEACHER_UUID ?? '11111111-1111-1111-1111-111111111104';
 
 const SKIP =
   !SUPABASE_URL ||
@@ -93,7 +99,6 @@ async function resetPendingB(): Promise<void> {
     .update({ role: 'pending_teacher' })
     .eq('id', PENDING_B_UUID);
   if (error) {
-    // eslint-disable-next-line no-console
     console.warn(`[approveTeacher.integration.test] resetPendingB failed: ${error.message}`);
   }
 }
@@ -354,5 +359,120 @@ describe('approve_teacher — direct PATCH audit row (F-001 closure)', () => {
 
     expect(rpcAfter ?? 0).toBe((rpcBefore ?? 0) + 1);
     expect(patchAfter ?? 0).toBe(patchBefore ?? 0);
+  });
+});
+
+// ─── Test 8 & 9 & 10: Hotfix migration 027 — super_admin cross-role + cross-institution
+// ────────────────────────────────────────────────────────────────────────────
+// Bug UX trouvé empiriquement 26/05 par @thierry : super_admin voit le panel mais
+// le RPC body check 'caller_role = institution_admin' strict rejette super_admin.
+// Migration 027 étend l'RPC : accepte institution_admin (same-institution) OR
+// super_admin (cross-institution allowed).
+
+describe('approve_teacher — hotfix 027 super_admin support', () => {
+  /**
+   * Reset pending_teacher_a (École A) to 'pending_teacher' state.
+   * Pattern identique à resetPendingB (super_admin can bypass via trigger 010 branch).
+   * Garantie d'exécution via afterAll ci-dessous (security-auditor L1 robustness).
+   */
+  const resetPendingA = async (): Promise<void> => {
+    if (!superAdminClient) return;
+    const { error } = await superAdminClient
+      .from('profiles')
+      .update({ role: 'pending_teacher' })
+      .eq('id', PENDING_A_UUID);
+    if (error) {
+      console.warn(`[approveTeacher.integration.test] resetPendingA failed: ${error.message}`);
+    }
+  };
+
+  // [security-auditor L1] try/finally robustness — si un test 9 throw avant
+  // d'atteindre son cleanup inline, ce afterAll garantit l'idempotence sur
+  // l'École A pending_teacher pour les suites suivantes.
+  afterAll(async () => {
+    if (SKIP) return;
+    try {
+      await resetPendingA();
+    } catch (err) {
+      console.warn(`[approveTeacher.integration.test] afterAll resetPendingA threw: ${err}`);
+    }
+  });
+
+  it.skipIf(SKIP)('super_admin approves pending_teacher_b (École B) — cross-role success', async () => {
+    const { error } = await superAdminClient.rpc('approve_teacher', {
+      target_user_id: PENDING_B_UUID,
+    });
+    expect(error).toBeNull();
+
+    // Verify role promoted
+    const { data } = await superAdminClient
+      .from('profiles')
+      .select('role')
+      .eq('id', PENDING_B_UUID)
+      .single();
+    expect(data?.role).toBe('teacher');
+  });
+
+  it.skipIf(SKIP)('super_admin approves pending_teacher_a (École A) — cross-institution allowed (supervision)', async () => {
+    await resetPendingA();
+
+    const { error } = await superAdminClient.rpc('approve_teacher', {
+      target_user_id: PENDING_A_UUID,
+    });
+    expect(error).toBeNull();
+
+    const { data } = await superAdminClient
+      .from('profiles')
+      .select('role')
+      .eq('id', PENDING_A_UUID)
+      .single();
+    expect(data?.role).toBe('teacher');
+
+    // Restore for idempotence — next test runs expect pending_teacher_a in pending state
+    await resetPendingA();
+  });
+
+  it.skipIf(SKIP)('audit log enriched with caller_role + target_institution_id (migration 027)', async () => {
+    // Snapshot count before
+    const { count: beforeCount } = await superAdminClient
+      .from('admin_audit_log')
+      .select('*', { count: 'exact', head: true })
+      .eq('action', 'approve_teacher')
+      .eq('target_id', PENDING_B_UUID);
+
+    // super_admin approves
+    const { error: rpcErr } = await superAdminClient.rpc('approve_teacher', {
+      target_user_id: PENDING_B_UUID,
+    });
+    expect(rpcErr).toBeNull();
+
+    // Verify latest audit row has enriched metadata (caller_role + target_institution_id)
+    const { count: afterCount } = await superAdminClient
+      .from('admin_audit_log')
+      .select('*', { count: 'exact', head: true })
+      .eq('action', 'approve_teacher')
+      .eq('target_id', PENDING_B_UUID);
+    expect(afterCount ?? 0).toBe((beforeCount ?? 0) + 1);
+
+    const { data: row } = await superAdminClient
+      .from('admin_audit_log')
+      .select('actor_id, metadata')
+      .eq('action', 'approve_teacher')
+      .eq('target_id', PENDING_B_UUID)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    // Hotfix 027 enriched metadata
+    expect(row?.metadata).toMatchObject({
+      caller_role: 'super_admin',
+      scope: 'global', // [security-auditor M1 fix] distingue super_admin path
+      previous_role: 'pending_teacher',
+      new_role: 'teacher',
+    });
+    // target_institution_id should be the École B UUID (super_admin has no own institution)
+    expect((row?.metadata as { target_institution_id?: string })?.target_institution_id).toBeTruthy();
+    // caller_institution_id should be null for super_admin (no institution scope)
+    expect((row?.metadata as { caller_institution_id?: string | null })?.caller_institution_id).toBeNull();
   });
 });

--- a/supabase/migrations/027_approve_teacher_allow_super_admin.sql
+++ b/supabase/migrations/027_approve_teacher_allow_super_admin.sql
@@ -1,0 +1,121 @@
+-- Migration 027 — Hotfix Sprint 2.B reliquat — super_admin can approve teachers
+--
+-- Bug UX trouvé empiriquement 26/05/2026 par @thierry post-Sprint 2.B Étape 4 :
+--   * super_admin connecté voit /app/institution + 2 pending teachers (RLS allow
+--     cross-institution = intentional pour super_admin)
+--   * Click "Approuver" → erreur "Vous n'avez pas la permission d'approuver ce profil"
+--   * Root cause : RPC approve_teacher body check `caller_role = 'institution_admin'`
+--     strict, rejette super_admin
+--   * RequireRole UI permissif (institution_admin + super_admin) → divergence UX
+--
+-- Doc : memory/project_sprint_2b_super_admin_approve_bug.md (Option A recommandée).
+--
+-- Cette migration étend `approve_teacher` :
+--   1. Accept 2 rôles : institution_admin OR super_admin
+--   2. Pour institution_admin : check same-institution (logic actuelle préservée)
+--   3. Pour super_admin : skip institution check (cross-institution allowed)
+--   4. Audit log enrichi : caller_role + target_institution_id pour forensic traceability
+--
+-- Patterns préservés (migration 025 hardening + Sourcery review PR #298) :
+--   - FOR UPDATE row lock (race-safe)
+--   - Compare-and-swap WHERE role + IF NOT FOUND (belt + suspenders)
+--   - Flag transactionnel app.in_approve_teacher_rpc (évite double insertion trigger 026)
+--   - REVOKE FROM PUBLIC + anon, GRANT TO authenticated only
+
+create or replace function public.approve_teacher(target_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  caller_role text;
+  caller_institution_id uuid;
+  target_institution_id uuid;
+  target_role text;
+begin
+  -- 1. Caller doit être institution_admin OU super_admin
+  caller_role := public.get_my_role();
+  if caller_role is null or caller_role not in ('institution_admin', 'super_admin') then
+    raise exception 'PERMISSION_DENIED: institution_admin or super_admin role required';
+  end if;
+
+  -- 2. Pour institution_admin : caller doit avoir un institution_id non-null
+  --    Pour super_admin : skip (peut être null par design — global scope)
+  if caller_role = 'institution_admin' then
+    caller_institution_id := public.get_my_institution_id();
+    if caller_institution_id is null then
+      raise exception 'PERMISSION_DENIED: caller has no institution';
+    end if;
+  end if;
+
+  -- 3. Target doit exister + (institution_admin only) appartenir à la même institution
+  --    FOR UPDATE pose row-level lock (race-safe sérialisation des approvals concurrents)
+  select role, institution_id
+    into target_role, target_institution_id
+    from public.profiles
+   where id = target_user_id
+   for update;
+
+  if not found then
+    raise exception 'NOT_FOUND: target user does not exist';
+  end if;
+
+  -- 4. Institution check appliqué SEULEMENT pour institution_admin
+  --    super_admin peut approuver n'importe quelle institution (par design — supervision)
+  if caller_role = 'institution_admin' then
+    if target_institution_id is null or target_institution_id <> caller_institution_id then
+      raise exception 'PERMISSION_DENIED: cross-institution approval blocked';
+    end if;
+  end if;
+
+  -- 5. Target doit être en pending_teacher (même check pour les 2 rôles)
+  if target_role <> 'pending_teacher' then
+    raise exception 'INVALID_STATE: target not in pending_teacher state';
+  end if;
+
+  -- 6. Flag transactionnel pour éviter double insertion via trigger audit 026
+  perform set_config('app.in_approve_teacher_rpc', 'true', true);
+
+  -- 7. Compare-and-swap UPDATE (Sourcery review PR #298 — belt + suspenders)
+  update public.profiles
+     set role = 'teacher'
+   where id = target_user_id
+     and role = 'pending_teacher';
+
+  if not found then
+    raise exception 'INVALID_STATE: target not in pending_teacher state';
+  end if;
+
+  -- 8. Audit log enrichi
+  --    - caller_role : différencie super_admin vs institution_admin path
+  --    - scope : 'institution' pour institution_admin (caller_institution_id non-null),
+  --              'global' pour super_admin (caller_institution_id intentionnellement null)
+  --              Évite ambiguïté forensique entre absence-intentionnelle et bug futur
+  --              (security-auditor M1, drive-by fix in-PR).
+  --    - caller_institution_id : null pour super_admin, valid pour institution_admin
+  --    - target_institution_id : toujours présent (l'institution promue)
+  insert into public.admin_audit_log (actor_id, action, target_type, target_id, metadata)
+  values (
+    auth.uid(),
+    'approve_teacher',
+    'user',
+    target_user_id,
+    jsonb_build_object(
+      'caller_role', caller_role,
+      'scope', case when caller_role = 'super_admin' then 'global' else 'institution' end,
+      'caller_institution_id', caller_institution_id,
+      'target_institution_id', target_institution_id,
+      'previous_role', 'pending_teacher',
+      'new_role', 'teacher'
+    )
+  );
+end;
+$$;
+
+revoke execute on function public.approve_teacher(uuid) from public;
+revoke execute on function public.approve_teacher(uuid) from anon;
+grant execute on function public.approve_teacher(uuid) to authenticated;
+
+comment on function public.approve_teacher(uuid) is
+  'Sprint 2.B Étape 3 hotfix (THI-280 reliquat, migration 027). Promotes pending_teacher → teacher. Accepts institution_admin (same-institution only) OR super_admin (any institution). SECURITY DEFINER + FOR UPDATE row lock + compare-and-swap UPDATE (race-safe). REVOKE PUBLIC + anon. Audit log enriched with caller_role + target_institution_id for forensic traceability.';


### PR DESCRIPTION
## Summary

**Hotfix Sprint 2.B reliquat** — Bug UX trouvé empiriquement 26/05/2026 par @thierry post Étape 4 : super_admin connecté sur `/app/institution` voit les 2 pending_teachers (RLS allow cross-institution = intentional) mais click "Approuver" échoue avec « Vous n'avez pas la permission » car RPC body check `caller_role = 'institution_admin'` strict, rejette super_admin.

## Migration 027 — étend `approve_teacher`

- Accepte `institution_admin` OR `super_admin` (check élargi)
- institution_admin : check same-institution (logic 025 préservée)
- super_admin : skip institution check (cross-institution allowed pour supervision)
- Audit log enrichi : `caller_role` + `scope` ('global'/'institution') + `caller_institution_id` (null pour super_admin) + `target_institution_id`

Patterns préservés intégralement (migration 025 + Sourcery PR #298) :
- FOR UPDATE row lock + compare-and-swap WHERE role + IF NOT FOUND (race-safe)
- Flag transactionnel `app.in_approve_teacher_rpc` (évite double insert trigger 026)
- REVOKE FROM PUBLIC + anon, GRANT TO authenticated only

## Tests vitest +3 (11/11 PASS empirique PROD)

| # | Cas |
|---|---|
| 8 | super_admin approves pending_teacher_b École B → cross-role success |
| 9 | super_admin approves pending_teacher_a École A → cross-institution allowed |
| 10 | Audit log enriched : caller_role=super_admin, scope=global, target_institution_id présent |

## Audits cascade ALL GREEN

### `security-auditor` 🟢 SHIP 9.4/10
- 0 CRITICAL · 0 HIGH
- 1 MED (forensic opacity intentionnelle) **fixé in-PR via scope metadata**
- 4 LOW — 3 fixés in-PR (afterAll cleanup + TEST_PENDINGTEACHER_UUID env var + scope='global' clarity)

### `institution-rbac-auditor` 🟢 SHIP — 0 CRITICAL/0 HIGH
- 16/16 static code checks PASS
- 4/4 cross-institution isolation tests PASS (REST API + JWT)
- 2/2 super_admin new path tests PASS (migration 027 core)
- 2/2 race-safety + defense-in-depth (trigger 026) PASS
- 2/2 audit log discipline + RLS PASS

## Test plan

- [x] CI verte (type-check + lint + test + build)
- [x] 11/11 approveTeacher.integration.test.ts PASS PROD
- [x] Full suite 1724 PASS (stable, 0 régression)
- [x] security-auditor SHIP 9.4/10
- [x] institution-rbac-auditor SHIP 0 CRITICAL/0 HIGH
- [ ] Voie A Chrome MCP smoke preview
- [ ] Sourcery check

## Refs

- Sprint 2.B umbrella (THI-280) déjà Done — ce hotfix est un reliquat post-merge
- Doc bug : `memory/project_sprint_2b_super_admin_approve_bug.md`
- Validation finale post-merge : @thierry pourra cliquer "Approuver" sur `/app/institution` connecté en super_admin → row promue + 1 audit log row avec metadata `scope: 'global'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)