### PR TITLE
feat(rbac): Sprint 2.B.2 UX feedback — scope badge + success status after approve

### DIFF
--- a/src/app/components/InstitutionAdminPanel.tsx
+++ b/src/app/components/InstitutionAdminPanel.tsx
@@ -24,12 +24,13 @@
  *             regardless of path (migration 026)
  */
 import { Helmet } from 'react-helmet-async';
-import { CheckCircle2, ShieldUser, UserCheck } from 'lucide-react';
+import { CheckCircle2, Globe, ShieldUser, UserCheck, X } from 'lucide-react';
 
 import { RequireRole } from './auth/RequireRole';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { usePendingTeachers } from '@/lib/hooks/usePendingTeachers';
+import { useUserRole } from '@/lib/hooks/useUserRole';
 
 export function InstitutionAdminPanel() {
   return (
@@ -40,7 +41,26 @@ export function InstitutionAdminPanel() {
 }
 
 function InstitutionAdminPanelContent() {
-  const { pendingTeachers, loading, approving, error, approve } = usePendingTeachers();
+  const {
+    pendingTeachers,
+    loading,
+    approving,
+    error,
+    lastSuccess,
+    approve,
+    clearLastSuccess,
+  } = usePendingTeachers();
+  const { role } = useUserRole();
+
+  // Sprint 2.B.2 — scope visible distingue le path forensique :
+  //   - super_admin  → 'global'      (cross-institution allowed via migration 027)
+  //   - institution_admin → 'institution' (same-institution only)
+  // Cohérent avec metadata.scope inséré par la RPC dans admin_audit_log.
+  const isSuperAdmin = role === 'super_admin';
+  const scopeLabel = isSuperAdmin ? 'global' : 'institution';
+  const scopeDescription = isSuperAdmin
+    ? "Tu agis en super_admin — visibilité et approbations cross-institution."
+    : "Les profils visibles ici appartiennent uniquement à votre institution.";
 
   return (
     <main className="flex-1 px-6 py-8 max-w-4xl mx-auto w-full">
@@ -54,17 +74,29 @@ function InstitutionAdminPanelContent() {
       </Helmet>
 
       <header className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
+        <div className="flex flex-wrap items-center gap-3 mb-2">
           <span className="text-emerald-400" aria-hidden="true">
             <ShieldUser size={24} />
           </span>
           <h1 className="text-2xl font-semibold text-[var(--github-text-primary)]">
             Mon institution
           </h1>
+          {/* Sprint 2.B.2 — badge scope visible (forensic clarity). */}
+          <span
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-mono border ${
+              isSuperAdmin
+                ? 'bg-emerald-500/10 border-emerald-500/40 text-emerald-300'
+                : 'bg-[var(--github-bg)]/60 border-[var(--github-border-primary)] text-[var(--github-text-secondary)]'
+            }`}
+            aria-label={`Périmètre d'action ${scopeLabel}`}
+          >
+            {isSuperAdmin && <Globe size={11} aria-hidden="true" />}
+            scope : {scopeLabel}
+          </span>
         </div>
         <p className="text-sm text-[var(--github-text-secondary)]">
-          Approuvez les demandes d&apos;enseignants pour votre établissement.
-          Les profils visibles ici appartiennent uniquement à votre institution.
+          Approuvez les demandes d&apos;enseignants pour votre établissement.{' '}
+          {scopeDescription}
         </p>
       </header>
 
@@ -87,6 +119,40 @@ function InstitutionAdminPanelContent() {
             so screen readers don't re-announce the static heading on each
             refresh (ui-auditor M1). */}
         <div aria-live="polite" aria-busy={loading}>
+          {/* Sprint 2.B.2 — feedback success post-approve.
+              Affiche le displayName promu + scope utilisé (path forensique).
+              Auto-clear après 8s (timer dans le hook). Bouton X pour dismiss
+              manuel — cohérent avec le pattern toast inline non-bloquant. */}
+          {lastSuccess && !error && (
+            <Card
+              variant="tl-surface"
+              className="mb-4 px-4 py-3 border-emerald-500/40 bg-emerald-500/5"
+              role="status"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-emerald-400 shrink-0" aria-hidden="true">
+                    <CheckCircle2 size={16} />
+                  </span>
+                  <p className="text-sm text-emerald-300 font-mono truncate">
+                    <span className="font-semibold">{lastSuccess.displayName}</span>{' '}
+                    approuvé · scope {scopeLabel}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost-gh"
+                  size="icon-lg"
+                  className="shrink-0 text-emerald-300/70 hover:text-emerald-300"
+                  onClick={clearLastSuccess}
+                  aria-label="Fermer le message de confirmation"
+                >
+                  <X size={14} aria-hidden="true" />
+                </Button>
+              </div>
+            </Card>
+          )}
+
           {error && (
             <Card
               variant="tl-surface"

--- a/src/lib/hooks/usePendingTeachers.ts
+++ b/src/lib/hooks/usePendingTeachers.ts
@@ -19,15 +19,19 @@
  *   loading         : initial fetch in flight
  *   approving       : id currently being approved (single RPC at a time)
  *   error           : last failed operation (Error or null)
+ *   lastSuccess     : Sprint 2.B.2 UX feedback — derniere approbation réussie
+ *                    (displayName + scope) pour affichage "Approuvé via X".
+ *                    Auto-clear après 8s OU prochain `approve()` call.
  *   approve(id)     : calls approve_teacher RPC and refetches on success
  *   refresh()       : manual re-fetch
+ *   clearLastSuccess: dismiss manuel du message de succès
  *
  * Out of scope (v1.0 Étape 4) :
  *   - Rejection workflow (no `reject_teacher` RPC yet — backlog)
  *   - Multi-select bulk approve
  *   - Statistics (n total pending, n approved this month)
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '@/app/context/AuthContext';
 import { supabase } from '@/lib/supabase';
@@ -42,13 +46,28 @@ export interface PendingTeacher {
   created_at: string;
 }
 
+/**
+ * Sprint 2.B.2 — feedback UX post-approve.
+ * Capture le displayName de la dernière approbation réussie pour affichage
+ * inline (toast-like) dans le panel. Le composant InstitutionAdminPanel
+ * enrichit avec le scope ('global' pour super_admin / 'institution' pour
+ * institution_admin) via useUserRole — séparation concerns hook/composant.
+ */
+export interface ApprovalSuccess {
+  displayName: string;
+}
+
+const SUCCESS_AUTO_CLEAR_MS = 8000;
+
 export interface UsePendingTeachersResult {
   pendingTeachers: PendingTeacher[];
   loading: boolean;
   approving: string | null;
   error: Error | null;
+  lastSuccess: ApprovalSuccess | null;
   approve: (targetId: string) => Promise<boolean>;
   refresh: () => Promise<void>;
+  clearLastSuccess: () => void;
 }
 
 async function fetchPendingTeachers(): Promise<PendingTeacher[]> {
@@ -70,6 +89,25 @@ export function usePendingTeachers(): UsePendingTeachersResult {
   const [loading, setLoading] = useState(true);
   const [approving, setApproving] = useState<string | null>(null);
   const [error, setError] = useState<Error | null>(null);
+  const [lastSuccess, setLastSuccess] = useState<ApprovalSuccess | null>(null);
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLastSuccess = useCallback(() => {
+    if (successTimerRef.current) {
+      clearTimeout(successTimerRef.current);
+      successTimerRef.current = null;
+    }
+    setLastSuccess(null);
+  }, []);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current);
+      }
+    };
+  }, []);
 
   const refresh = useCallback(async () => {
     if (!user || !supabase) {
@@ -105,8 +143,19 @@ export function usePendingTeachers(): UsePendingTeachersResult {
       }
       if (approving) return false;
 
+      // Snapshot du target avant approve — utilisé pour le success message
+      const targetRow = pendingTeachers.find((row) => row.id === targetId);
+      const displayName =
+        targetRow?.display_name ?? targetRow?.username ?? 'Profil sans nom';
+
       setApproving(targetId);
       setError(null);
+      // Clear precedent success message (anti-stale display)
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current);
+        successTimerRef.current = null;
+      }
+      setLastSuccess(null);
 
       try {
         const { error: rpcError } = await supabase.rpc('approve_teacher', {
@@ -134,6 +183,20 @@ export function usePendingTeachers(): UsePendingTeachersResult {
         // A refresh() would also work but adds a round-trip — the RLS view
         // would exclude the now-teacher anyway.
         setPendingTeachers((prev) => prev.filter((row) => row.id !== targetId));
+
+        // Sprint 2.B.2 — feedback UX post-approve.
+        // Le hook expose uniquement `displayName` ; le composant enrichit
+        // l'affichage avec le scope (super_admin/institution_admin) via
+        // useUserRole. Séparation concerns : pas de round-trip SELECT
+        // admin_audit_log (RLS restreint super_admin only + latence inutile).
+        setLastSuccess({ displayName });
+
+        // Auto-clear timer
+        successTimerRef.current = setTimeout(() => {
+          setLastSuccess(null);
+          successTimerRef.current = null;
+        }, SUCCESS_AUTO_CLEAR_MS);
+
         return true;
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Approbation impossible'));
@@ -142,8 +205,17 @@ export function usePendingTeachers(): UsePendingTeachersResult {
         setApproving(null);
       }
     },
-    [user, approving],
+    [user, approving, pendingTeachers],
   );
 
-  return { pendingTeachers, loading, approving, error, approve, refresh };
+  return {
+    pendingTeachers,
+    loading,
+    approving,
+    error,
+    lastSuccess,
+    approve,
+    refresh,
+    clearLastSuccess,
+  };
 }

--- a/src/test/institutionAdminPanel.test.tsx
+++ b/src/test/institutionAdminPanel.test.tsx
@@ -52,14 +52,17 @@ type MockPending = {
   loading: boolean;
   approving: string | null;
   error: Error | null;
+  lastSuccess: { displayName: string } | null;
 };
 const pendingState: MockPending = {
   pendingTeachers: [],
   loading: false,
   approving: null,
   error: null,
+  lastSuccess: null,
 };
 const approveMock = vi.fn().mockResolvedValue(true);
+const clearLastSuccessMock = vi.fn();
 
 vi.mock('@/lib/hooks/usePendingTeachers', () => ({
   usePendingTeachers: () => ({
@@ -67,8 +70,10 @@ vi.mock('@/lib/hooks/usePendingTeachers', () => ({
     loading: pendingState.loading,
     approving: pendingState.approving,
     error: pendingState.error,
+    lastSuccess: pendingState.lastSuccess,
     approve: approveMock,
     refresh: vi.fn().mockResolvedValue(undefined),
+    clearLastSuccess: clearLastSuccessMock,
   }),
 }));
 
@@ -93,8 +98,10 @@ beforeEach(() => {
   pendingState.loading = false;
   pendingState.approving = null;
   pendingState.error = null;
+  pendingState.lastSuccess = null;
   approveMock.mockClear();
   approveMock.mockResolvedValue(true);
+  clearLastSuccessMock.mockClear();
 });
 
 describe('InstitutionAdminPanel — auth & role guard', () => {
@@ -229,5 +236,59 @@ describe('InstitutionAdminPanel — institution_admin view', () => {
     const button = screen.getByRole('button', { name: /approuver alice pending/i });
     expect(button).toBeDisabled();
     expect(button).toHaveTextContent(/approbation…/i);
+  });
+});
+
+// ─── Sprint 2.B.2 — UX feedback (scope badge + success toast) ────────────────
+
+describe('InstitutionAdminPanel — Sprint 2.B.2 UX feedback', () => {
+  it('renders scope badge "institution" for institution_admin', () => {
+    authState.user = { id: 'instadmin-123' };
+    roleState.role = 'institution_admin';
+    renderPanel();
+    const badge = screen.getByLabelText(/périmètre d'action institution/i);
+    expect(badge).toHaveTextContent(/scope\s*:\s*institution/i);
+  });
+
+  it('renders scope badge "global" for super_admin', () => {
+    authState.user = { id: 'super-123' };
+    roleState.role = 'super_admin';
+    renderPanel();
+    const badge = screen.getByLabelText(/périmètre d'action global/i);
+    expect(badge).toHaveTextContent(/scope\s*:\s*global/i);
+  });
+
+  it('describes super_admin scope in header subtitle (cross-institution explicit)', () => {
+    authState.user = { id: 'super-123' };
+    roleState.role = 'super_admin';
+    renderPanel();
+    expect(
+      screen.getByText(/super_admin.*cross-institution/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders success status with displayName + scope after approve (lastSuccess set)', () => {
+    authState.user = { id: 'instadmin-123' };
+    roleState.role = 'institution_admin';
+    pendingState.lastSuccess = { displayName: 'Alice Pending' };
+    renderPanel();
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(/Alice Pending/);
+    expect(status).toHaveTextContent(/approuvé.*scope institution/i);
+  });
+
+  it('clicking dismiss X on success card calls clearLastSuccess', async () => {
+    authState.user = { id: 'super-123' };
+    roleState.role = 'super_admin';
+    pendingState.lastSuccess = { displayName: 'Bob Pending' };
+    renderPanel();
+    const dismiss = screen.getByRole('button', {
+      name: /fermer le message de confirmation/i,
+    });
+    const user = userEvent.setup();
+    await user.click(dismiss);
+    await waitFor(() => {
+      expect(clearLastSuccessMock).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Hotfix UX Sprint 2.B reliquat** — Lacune identifiée empiriquement par @thierry 27/05 : « où est l'info qui prouve que j'ai approuvé un user avec le rôle adapté ? ». Le panel `/app/institution` n'avait aucun feedback visuel post-approve ni indicateur du rôle/scope utilisé.

## Solution

### 1. Badge scope dans le header (visible permanent)
- **super_admin** → badge emerald `scope: global` + icône Globe + subtitle "cross-institution"
- **institution_admin** → badge neutre `scope: institution` + subtitle standard
- `aria-label="Périmètre d'action {scope}"` pour lecteurs d'écran

### 2. Success status après approve (toast inline non-bloquant)
- Card emerald avec `role="status"` (ARIA assertive)
- Texte : `{displayName} approuvé · scope {scope}`
- Bouton X dismiss `size="icon-lg"` = 44×44 (Apple HIG ✅)
- Auto-clear 8s timer dans le hook (cleanup sur unmount + sur new approve)

### 3. Séparation concerns
- Hook `usePendingTeachers` expose `lastSuccess: { displayName }` + `clearLastSuccess()`
- Composant enrichit avec scope via `useUserRole` (pas de round-trip SELECT admin_audit_log — RLS restreint super_admin only + latence inutile)

## Tests +5 (17/17 PASS)

| # | Cas |
|---|---|
| 13 | scope badge "institution" rendered for institution_admin |
| 14 | scope badge "global" rendered for super_admin |
| 15 | subtitle mentions cross-institution for super_admin |
| 16 | success status renders displayName + scope |
| 17 | dismiss X calls clearLastSuccess |

Total : 12 RBAC × behavior (Sprint 2.B Étape 4) + 5 Sprint 2.B.2 = **17/17 PASS**.

Full suite : **1729 PASS** + 20 skipped (+5 vs main).

## Audit ui-auditor

- **🔴 → 🟢** : 1 CRITICAL initial (dismiss button 32×32 < HIG 44×44) **fixé in-PR** via `size="icon-lg"`
- Verdict final : 0 CRITICAL · 0 HIGH · 0 MED · 0 LOW restant
- Cohérent doctrine THI-152 + pattern AiTutorPanel touch targets

## Test plan

- [x] 17/17 tests PASS (5 nouveaux Sprint 2.B.2 + 12 existing)
- [x] Full suite 1729 PASS (stable, 0 régression)
- [x] Typecheck + lint clean
- [x] ui-auditor 🟢 SHIP après C1 fix in-PR
- [ ] CI verte (sur push)
- [ ] Voie A Chrome MCP smoke preview
- [ ] Sourcery check
- [ ] Validation visuelle @thierry après merge (login super_admin → click Approuver → toast vert "{nom} approuvé · scope global" visible 8s)

## Refs

- Bug UX identifié : `memory/project_sprint_2b_super_admin_approve_bug.md`
- Hotfix migration 027 mergé matin via PR #305 : enriched audit_log metadata `scope` field
- Sprint 2.B umbrella THI-280 (Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)