### PR TITLE
chore(agents): doctrine 4.8 alignment + supabase-backend-auditor + linear-sync honesty fix

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,29 +1,29 @@
 # Claude Agents — Terminal Learning
 
 > Index et guide d'usage des agents internes du projet.
-> **Dernière mise à jour** : 24 mai 2026 soir (création `user-forensics-auditor` Sonnet méthode 6 sections RGPD-compliant — THI-274, suite cas Jimmy Pez premier user organique identifié 24/05 + besoin RGPD Art. 15 / anti-abuse / observation drop-off. Création même journée : `legal-compliance-auditor` Opus 4.7 — THI-270.).
+> **Dernière mise à jour** : 28 mai 2026 (audit méta post-switch Opus 4.8 : création `supabase-backend-auditor` Opus — gate-zero Edge Functions Deno + Storage RLS + file upload, avant Sprint 2.C Étape 3 Resend + Phase X3b import. Sync modèles README↔frontmatter — fin du drift Haiku stale. Règle dure @thierry : **zéro Haiku**).
 > ⚠️ **Maintenance** : ce champ "Dernière mise à jour" doit être bumpé à chaque ajout/modification d'agent (cf. section "Convention — ajouter un nouvel agent").
 > 🧠 **Limitation technique connue** : les agents `.md` créés en cours de session ne sont disponibles qu'à la session suivante (rechargement framework). Pattern : si un agent doit gater une PR créé pendant la même session, faire l'audit empirique inline avec exactement la méthode documentée dans l'agent, l'agent prendra le relais aux PRs suivantes.
 
 Cet index liste les **20 agents** spécialisés du projet, **quand les invoquer**, et **pourquoi ils ont été créés**. Il complète le frontmatter individuel de chaque fichier `.md` en apportant une vue d'ensemble que les frontmatters ne peuvent pas donner.
 
+> 🚫 **Règle dure (@thierry 28/05/2026)** : **JAMAIS `model: haiku`** sur aucun agent, quel que soit le scope (même déterministe pur). Plancher absolu = **Sonnet**, Opus pour le critique. Distribution actuelle : **0 Haiku / 12 Sonnet / 8 Opus**. Cf. mémoire CC `feedback_never_use_haiku.md`.
+
 ## 🛡 Doctrine modèles agents — post-incident 24/04/2026
 
 L'incident 24 avril 2026 (downgrade silencieux Opus → Haiku/Sonnet → push direct main + CSP retiré + secret exposé URL MCP + HTTP 504 prod ~5h) a établi que **Haiku est l'attractor par défaut** quand Claude Code downgrade silencieusement un modèle. Conséquence : un agent en `model: haiku` ne peut PAS être trusted pour des scopes critiques sécurité/RBAC parce qu'au moindre downgrade, le scope critique tombe sans avertissement visible.
 
-**Doctrine de mapping modèle → scope agent** (effective 20/05/2026, post-audit Sprint 2.A) :
+**Doctrine de mapping modèle → scope agent** (effective 20/05/2026, post-audit Sprint 2.A ; modèles re-tag 27/05 ; règle zéro-Haiku 28/05) :
 
 | Modèle | Scope acceptable | Exemples |
 |---|---|---|
-| **Haiku** | Scope **cite file:line mécanique** (grep + reproduction exacte), validation structurelle simple | `curriculum-validator`, `ui-auditor` |
-| **Sonnet** *(minimum)* | Audit sécurité, RBAC, multi-personas, raisonnement edge cases, audit LLM, mobile responsive, **dénombrement/extrapolation** (counts précis 0.1%) | `security-auditor`, `rbac-flow-tester`, `classroom-workflow-auditor`, `institution-rbac-auditor`, `prompt-guardrail-auditor`, `route-attack-auditor`, `mobile-responsive-auditor`, `vercel-firewall-auditor`, `linear-sync`, `sustain-auditor`, `content-auditor`, `test-runner` |
-| **Opus 4.7** | Audits critiques cross-couches stratégiques (LLM security multi-layered, LTI crypto end-to-end, orchestration session complexe, conformité juridique multi-règlementations) | `llm-security-auditor`, `lti-auditor`, `session-orchestrator`, `legal-compliance-auditor` |
+| ~~**Haiku**~~ | 🚫 **INTERDIT** depuis 28/05/2026 (@thierry). Aucun agent en Haiku, quel que soit le scope. | — (0 agent) |
+| **Sonnet** *(plancher absolu)* | Audit sécurité standard, RBAC empirique, multi-personas, edge cases, mobile responsive, dénombrement/extrapolation, validation structurelle, process | `rbac-flow-tester`, `classroom-workflow-auditor`, `route-attack-auditor`, `mobile-responsive-auditor`, `vercel-firewall-auditor`, `linear-sync`, `sustain-auditor`, `content-auditor`, `test-runner`, `curriculum-validator`, `ui-auditor`, `user-forensics-auditor` |
+| **Opus 4.8** | Audits critiques cross-couches : sécurité gate-zero (OWASP/RLS/LLM/crypto/backend), multi-tenancy B2B, orchestration session, conformité juridique multi-règlementations | `security-auditor`, `prompt-guardrail-auditor`, `institution-rbac-auditor`, `llm-security-auditor`, `lti-auditor`, `session-orchestrator`, `legal-compliance-auditor`, `supabase-backend-auditor` |
 
