### PR TITLE
docs: align lesson count 64 → 65 + extend anti-drift guard to markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Phase 3 ✅ Supabase Auth + DB — live (projet: `jdnukbpkjyyyjpuwgxhv`, eu-west-1)
 - Phase 3.5 ✅ Landing upgrade + OAuth GitHub/Google + security hardening + sidebar auth (3 avril 2026)
 - Phase 4 ✅ Curriculum v2 + multi-environment (Linux/macOS/Windows) + terminal profiles (9 avril 2026)
-- Phase 5 🔄 Curriculum expansion — 11 modules, 64 leçons, 900 tests unitaires + 176 E2E Playwright (en cours)
+- Phase 5 🔄 Curriculum expansion — 11 modules, 65 leçons, 900 tests unitaires + 176 E2E Playwright (en cours)
 - Phase 5.5 ✅ Terminal Sentinel — agents sécurité + contenus automatisés (PR #90, 12 avril 2026)
 - Phase 7 ✅ RBAC complet — student/teacher/institution_admin/super_admin + RLS + audit log (PR #92, 12 avril 2026)
 - THI-29 ✅ Module 11 — L'IA comme outil dev (12 leçons, `ai-help` + 11 sous-commandes, PR #103, 13 avril 2026)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ No account required. No setup. Just open it and start learning.
 
 - 🖥️ **Interactive terminal** — type real commands, get real feedback (not just theory)
 - 🌍 **Multi-environment** — learn on Linux, macOS, or Windows — the interface adapts
-- 🔒 **Progressive curriculum** — 11 modules, 64 lessons, 1000+ unit tests
+- 🔒 **Progressive curriculum** — 11 modules, 65 lessons, 1000+ unit tests
 - 🤖 **AI as a dev tool** — dedicated module on using AI professionally (prompts, validation, limits)
 - 💾 **Progress saved automatically** — locally, or synced to the cloud with a free account
 - 📖 **Contextual help** — `help <command>` returns usage and examples for your environment
@@ -113,7 +113,7 @@ Full security policy and vulnerability reporting: [SECURITY.md](SECURITY.md). In
 | **Phase 2** | ✅ Done | Vercel Analytics + Sentry error monitoring + source maps |
 | **Phase 3** | ✅ Done | Supabase Auth + user progress sync |
 | **Phase 4** | ✅ Done | Curriculum v2 + multi-environment selection + terminal profiles |
-| **Phase 5** | 🔄 In progress | Curriculum expansion: 11 modules, 64 lessons, 1000+ unit tests + 176 E2E |
+| **Phase 5** | 🔄 In progress | Curriculum expansion: 11 modules, 65 lessons, 1000+ unit tests + 176 E2E |
 | **Phase 5.5** | ✅ Done | Terminal Sentinel — automated security & content audit agents |
 | **Phase 7** | ✅ Done | RBAC — student / teacher / institution_admin / super_admin roles |
 | **THI-29** | ✅ Done | Module 11 — AI as a dev tool (12 lessons, `ai-help` command) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ src/
 │   │   ├── curriculum.ts         # ENVIRONMENTS, LEVELS, ROADMAP_PRIORITIES, EnvId
 │   │   └── database.ts           # Supabase DB types (Phases 3+)
 │   ├── data/
-│   │   ├── curriculum.ts         # ⚠️ Critical — all modules + lessons (64 lessons, 11 modules)
+│   │   ├── curriculum.ts         # ⚠️ Critical — all modules + lessons (65 lessons, 11 modules)
 │   │   ├── terminalEngine.ts     # Terminal command interpreter (60+ commands, env-aware)
 │   │   ├── commandCatalogue.ts   # Command catalogue with level + prerequisites metadata
 │   │   ├── validators.ts         # 44 exercise validation functions (extracted from curriculum)
@@ -224,7 +224,7 @@ security_reports (id, run_at, score int, findings jsonb, component text)
 | 2 | ✅ | Vercel Analytics + Sentry |
 | 3 | ✅ | Supabase Auth + progress persistence |
 | 4 | ✅ | Curriculum v2 + multi-environment + terminal profiles (192 tests) |
-| 5 | 🔄 | Curriculum expansion — 11 modules, 64 lessons, 900 unit + 176 E2E tests |
+| 5 | 🔄 | Curriculum expansion — 11 modules, 65 lessons, 900 unit + 176 E2E tests |
 | 5.5 | ✅ | Terminal Sentinel — automated security audit (THI-36, PR #90) |
 | 6 | 🔮 | Terminal multi-session (tabs) |
 | 7 | ✅ | Full RBAC — student/teacher/institution/admin + RLS (THI-37, PR #92) |

--- a/docs/exports/README.md
+++ b/docs/exports/README.md
@@ -4,7 +4,7 @@ This directory contains data exports from Terminal Learning's curriculum for ext
 
 ## curriculum.csv
 
-**Export of 64 lessons from 11 modules** — useful for pedagogical collaborators, curriculum review, or integration with external tools.
+**Export of 65 lessons from 11 modules** — useful for pedagogical collaborators, curriculum review, or integration with external tools.
 
 ### Columns
 

--- a/src/test/docLessonCount.test.ts
+++ b/src/test/docLessonCount.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="node" />
+/**
+ * Guard: anti-drift du compteur de leçons dans la doc markdown d'ÉTAT PRÉSENT.
+ *
+ * Contexte : le curriculum est passé à 65 leçons (Module 11 "IA", avril 2026),
+ * mais le "64" a persisté dans plusieurs docs. Le garde-fou `seo.test.ts` ne
+ * couvrait que le HTML/SEO public (numberOfLessons === 65), pas la doc markdown.
+ * Ce test étend la couverture aux fichiers de doc qui affirment un état présent.
+ *
+ * Exclus volontairement (traces historiques datées — les "corriger" = falsifier
+ * l'historique) : CHANGELOG.md, STORY.md, docs/audits/*, docs/reports/*.
+ *
+ * Source de vérité : getTotalLessons() (compte réel du curriculum). Si le
+ * curriculum change de taille, l'assertion d'ancrage ci-dessous échoue et
+ * rappelle de mettre à jour la doc + ce test ensemble.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+import { getTotalLessons } from '../app/data/curriculum';
+
+const ROOT = resolve(__dirname, '../../');
+
+// Fichiers de doc affirmant un état présent du curriculum (≠ historique daté).
+const PRESENT_STATE_DOCS = [
+  'README.md',
+  'CLAUDE.md',
+  'docs/ARCHITECTURE.md',
+  'docs/exports/README.md',
+];
+
+// Détecte un compteur de leçons obsolète "64 lessons" / "64 leçon(s)".
+const STALE_LESSON_COUNT = /64[\s-]*(le[çc]on|lesson)/i;
+
+describe('doc lesson count — anti-drift guard', () => {
+  it('le curriculum compte bien 65 leçons (ancrage source de vérité)', () => {
+    // Si cette assertion casse, le curriculum a changé de taille : mettre à
+    // jour la doc d'état présent ET le pattern de ce test ensemble.
+    expect(getTotalLessons()).toBe(65);
+  });
+
+  it.each(PRESENT_STATE_DOCS)(
+    '%s ne contient aucun compteur "64 leçons/lessons" obsolète',
+    (relPath) => {
+      const content = readFileSync(resolve(ROOT, relPath), 'utf-8');
+      const match = content.match(STALE_LESSON_COUNT);
+      expect(
+        match,
+        match
+          ? `"${match[0]}" trouvé dans ${relPath} — le curriculum compte 65 leçons, pas 64. Corriger l'assertion d'état présent (l'historique CHANGELOG/STORY/audits/reports reste inchangé).`
+          : undefined,
+      ).toBeNull();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fix drift documentaire : le curriculum compte **65 leçons** (Module 11 "IA", avril 2026 — vérifié empiriquement `getTotalLessons()` = 5+5+4+5+4+4+6+6+7+7+12 = 65) mais le "64" persistait dans la doc markdown. Le garde-fou `seo.test.ts` ne couvrait que le HTML/SEO public, pas la doc markdown.

Brief @cowork — scope chirurgical, assertions d'état présent uniquement.

## Fix (6 occurrences / 4 fichiers — état présent)
- `README.md` : feature bullet + tableau Phase 5
- `CLAUDE.md` : Phase 5 curriculum
- `docs/ARCHITECTURE.md` : commentaire `curriculum.ts` + tableau Phase 5
- `docs/exports/README.md` : "Export of N lessons"

## Historique PRÉSERVÉ (non touché)
`CHANGELOG.md`, `STORY.md`, `docs/audits/*`, `docs/reports/*` gardent leurs "64" — états datés, les corriger = falsifier l'historique.

## Garde-fou anti-récidive
`src/test/docLessonCount.test.ts` (5 tests) :
- ancrage source de vérité : `getTotalLessons() === 65`
- échoue si `64 le[çc]on(s)` / `64 lessons` réapparaît dans les 4 fichiers d'état présent (exclut historique)
- regex JS `String.match` — fiable sur le `ç` UTF-8 (contrairement à `grep` locale C qui sous-compte)

## GO/NO-GO (vérifié via ripgrep UTF-8)
- ✅ 4 fichiers cibles : **0 occurrence** "64 lesson/leçon"
- ✅ Historique intact (STORY/CHANGELOG/audits/reports conservent leurs 64)
- ✅ type-check OK · lint OK · **1749/1769 tests PASS** (+5 nouveau guard)

## Hors scope (noté)
- Refactor "curriculum data-driven / source unique" (dette audit 2026-04-24) — à cadrer séparément.
- Finding W18 content-auditor (THI-294 "63 leçons") = erreur de comptage de l'agent ; vrai compte = 65. THI-294 peut être fermé "not a bug".

## Voie C
Docs + 1 test. Surfaces déployées touchées : aucune (`/changelog` + `/story` non modifiés ; README/CLAUDE/ARCHITECTURE/exports non rendus en SPA). Pas de preview visuelle requise — CI suffit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)