### PR TITLE
fix(ui): UserMenu — restaurer l'effet de survol sur 'Mon profil'

### DIFF
--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -121,17 +121,17 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
           </div>
           {extraActions && <div className="flex items-center gap-1 shrink-0">{extraActions}</div>}
         </div>
-        <Button
-          asChild
-          variant="emerald-soft"
-          size="link-inline"
-          className="w-full gap-2 min-h-11 py-1.5 mb-1.5 rounded-md text-xs font-mono hover:border-emerald-500/40"
+        {/* Mon profil — Link direct (pas Button asChild) pour fiabilité hover.
+            asChild + variant Button + <Link> avait un problème de propagation
+            des classes hover en cascade. Pattern cohérent NavLink sidebar :
+            classes explicites bg + border + text + transition + focus-visible. */}
+        <Link
+          to="/app/profile"
+          className="flex items-center justify-center w-full gap-2 min-h-11 py-1.5 mb-1.5 rounded-md text-xs font-mono bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 hover:text-emerald-300 border border-emerald-500/20 hover:border-emerald-500/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0"
         >
-          <Link to="/app/profile">
-            <CircleUser size={12} aria-hidden="true" />
-            Mon profil
-          </Link>
-        </Button>
+          <CircleUser size={12} aria-hidden="true" />
+          Mon profil
+        </Link>
         <Button
           variant="ghost"
           size="link-inline"


### PR DESCRIPTION
## Summary

**Bug UI remonté empiriquement par @thierry 27/05** : « ce menu n'a plus son effet de survol sur Mon profil ». Le pattern `<Button asChild variant="emerald-soft">` + `<Link>` enfant avait un problème de propagation des classes hover en cascade.

## Root cause

- Variant `emerald-soft` définit `bg-emerald-500/10 hover:bg-emerald-500/20`
- className inline ajoute `hover:border-emerald-500/40` (potentielle surcharge)
- `asChild` + Radix Slot propage les classes au `<Link>` mais empiriquement l'effet hover devenait subtle/invisible

## Solution

**Abandon du pattern Button asChild → Link direct** avec classes explicites, cohérent avec NavLink sidebar (Tableau de bord, Mon institution, etc.) :

```tsx
<Link
  to="/app/profile"
  className="flex items-center justify-center w-full gap-2 min-h-11 py-1.5 mb-1.5 rounded-md text-xs font-mono
             bg-emerald-500/10 hover:bg-emerald-500/20
             text-emerald-400 hover:text-emerald-300
             border border-emerald-500/20 hover:border-emerald-500/40
             transition-colors
             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0"
>
```

**Triple effet hover** (bg + text + border) plus visible que le subtle 10%→20% single-token précédent. Cohérence design avec "Se déconnecter" qui suit le même pattern triple-effet sur palette red.

## Évolution role-aware menu

@thierry délègue : « menu amélioré peut être réfléchi à la fin du projet ou quand il sera assez avancé pour être utilisé par les écoles ». **Décision orchestrateur** : fix hover seulement aujourd'hui. Refonte role-aware (badge rôle dans header, lien "Mon espace" role-aware) → backlog post-écoles.

Pattern scope badge introduit par Sprint 2.B.2 dans `/app/institution` servira de référence design pour la future refonte UserMenu role-aware.

## Test plan

- [x] Full suite 1729 PASS (stable, 0 régression)
- [x] Typecheck + lint clean
- [ ] CI verte (sur push)
- [ ] Voie A Chrome MCP smoke preview
- [ ] Validation visuelle @thierry hover Mon profil sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)