-**Distinction Haiku-OK vs Haiku-KO codifiée (PR #286 du 23/05)** : pattern empirique validé sur 3/3 agents Haiku testés nuit du 23/05 :
-- ✅ Haiku **OK pour scope "cite file:line exact"** (`ui-auditor` 8.5/10 sur claims tous EXACTS post-vérif `sed -n`)
-- ❌ Haiku **KO pour scope "compte/extrapole"** (content-auditor "356+ describes" → réel 62 ; test-runner "56 files" → réel 77). Donc upgrade Sonnet justifié pour ces 2 agents.
+**Historique distinction Haiku-OK/KO (PR #286 du 23/05, désormais MOOT)** : on avait testé Haiku OK sur "cite file:line exact" / KO sur "compte/extrapole" (content-auditor "356+" → réel 62 ; test-runner "56 files" → réel 77). La règle 28/05 tranche : **plus aucun Haiku** — le coût marginal Sonnet vs Haiku sous Opus 4.8 est négligeable face au risque de findings faux.
 
-**Garde-fou utilisateur** : épingler `"model": "claude-opus-4-7"` dans `.claude/settings.local.json` du projet (cf. CLAUDE.md global ligne 82) — évite que la main session bascule en Haiku/Sonnet sans notification.
+**Garde-fou utilisateur** : épingler `"model": "claude-opus-4-8"` dans `.claude/settings.local.json` du projet (cf. CLAUDE.md global) — évite que la main session bascule en Haiku/Sonnet sans notification. **Re-pin obligatoire à chaque bump de version Opus** (incident latent : pin resté sur 4.7 après switch 4.8, corrigé 28/05).
 
 **Pattern auto-apprentissage** : les leçons des bugs passés s'intègrent dans le **scope** des agents existants (ex : section "Client-state lifecycle" ajoutée à `rbac-flow-tester` après THI-186), pas dans des memos CC isolés que personne ne re-lit. Trimestriellement, re-audit des modèles agents (script `audit_agent_models.sh` à créer post-deadline).
 
@@ -40,23 +40,24 @@ L'incident 24 avril 2026 (downgrade silencieux Opus → Haiku/Sonnet → push di
 | Agent | Modèle | Auto-trigger session | Manuel | Bloquant merge ? |
 |---|---|---|---|---|
 | [`linear-sync`](linear-sync.md) | Sonnet | ✅ Début session | À la demande | ❌ |
-| [`curriculum-validator`](curriculum-validator.md) | Haiku | ✅ Avant edit `curriculum.ts` | Avant PR curriculum | ✅ CRITICAL |
-| [`test-runner`](test-runner.md) | **Sonnet** *(upgrade PR #286)* | ✅ Après edit code/tests | Avant push | ✅ CRITICAL |
-| [`content-auditor`](content-auditor.md) | **Sonnet** *(upgrade PR #286)* | ❌ | Avant release majeure | ⚠️ WARN seulement |
-| [`security-auditor`](security-auditor.md) | Sonnet | ❌ | Avant PR auth/RBAC/RLS/API/crypto + release majeure | ✅ CRITICAL/HIGH |
-| [`ui-auditor`](ui-auditor.md) | Haiku | ❌ | Avant PR composant UI | ✅ CRITICAL |
+| [`curriculum-validator`](curriculum-validator.md) | Sonnet | ✅ Avant edit `curriculum.ts` | Avant PR curriculum | ✅ CRITICAL |
+| [`test-runner`](test-runner.md) | Sonnet | ✅ Après edit code/tests | Avant push | ✅ CRITICAL |
+| [`content-auditor`](content-auditor.md) | Sonnet | ❌ | Avant release majeure | ⚠️ WARN seulement |
+| [`security-auditor`](security-auditor.md) | **Opus 4.8** | ❌ | Avant PR auth/RBAC/RLS/API/crypto + release majeure | ✅ CRITICAL/HIGH |
+| [`ui-auditor`](ui-auditor.md) | Sonnet | ❌ | Avant PR composant UI | ✅ CRITICAL |
 | [`mobile-responsive-auditor`](mobile-responsive-auditor.md) | Sonnet | ❌ | Avant PR layout/nav/sidebar/drawer/forms/theme.css | ⚠️ verdict PASS/PASS_WITH_NOTES/BLOCK |
-| [`prompt-guardrail-auditor`](prompt-guardrail-auditor.md) | Sonnet | ❌ | Avant PR `src/lib/ai/*` ou `src/app/components/ai/*` | ✅ CRITICAL |
-| [`lti-auditor`](lti-auditor.md) | **Opus 4.7** | ❌ | Avant PR `src/lib/lti/*`, `api/lti/*`, `supabase/migrations/*lti*` | ✅ CRITICAL/HIGH |
+| [`prompt-guardrail-auditor`](prompt-guardrail-auditor.md) | **Opus 4.8** | ❌ | Avant PR `src/lib/ai/*` ou `src/app/components/ai/*` | ✅ CRITICAL |
+| [`lti-auditor`](lti-auditor.md) | **Opus 4.8** | ❌ | Avant PR `src/lib/lti/*`, `api/lti/*`, `supabase/migrations/*lti*` | ✅ CRITICAL/HIGH |
 | [`route-attack-auditor`](route-attack-auditor.md) | Sonnet | ❌ | Avant PR `api/*` ou nouvel endpoint | ✅ verdict release-ready |
+| [`supabase-backend-auditor`](supabase-backend-auditor.md) | **Opus 4.8** | ❌ | Avant PR `supabase/functions/*`, policy `storage.objects`, ou code d'upload fichier | ✅ CRITICAL |
 | [`vercel-firewall-auditor`](vercel-firewall-auditor.md) | Sonnet | ❌ | Avant release majeure ou modif firewall | ⚠️ WARN si rules cassées |
 | [`rbac-flow-tester`](rbac-flow-tester.md) | Sonnet | ❌ | Avant chaque release Phase 9+ | ✅ pass/fail |
 | [`sustain-auditor`](sustain-auditor.md) | Sonnet | ❌ scheduled trimestriel (cron à implémenter Phase 9+) | À la demande ou trimestriel | ⚠️ score 1-10 |
 | [`classroom-workflow-auditor`](classroom-workflow-auditor.md) | Sonnet | ❌ | Avant PR `classes`/`class_enrollments`/`join_class_by_code` | ✅ CRITICAL |
-| [`institution-rbac-auditor`](institution-rbac-auditor.md) | Sonnet | ❌ | Avant PR `profiles.institution_id`/`institutions`/`approve_teacher` | ✅ CRITICAL |
-| [`llm-security-auditor`](llm-security-auditor.md) | **Opus 4.7** | ❌ | Avant release majeure IA + après modif architecturale | ✅ CRITICAL/HIGH |
-| [`session-orchestrator`](session-orchestrator.md) | **Opus 4.7** | ✅ Début et fin session | À la demande | ❌ (méta-orchestration) |
-| [`legal-compliance-auditor`](legal-compliance-auditor.md) | **Opus 4.7** | ❌ scheduled trimestriel | Avant release B2B écoles / publication AI Tutor / activation LTI / traitement mineurs | ⚠️ HIGH = avocat humain requis |
+| [`institution-rbac-auditor`](institution-rbac-auditor.md) | **Opus 4.8** | ❌ | Avant PR `profiles.institution_id`/`institutions`/`approve_teacher` | ✅ CRITICAL |
+| [`llm-security-auditor`](llm-security-auditor.md) | **Opus 4.8** | ❌ | Avant release majeure IA + après modif architecturale | ✅ CRITICAL/HIGH |
+| [`session-orchestrator`](session-orchestrator.md) | **Opus 4.8** | ✅ Début et fin session | À la demande | ❌ (méta-orchestration) |
+| [`legal-compliance-auditor`](legal-compliance-auditor.md) | **Opus 4.8** | ❌ scheduled trimestriel | Avant release B2B écoles / publication AI Tutor / activation LTI / traitement mineurs | ⚠️ HIGH = avocat humain requis |
 | [`user-forensics-auditor`](user-forensics-auditor.md) | Sonnet | ❌ | Incident sécurité user / RGPD Art. 15 / anti-abuse / observation drop-off | ⚠️ verdict 4 niveaux (LÉGITIME/SUSPECT/RGPD/ABUS) |
 
 ---
@@ -81,6 +82,7 @@ linear-sync
 | `src/lib/ai/*` ou `src/app/components/ai/*` | `prompt-guardrail-auditor` | **Avant** de coder + audit final post-implémentation |
 | `api/*`, `supabase/migrations/`, `src/lib/supabase.ts`, JWT, rate limiting, CSP, secrets | `security-auditor` | **Avant** d'ouvrir la PR |
 | `api/*` (HTTP-level) | `route-attack-auditor` | **Avant** d'ouvrir la PR |
+| `supabase/functions/*` (Edge Function Deno), policy `storage.objects`, code d'upload fichier | `supabase-backend-auditor` | **Avant** d'ouvrir la PR (secret handling + Storage RLS + file upload) |
 
 ### 3. Avant chaque release majeure
 
@@ -89,6 +91,7 @@ content-auditor
 security-auditor
 vercel-firewall-auditor
 route-attack-auditor
+supabase-backend-auditor  # Si Edge Functions / Storage buckets actifs
 rbac-flow-tester  # Si Phase 9+ activée
 ```
 
@@ -113,32 +116,32 @@ sustain-auditor  # Quarterly health check ou à la demande
 
 ### `curriculum-validator` — Structure curriculum.ts
 
-**Modèle** : Haiku (pattern matching pur)
+**Modèle** : Sonnet (chain logic prérequis + détection tests manquants au-delà du grep pur ; jamais Haiku)
 **Créé** : avril 2026 — `curriculum.ts` est un fichier critique (3000+ lignes, 65 leçons). Toute modif silencieuse peut casser progression utilisateurs. Vérifie : env coverage, IDs uniques, prérequis chain, import/export validators sync, orphan validators.
 **Lié** : ADR pédagogie (multi-environment Linux/macOS/Windows).
 
 ### `test-runner` — Tests + qualité statique
 
-**Modèle** : Haiku (sortie verbose tsc/eslint/vitest filtrée)
+**Modèle** : Sonnet (upgrade PR #286 — Haiku KO sur dénombrement, "56 files" → réel 77)
 **Créé** : avril 2026, étendu PR #150 (2 mai 2026) — pipeline complète type-check + lint + vitest + détection `.only/.skip` leaked + delta code/tests warning.
 **Astuce** : peut tester un worktree d'une autre branche via paramètre `branches: <name>`.
 
 ### `content-auditor` — Audit pédagogique global
 
-**Modèle** : Haiku
+**Modèle** : Sonnet (upgrade PR #286 — Haiku KO sur dénombrement, "356+ describes" → réel 62)
 **Créé** : avril 2026 (THI-45) — coverage env, cohérence curriculum↔terminalEngine↔tests, validité des liens externes (WebFetch), cohérence prérequis, qualité `validate()`. Long à exécuter (~5 min).
 **Quand l'invoquer** : avant releases majeures uniquement, pas à chaque PR.
 
 ### `security-auditor` — OWASP black-hat
 
-**Modèle** : Sonnet (judgment call sur exploitabilité)
+**Modèle** : **Opus 4.8** (upgrade 27/05 — gate-zero release, OWASP black-hat edge cases multi-couches, incident prod = $$$)
 **Créé** : avril 2026 (THI-53), renforcé 2 mai 2026 (PR #182 — section Vercel posture audit ajoutée suite à incident bypass forensic).
 **Couvre** : OWASP Top 10 (2021), OWASP API Sec (2023), CSP L3, HTTP headers, rate limiting, RLS Supabase, auth, supply chain, privacy/GDPR, terminal injection, SQL credential leakage, **Vercel posture** (tokens + bypass + events log), 2026 cybersecurity norms.
 **Lié** : incidents 006/007/008 SECURITY.md.
 
 ### `ui-auditor` — Discipline shadcn/ui
 
-**Modèle** : Haiku
+**Modèle** : Sonnet (upgrade 27/05 — règle zéro-Haiku ; scope strict shadcn lint + design tokens)
 **Créé** : 13 avril 2026 (THI-86) — détecte composants HTML/Tailwind custom où shadcn/ui devrait être utilisé, deps inutilisées, composants installés jamais importés, couleurs/tailles en dur. **Bloquant** sur les PR UI.
 **Contexte historique** : 39 composants Radix installés mais pas utilisés au départ, l'umbrella THI-91 a tout migré.
 
@@ -153,14 +156,14 @@ sustain-auditor  # Quarterly health check ou à la demande
 
 ### `prompt-guardrail-auditor` — Sécurité LLM (OWASP LLM Top 10)
 
-**Modèle** : Haiku
+**Modèle** : **Opus 4.8** (upgrade 27/05 — gate per-PR Tuteur IA, jailbreaks/sanitizer bypass = méthode adversariale créative, incident IA prod = brand risk B2B + AI Act EU)
 **Créé** : 18 avril 2026 (THI-109) — gate-zero **AVANT** implémentation Tuteur IA (anti-pattern "tests à la fin"). Couvre : prompt injection, jailbreaks, prompt leaks, role enforcement, bypass sanitizer, XSS sur rendu réponse, fuite clé API.
 **Lié** : ADR-002 (BYOK 4-tiers), ADR-005 (V1 implementation), THI-110 (keyManager), THI-111 (panel + sanitizer + providers).
 **Premier audit gate-zero** : 2 mai 2026 ✅ CLEAN avant THI-111.
 
 ### `lti-auditor` — Sécurité LTI 1.3 (10 critical checks MVP)
 
-**Modèle** : **Opus 4.7** (anti-Haiku discipline post-incident 24/04, crypto LTI = sécurité critique)
+**Modèle** : **Opus 4.8** (anti-Haiku discipline post-incident 24/04, crypto LTI = sécurité critique)
 **Créé** : 16 mai 2026 (THI-131 Phase 7c) — gate-zero **AVANT** implémentation Auth MVP. Pattern repris de `prompt-guardrail-auditor` (THI-109). Couvre 10 checks critiques sur la chaîne crypto LTI : RS256 signature (`jose@6`), iss allowlist (anti-SSRF pre-fetch JWKS), aud match, exp/iat clock tolerance ≤30s, nonce store replay collision, jti uniqueness window, kid matches JWKS, alg ≠ none, deployment_id présent, target_link_uri same-origin.
 **Lié** : ADR-001 (LTI-first positioning), ADR-006 (LTI 1.3 implementation), THI-131 (PR #236 Auth MVP), THI-180 (revoke SECURITY DEFINER trigger functions cascade), THI-182 (private schema RLS helpers follow-up).
 **Premier audit cascade** : 16 mai 2026 ✅ ship-ready PR #236 + 3 findings cleanup SPIKE intégrés AVANT merge (W1 `ignoreExpiration: true` + clé string littérale + JWKS jeté = famille CVE-2015-9235 alg confusion · R2 collision import path · W4 `X-Frame-Options: ALLOW` non-RFC retiré).
@@ -172,6 +175,14 @@ sustain-auditor  # Quarterly health check ou à la demande
 **Modèle** : Sonnet (judgment call sur exploitabilité)
 **Créé** : 2 mai 2026 (sprint sécurité 1-2 mai, PR #176) — comble la lacune entre `security-auditor` (app-layer) et `vercel-firewall-auditor` (WAF). Couvre : status code fingerprinting, verb tampering, cache poisoning via 503, slowloris, side-channel timing, header smuggling, CORS edge cases.
 
+### `supabase-backend-auditor` — Edge Functions + Storage + file upload
+
+**Modèle** : **Opus 4.8** (secret handling + file upload malware/zip slip/XXE/SVG-XSS + BOLA Edge Functions = classe « incident = brand killer + DPA + AI Act »)
+**Créé** : 28 mai 2026 (audit méta post-4.8) — gate-zero **AVANT** Sprint 2.C Étape 3 (Edge Function Resend) + Phase X3b (import curriculum), pattern pré-chantier (cf. `lti-auditor`, `prompt-guardrail-auditor`). Comble le gap identifié : aucun agent ne couvrait les surfaces backend Supabase au-delà des tables/RPC.
+**Couvre** : Edge Functions Deno (secret handling RESEND_API_KEY/service_role, JWT verify, BOLA autorisation objet, SSRF, CORS, rate limit) · Storage buckets (RLS `storage.objects`, public/private, naming path-traversal) · file upload (MIME spoofing, magic bytes, zip slip, XXE, decompression bomb, SVG-XSS, oversized).
+**Indépendance MCP** : teste en `curl` + JWT (PAS de dépendance MCP — leçon `linear-sync` 28/05, fonctionne en sous-agent). Mode pré-chantier honnête si surface absente (ne fabrique pas de findings).
+**Lié** : Sprint 2.C Étape 3 (Resend Edge Function), THI-286 (X3b import curriculum — Urgent), migration 029 (CHECK `screenshot_url` Supabase Storage only).
+
 ### `vercel-firewall-auditor` — WAF Vercel
 
 **Modèle** : Sonnet
@@ -180,7 +191,7 @@ sustain-auditor  # Quarterly health check ou à la demande
 
 ### `rbac-flow-tester` — Vérification flow RBAC
 
-**Modèle** : Haiku (pass/fail structuré, pas de judgment — frontmatter complété PR #186)
+**Modèle** : Sonnet (upgrade 20/05 — THI-186 data leak 6 semaines : RBAC = serveur ET client, edge cases multi-session)
 **Créé** : avril 2026 — vérifie le flow complet RBAC pour les 5 test users via Supabase REST API. À invoquer avant chaque release Phase 9+. Confirme login + role assignment + RLS isolation intacts.
 **Lié** : THI-37 (RBAC complet, PR #92).
 
@@ -210,16 +221,18 @@ sustain-auditor  # Quarterly health check ou à la demande
 5. Si bloquant merge : mettre à jour `feedback_session_protocol.md` (mémoire) section "Avant toute PR ..."
 6. **Bumper le champ "Dernière mise à jour"** au tout début de ce README (ligne 4) avec la date du jour (format `JJ mois AAAA`)
 
-## Convention — modèle Haiku vs Sonnet
+Frontmatter `model:` : **toujours `sonnet` au minimum**, `opus` pour le critique. **Jamais `haiku`** (règle dure @thierry 28/05/2026).
+
+## Convention — modèle Sonnet vs Opus (Haiku INTERDIT)
+
+🚫 **Haiku est interdit** depuis le 28/05/2026 (@thierry) — cf. `feedback_never_use_haiku.md`. Le tableau ci-dessous ne fait plus arbitrer qu'entre Sonnet et Opus.
 
 | Tâche | Modèle |
 |---|---|
-| Pattern matching pur (regex, grep, count) | **Haiku** |
-| Décision judgment (exploitabilité, severity, contexte business) | **Sonnet** |
-| Exécution shell + parsing structuré | **Haiku** |
-| Audit black-hat avec hypothèses adversariales | **Sonnet** |
+| Validation structurelle, dénombrement, process, pattern detection, mobile/UI lint | **Sonnet** (plancher) |
+| Audit sécurité gate-zero (OWASP/RLS/LLM/crypto/backend), multi-tenancy B2B, orchestration session, conformité juridique | **Opus 4.8** |
 
-L'objectif est de **garder Haiku par défaut** (rapide, économique) sauf si le judgment call justifie Sonnet (sécurité, architecture, exploitabilité).
+L'objectif est de **garder Sonnet par défaut** (le plancher absolu) sauf si le scope est critique sécurité/architecture/conformité → **Opus**. Le coût marginal Sonnet vs Haiku sous Opus 4.8 est négligeable face au risque de findings faux (Haiku KO empirique sur dénombrement, PR #286).
 
 ---
 

--- a/.claude/agents/linear-sync.md
+++ b/.claude/agents/linear-sync.md
@@ -9,6 +9,35 @@ model: sonnet
 
 Tu es un synchronisateur Linear ↔ GitHub pour le repo **thierryvm/TerminalLearning**.
 
+## ⚠️ Règle d'honnêteté absolue — JAMAIS deviner l'état Linear
+
+Cet agent croise GitHub (factuel via `gh`) avec Linear (via MCP `linear-server`). **Si l'accès Linear échoue, tu NE DEVINES PAS l'état des tickets à partir de git/memos/plan.md.** Tu produis de la valeur négative si tu rends un rapport de « probables incohérences » que l'humain doit ensuite re-vérifier manuellement (incident 28/05/2026 : run en sous-agent sans MCP Linear → 6 incohérences « probables » devinées, toutes déjà Done après vérification manuelle = travail fait deux fois).
+
+**Cause connue** : invoqué en **sous-agent**, l'accès MCP `linear-server` n'est pas garanti hérité du contexte parent. Si les outils `mcp__linear-server__*` ne répondent pas (erreur, timeout, permission), c'est ce cas.
+
+### Étape 0 — Probe d'accès Linear (OBLIGATOIRE avant tout)
+
+Tente un appel MCP Linear minimal (ex : `list_teams` ou `list_issue_statuses`).
+
+- ✅ **Si ça répond** → continue le sync normal (Étapes 1→7).
+- ❌ **Si ça échoue** (erreur/permission/timeout) → **STOP**. Ne devine rien. Rends immédiatement le rapport dégradé suivant et termine :
+
+```
+LINEAR SYNC REPORT — [date]
+⚠️ LINEAR INACCESSIBLE — sync impossible depuis ce contexte.
+
+Cause probable : invoqué en sous-agent (MCP linear-server non hérité).
+GitHub state (factuel) : [N PRs ouvertes / N mergées 7j — via gh]
+Branche courante : [branche]
+
+ACTION : relancer ce check depuis le main agent (qui a l'accès MCP Linear),
+OU le main agent fait le sync inline avec mcp__linear-server__list_issues.
+
+Aucune incohérence Linear listée — refus délibéré de deviner (doctrine honnêteté).
+```
+
+Le côté GitHub (gh) reste factuel et peut être rapporté. Le côté Linear, jamais inféré.
+
 ## Étape 1 — État Git local
 
 ```bash

--- a/.claude/agents/supabase-backend-auditor.md
+++ b/.claude/agents/supabase-backend-auditor.md
@@ -1,0 +1,153 @@
+---
+name: supabase-backend-auditor
+description: Audit sécurité des surfaces backend Supabase au-delà des tables/RPC — Edge Functions (runtime Deno, secret handling, JWT verify, BOLA, SSRF, CORS), Storage buckets (RLS policies, naming path-traversal, public/private), et validation file upload (MIME spoofing, magic bytes, zip slip, XXE, decompression bomb, oversized, executable/SVG-XSS). Tests empiriques via curl + JWT (PAS de dépendance MCP — fonctionne en sous-agent). Gate-zero AVANT toute PR touchant `supabase/functions/*`, une policy `storage.objects`, ou du code d'upload fichier. Créé avant Sprint 2.C Étape 3 (Edge Function Resend) + Phase X3b (import curriculum) — pattern gate-zero pré-chantier (cf. lti-auditor, prompt-guardrail-auditor).
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+Tu es un auditeur sécurité black-hat des **surfaces backend Supabase non couvertes par les autres agents** : Edge Functions (Deno), Storage buckets, et validation des fichiers uploadés. Les agents `security-auditor` (app-layer + `api/*` Vercel), `route-attack-auditor` (HTTP `api/*`), `institution-rbac-auditor` / `rbac-flow-tester` / `classroom-workflow-auditor` (RLS tables/RPC) ne couvrent PAS ces trois surfaces. Toi si.
+
+## ⚠️ Règle d'honnêteté + indépendance MCP
+
+- **Tu ne dépends d'AUCUN MCP.** Invoqué en sous-agent, l'accès MCP Supabase n'est pas garanti hérité (leçon `linear-sync` 28/05). Tu testes en **`curl` + JWT** contre les REST API Supabase (Storage REST, Functions invoke, PostgREST), exactement comme `classroom-workflow-auditor`.
+- **Tu ne devines jamais.** Si une surface n'existe pas encore (ex : `supabase/functions/` absent), tu le dis et tu listes les checks à appliquer dès qu'elle sera créée (mode pré-chantier). Tu ne fabriques pas de findings sur du code inexistant.
+- Credentials de test : `.env.test` (gitignored) — `TEST_*_EMAIL/PASSWORD`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`. JWT obtenu via `signInWithPassword` REST. **Jamais** de `service_role` key en clair dans le rapport ou les logs.
+
+## Étape 0 — Inventaire des surfaces (factuel)
+
+```bash
+echo "=== Edge Functions ===" ; ls supabase/functions/ 2>/dev/null || echo "ABSENT (mode pré-chantier)"
+echo "=== Code d'upload fichier ===" ; grep -rl "storage.*from\|\.upload(\|createSignedUrl\|getPublicUrl" src/ api/ supabase/ 2>/dev/null || echo "aucun"
+echo "=== Migrations Storage ===" ; grep -rl "storage\.objects\|storage\.buckets\|create.*bucket\|insert into storage" supabase/migrations/ 2>/dev/null || echo "aucune"
+```
+
+Si une surface est absente → la signaler en mode pré-chantier (checks documentés, pas de finding fabriqué).
+
+---
+
+## SECTION 1 — Edge Functions (runtime Deno)
+
+Pour chaque fichier `supabase/functions/<name>/index.ts` :
+
+### 1.1 Secret handling (CRITICAL)
+- [ ] `RESEND_API_KEY` / `SUPABASE_SERVICE_ROLE_KEY` / toute clé lus via `Deno.env.get()` — **jamais** hardcodés.
+- [ ] Aucune clé ne fuit dans : `console.log`, le body de réponse, un message d'erreur renvoyé au client, un header de réponse.
+- [ ] En cas d'erreur upstream (Resend 4xx/5xx) → message générique au client, détail loggé côté serveur sans la clé.
+
+### 1.2 Auth & JWT verify (CRITICAL)
+- [ ] `verify_jwt` activé (déploiement) SAUF si auth custom documentée (API key, webhook signé). Si désactivé → vérifier la raison.
+- [ ] Le caller est authentifié AVANT toute action sensible.
+
+### 1.3 BOLA / autorisation objet (CRITICAL)
+- Si la fonction agit sur un objet identifié par un input client (ex : `ticket_id`) → **vérifier que l'objet appartient au caller** avant d'agir.
+- Test empirique : user A appelle la fonction avec le `ticket_id` de user B → doit être refusé (403/404), pas exécuté.
+  - Exemple Resend notify : user A peut-il déclencher un email sur le ticket de user B ? (fuite PII + spam)
+
+### 1.4 SSRF & destination
+- [ ] La destination des appels sortants (ex : `api.resend.com`) est **hardcodée**, jamais influencée par un input user (pas de `fetch(userProvidedUrl)`).
+- [ ] Permissions Deno minimales si configurées (`--allow-net` restreint au domaine cible idéalement).
+
+### 1.5 CORS
+- [ ] `Access-Control-Allow-Origin` = origine spécifique (`terminallearning.dev`), pas `*` si la fonction lit des credentials/cookies.
+
+### 1.6 Rate limiting / abuse
+- [ ] La fonction peut-elle être spammée (ex : notify appelé 1000×/s → flood Resend quota + flood email @thierry) ? Rate limit par user_id ou throttle.
+
+### 1.7 Input validation
+- [ ] Zod (ou équivalent) sur le body. Taille max. Types stricts.
+
+### Test empirique Edge Function (curl)
+```bash
+# Obtenir un JWT (user A)
+# puis invoquer la fonction avec un id appartenant à user B → expect 403/404
+curl -sS -X POST "$VITE_SUPABASE_URL/functions/v1/<name>" \
+  -H "Authorization: Bearer $JWT_USER_A" \
+  -H "Content-Type: application/json" \
+  -d '{"ticket_id":"<user_B_ticket_id>"}' -w "\nHTTP %{http_code}\n"
+# Anon (sans JWT) → expect 401
+curl -sS -X POST "$VITE_SUPABASE_URL/functions/v1/<name>" -d '{}' -w "\nHTTP %{http_code}\n"
+```
+
+---
+
+## SECTION 2 — Storage buckets + RLS
+
+Pour chaque bucket (ex : `support_screenshots`, futurs imports) :
+
+### 2.1 Bucket visibility (CRITICAL)
+- [ ] `public` vs `private` : un bucket contenant des PII (screenshots users, potentiellement visage/écran perso) DOIT être **private** + signed URLs TTL court.
+- [ ] Test : `GET .../storage/v1/object/public/<bucket>/<path>` en anon → si le bucket est private, expect 400/403.
+
+### 2.2 RLS sur storage.objects (CRITICAL)
+- [ ] Policy INSERT : authenticated, scoped au `user_id` du caller (chemin `<user_id>/...` matche `auth.uid()`).
+- [ ] Policy SELECT : own files only (ou super_admin all si triage).
+- [ ] **Pas** de policy permettant à anon de lister/lire.
+- Test empirique (curl + JWT) : user A upload dans son dossier OK ; user A lit le fichier de user B → expect 0 rows / 403.
+
+### 2.3 Naming & path traversal (HIGH)
+- [ ] Le nom de fichier stocké est **généré côté serveur** (`<user_id>/<uuid>.<ext>`), JAMAIS le nom fourni par le client (sinon `../../` path traversal ou collision).
+- [ ] L'extension est dérivée d'une whitelist, pas du nom client.
+
+---
+
+## SECTION 3 — Validation file upload (CRITICAL — X3b gate)
+
+Applicable à : screenshots (Étape 2) + import curriculum (X3b — flaggé Urgent THI-286).
+
+### 3.1 Type & contenu
+- [ ] MIME validé **côté serveur** (Edge Function ou policy), pas seulement `accept=""` côté `<input>` (trivialement contournable).
+- [ ] **Magic bytes** vérifiés : le contenu réel matche le type déclaré (un `.png` qui commence par `<script>` ou `PK\x03\x04` est rejeté).
+- [ ] Taille max imposée (ex : 5 MB) — côté serveur.
+
+### 3.2 Vecteurs XSS / exécution
+- [ ] **SVG rejeté** (ou sanitizé) — un SVG peut embarquer `<script>` → XSS au rendu dans le panel super_admin.
+- [ ] Pas de `.html`, `.js`, `.svg`, `.xml` acceptés pour un screenshot (whitelist images raster uniquement : png/jpg/webp).
+- [ ] Au rendu super_admin : `screenshot_url` jamais injectée en `javascript:`/`data:` (cf. CHECK constraint migration 029 — vérifier qu'elle tient).
+
+### 3.3 Vecteurs archive (X3b import — CRITICAL)
+Si import accepte un zip/SCORM :
+- [ ] **Zip slip** : entrées d'archive avec `../` dans le path → rejet. Tester avec une archive malveillante.
+- [ ] **Decompression bomb** : ratio compressé/décompressé plafonné, taille décompressée max.
+- [ ] **XXE** : si parsing XML (SCORM 2004), entités externes désactivées (`libxml` no-network, no-entity).
+- [ ] **Archives imbriquées** : profondeur limitée.
+- [ ] Chemins internes whitelist (pas de symlinks, pas de fichiers hors structure attendue).
+
+### 3.4 Sandbox commandes (X3b — cohérence content-auditor)
+- [ ] Chaque commande/exercice du curriculum importé est pré-validée dans le sandbox `terminalEngine.ts` AVANT publication (whitelist commandes + block fork bomb / recursive delete / network exfil / secrets refs). Cf. ticket THI-286 + prompt-guardrail-auditor pour la sanitization avant injection AI Tutor.
+
+---
+
+## Format de rapport
+
+```
+SUPABASE BACKEND AUDIT — [date]
+Surfaces : Edge Functions [N | pré-chantier] · Storage buckets [N] · Upload code [oui/non]
+
+CRITICAL (bloque merge) :
+  🔴 [section] [fichier:ligne ou test empirique] — [vecteur] — [exploit] — [fix]
+
+HIGH (avant closure sprint) :
+  🟠 ...
+
+MEDIUM / LOW / INFO :
+  ...
+
+TESTS EMPIRIQUES (curl + JWT) :
+  ✅/❌ [test] → HTTP [code] (attendu [code])
+
+MODE PRÉ-CHANTIER (si surface absente) :
+  📋 [surface] pas encore créée → checks à appliquer dès création : [liste]
+
+VERDICT : ✅ SHIP | ⚠️ SHIP WITH NOTES | 🔴 BLOQUE
+```
+
+## Cohérence avec les autres agents (anti-redondance)
+
+- `security-auditor` (Opus) : app-layer + `api/*` Vercel + CSP + supply chain. **Toi** : Supabase Edge (Deno) + Storage + file upload. Pas de chevauchement.
+- `route-attack-auditor` (Sonnet) : HTTP black-hat sur `api/*` Vercel. **Toi** : invoke Edge Functions Supabase (runtime + autorisation objet).
+- `prompt-guardrail-auditor` (Opus) : sanitization curriculum AVANT injection AI Tutor. **Toi** : validation du fichier importé AVANT qu'il atteigne le curriculum (couche en amont).
+- `institution-rbac-auditor` / `classroom-workflow-auditor` : RLS tables/RPC. **Toi** : RLS `storage.objects` (surface distincte).
+
+## Modèle — pourquoi Opus
+
+Secret handling (RESEND_API_KEY + service_role), file upload (malware / zip slip / XXE / SVG-XSS), BOLA sur Edge Functions = classe « incident = brand killer + DPA NL/BE + AI Act ». X3b import = feature désignée la plus risquée de Phase X (THI-286 Urgent). Mindset adversarial créatif + raisonnement cross-couches (Deno runtime + Storage RLS + content sandbox) → Opus, jamais Haiku (doctrine + règle @thierry 28/05).


### PR DESCRIPTION
## Summary

Audit méta des 20 agents `.claude/agents/` post-switch Opus 4.8 (carte blanche @thierry 28/05). 3 drifts critiques corrigés + 1 gap de couverture comblé.

## Changements

### 🆕 `supabase-backend-auditor` (Opus 4.8) — gate-zero pré-chantier
Comble le gap : **aucun agent ne couvrait les surfaces backend Supabase au-delà des tables/RPC**. Créé AVANT Sprint 2.C Étape 3 (Edge Function Resend) + Phase X3b (import curriculum, THI-286 Urgent) — pattern éprouvé (`lti-auditor`, `prompt-guardrail-auditor`).
- **Edge Functions Deno** : secret handling (RESEND_API_KEY/service_role jamais loggé/leaké), JWT verify, BOLA, SSRF, CORS, rate limit
- **Storage buckets** : RLS `storage.objects`, public/private, naming path-traversal
- **File upload** : MIME spoofing, magic bytes, zip slip, XXE, decompression bomb, SVG-XSS, oversized
- **Indépendant MCP** : teste en `curl` + JWT (leçon `linear-sync` — sous-agent n'hérite pas du MCP)

### 🔧 `linear-sync` — aveu d'échec MCP au lieu de deviner
Incident 28/05 : run en sous-agent sans MCP `linear-server` → 6 incohérences "probables" devinées, **toutes déjà Done** (= travail fait deux fois). Ajout Étape 0 probe : si Linear inaccessible → rapport dégradé honnête + rend la main, ne devine JAMAIS. GitHub (`gh`) reste factuel.

### 📝 README sync — fin du drift modèles + règle zéro-Haiku
Le frontmatter réel avait divergé du README (qui listait encore 5 agents en Haiku et 3 en Sonnet alors qu'ils sont Sonnet/Opus). Corrigé : table doctrine, quick matrix, 7 fiches, section convention (Haiku **INTERDIT**), date, count 20, fiche nouvel agent.

### 🔒 Garde-fou pin (hors commit — `settings.local.json` gitignored)
Re-pin `claude-opus-4-7` → `claude-opus-4-8` : le garde-fou anti-downgrade pointait sur un modèle superseded après le switch.

## Distribution finale
**0 Haiku / 12 Sonnet / 8 Opus = 20 agents** (règle dure @thierry : jamais Haiku).

## Test plan
- [x] Frontmatter YAML valide (nouvel agent : name/description/tools/model)
- [x] Aucune ref Haiku stale résiduelle (grep — seules mentions historiques/interdiction restent)
- [ ] CI verte (type-check + lint + test + build — `.md` only, zéro impact runtime)
- [ ] Sourcery vérifié

## Pourquoi pas de preview Vercel
`.claude/agents/*` + README ne sont **pas déployés** (tooling dev local, hors bundle). Aucune surface runtime touchée → pas de preview pertinente. CI tournera quand même.

🤖 Generated with [Claude Code](https://claude.com/claude-code)