### PR TITLE
fix(seo): derive Course.numberOfLessons + hasPart from curriculum source (THI-294)

### DIFF
--- a/src/test/seo.test.ts
+++ b/src/test/seo.test.ts
@@ -8,6 +8,7 @@ import { createHash } from 'crypto';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { join, resolve } from 'path';
 import { describe, it, expect } from 'vitest';
+import { curriculum, getTotalLessons } from '../app/data/curriculum';
 
 const ROOT = resolve(__dirname, '../../');
 const INDEX_HTML = join(ROOT, 'index.html');
@@ -126,20 +127,24 @@ describe('SEO -- JSON-LD structured data (Schema.org)', () => {
     expect(app?.['isAccessibleForFree']).toBe(true);
   });
 
-  // THI-226 enrichissement Schema.org Course — empêche le drift du nombre de leçons
-  // et garantit que chaque module est listé comme sous-cours pour Google + LLM retrievals.
-  it('Course.numberOfLessons === 65 (anti-drift)', () => {
+  // THI-226 + THI-294 — Schema.org Course DÉRIVE de la source unique getTotalLessons()
+  // (et non plus d'une constante hardcodée). Si le curriculum change de taille et que
+  // index.html n'est pas mis à jour, la CI échoue ici → le SEO ne peut plus drifter
+  // silencieusement. La vraie source = curriculum.reduce(...) (curriculum.ts:getTotalLessons),
+  // pas le littéral du JSON-LD statique. Verdict THI-294 : compte réel = 65 (faux positif
+  // du décompte manuel "63" — reseau a 6 leçons, github-collaboration en a 7).
+  it('Course.numberOfLessons === getTotalLessons() (anti-drift dérivé de la source)', () => {
     const g = extractJsonLd()['@graph'] as Array<Record<string, unknown>>;
     const course = g.find((n) => n['@type'] === 'Course');
-    expect(course?.['numberOfLessons']).toBe(65);
+    expect(course?.['numberOfLessons']).toBe(getTotalLessons());
   });
 
-  it('Course.hasPart contient 11 modules avec URLs valides', () => {
+  it('Course.hasPart liste tous les modules (dérivé de curriculum.length) avec URLs valides', () => {
     const g = extractJsonLd()['@graph'] as Array<Record<string, unknown>>;
     const course = g.find((n) => n['@type'] === 'Course');
     const parts = course?.['hasPart'] as Array<Record<string, unknown>> | undefined;
     expect(Array.isArray(parts)).toBe(true);
-    expect(parts).toHaveLength(11);
+    expect(parts).toHaveLength(curriculum.length);
     for (const part of parts!) {
       expect(part['@type']).toBe('Course');
       expect(typeof part['name']).toBe('string');


### PR DESCRIPTION
## Verdict THI-294 — FAUX POSITIF, vrai compte = 65

content-auditor (28/05) suspectait un drift Schema.org `numberOfLessons=65` vs 63 au décompte manuel. **Vérification autoritative** (`getTotalLessons()` + ids distincts par module) :

| module | leçons | ids distincts |
|---|---|---|
| navigation | 5 | 5 |
| fichiers | 5 | 5 |
| lecture | 4 | 4 |
| permissions | 5 | 5 |
| processus | 4 | 4 |
| redirection | 4 | 4 |
| variables | 6 | 6 |
| **reseau** | **6** | 6 |
| git | 7 | 7 |
| **github-collaboration** | **7** | 7 |
| ia-dev | 12 | 12 |
| **TOTAL** | **65** | **65** (0 doublon) |

Le décompte "63" sous-comptait **reseau** (réel 6 : ping/curl/wget/dns/ssh/scp) et **github-collaboration** (réel 7 : git-remote/push-pull/fetch-clone/pull-requests/merge-strategies/conflicts/github-actions).

➡️ **SEO correct · PR #318 correcte · comm publique Instagram/LinkedIn (65) CORRECTE — rien à corriger.**

## Fix durable (cause racine @cowork)

Le drift était *possible* car 3 couches portaient le nombre, une seule dérivée :
- `getTotalLessons()` = vraie source (`curriculum.reduce`)
- `seo.test.ts` = **constante hardcodée 65** ← corrigé
- `docLessonCount.test.ts` = tripwire prose (conservé, rôle distinct)

`seo.test.ts` dérive désormais de la source vivante :
- `numberOfLessons === getTotalLessons()` (plus de littéral)
- `hasPart.length === curriculum.length` (plus de littéral 11)

→ Si le curriculum change et qu'`index.html` n'est pas mis à jour, **la CI échoue**. Le SEO ne peut plus drifter silencieusement. Le littéral `65` dans `index.html` reste par design (JSON-LD statique requis crawlers/GEO) mais est verrouillé sur la source au niveau CI.

## Follow-up recommandé (hors scope, non-trivial)
Auto-injection build-time du JSON-LD (Vite `transformIndexHtml` dérivant `numberOfLessons` + `hasPart` de `curriculum`) = dérivation pure sans littéral. Scope > trivial → ticket dédié (⚠ pattern generated-file PR #283).

## Test plan
- [x] Compte autoritatif vérifié (script tsx, 65, 0 doublon)
- [x] seo.test.ts + docLessonCount 73/73 PASS
- [x] type-check OK · lint OK · full suite 1749/1769 PASS
- [ ] CI verte

## Voie C
Test-only (1 fichier `src/test/`), 0 surface déployée modifiée. Pas de preview requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)