### PR TITLE
fix(auth): clearUserRoleCache() on signOut — F-1 rbac-flow-tester break-in 27/05

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { clearAiSessionData } from '@/lib/ai/keyManager';
+import { clearUserRoleCache } from '@/lib/hooks/useUserRole';
 
 // Dynamic import — defers the 194 kB Supabase SDK chunk from the FCP critical
 // path. The module starts loading immediately in parallel with initial render,
@@ -72,6 +73,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       console.error('[auth] clearAiSessionData failed (non-fatal):', err);
     }
+    // F-1 fix (rbac-flow-tester break-in 27/05/2026) : clear in-memory user role
+    // cache to prevent any cross-account leak path between successive signins
+    // on the same tab without page reload. Same defense-in-depth posture que
+    // THI-186 (progress data leak) — even si la garde UUID-mismatch dans
+    // `fetchRole` mitige le path d'exploit pratique, le contrat JSDoc de
+    // `clearUserRoleCache` exige cet appel à signOut.
+    clearUserRoleCache();
     // Clear local session immediately — the UI reacts instantly.
     // Then revoke the server-side refresh token in the background (fire-and-forget).
     // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the


### PR DESCRIPTION
## Summary

**Bug latent trouvé par `rbac-flow-tester`** (1er break-in après 45 jours dormant). @thierry m'a demandé de lancer les agents en smoke tests avant Sprint 2.C ("la sécurité est primordiale"). C'est exactement le pattern doctrine `feedback_agent_dormant_full_audit` que ça devait éviter.

## Root cause

`clearUserRoleCache()` exporté de `src/lib/hooks/useUserRole.ts` avec JSDoc explicite « Must be called from `AuthContext.signOut()` », mais l'appel **est absent** de l'implémentation. Le module-level `cachedRolePromise` + `cachedRoleUserId` persiste en mémoire après signOut.

**Mitigation existante** : le guard UUID-mismatch dans `fetchRole` force une re-fetch quand user A → user B sur le même tab. **Mais** le contrat JSDoc est cassé + posture defense-in-depth (THI-186 pattern : progress data leak via localStorage non cleared = 6 semaines dormant en prod).

## Severity

**MEDIUM** (pas HIGH) car la garde UUID-mismatch mitige le path pratique. Defense-in-depth justifie le fix.

## Fix

1 ligne d'import + 1 appel dans `signOut()` après `clearAiSessionData()`. Cohérent avec le pattern THI-207 (AI session wipe).

```diff
+ import { clearUserRoleCache } from '@/lib/hooks/useUserRole';

  signOut() {
    // ... clearAiSessionData() ...
+   clearUserRoleCache();
    setSession(null);
  }
```

## Doctrine validée 4× cette semaine

| Date | Agent | Dormancy | Finding |
|---|---|---|---|
| 26/05 matin | `institution-rbac-auditor` | 6j | 1 HIGH drift |
| 26/05 après-midi | `classroom-workflow-auditor` | 6j | 2 MED latents |
| 27/05 matin | @thierry validation E2E | — | 1 bug UX |
| **27/05 soir** | **`rbac-flow-tester`** | **45j** | **1 MED + 1 LOW + 1 MANUAL** |

→ Renforce : agents créés doivent être break-in empiriquement dans 48h post-création.

## Tests

- [x] 22/22 tests `auth.test.tsx` + `authContextSignoutAiKeys.test.ts` PASS
- [x] Typecheck + lint clean
- [ ] CI verte (sur push)
- [ ] Voie A Chrome MCP smoke test signOut (optional)

## Refs

- `rbac-flow-tester` rapport empirique 27/05 : 23/23 server checks PASS, 4/5 client checks PASS, 1 FAIL F-1 (cette PR), 1 LOW F-2 (service_role REST PATCH restore — edge case test automation), 1 MANUAL 4.4 (cross-tab pollution → Voie A Chrome MCP pre-Phase 9 release)
- Mémoire `feedback_agent_dormant_full_audit.md` validée 4× empiriquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Corrections de bugs :
- Effacer le rôle utilisateur mis en cache lors de la déconnexion pour éviter un risque potentiel de fuite de rôle entre comptes lors d’une nouvelle connexion dans le même onglet.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clear the cached user role on sign-out to avoid potential cross-account role leakage when signing in again on the same tab.

</details>