### PR TITLE
fix(spa): stale-chunk auto-recovery for lazy sub-components (UserMenu) + vite:preloadError net

### DIFF
--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
+import { lazyWithRetry } from '../lib/lazyWithRetry';
 import { FadeIn } from './landing/FadeIn';
 import {
   Terminal, ChevronRight, Github, BookOpen,
@@ -16,9 +17,12 @@ import { Badge } from './ui/badge';
 // THI-118 — defer non-critical chunks to keep the landing critical path lean.
 // UserMenu only renders for logged-in users (minority of landing visitors);
 // LoginModal / PWAInstallModal only mount after user interaction.
-const UserMenu = lazy(() => import('./auth/UserMenu').then((m) => ({ default: m.UserMenu })));
-const LoginModal = lazy(() => import('./auth/LoginModal').then((m) => ({ default: m.LoginModal })));
-const PWAInstallModal = lazy(() => import('./PWAInstallModal').then((m) => ({ default: m.PWAInstallModal })));
+// lazyWithRetry (not bare lazy) so a stale chunk after a deploy auto-recovers
+// instead of surfacing React Router's default error screen — see the
+// `UserMenu-<hash>.js` "Failed to fetch dynamically imported module" report.
+const UserMenu = lazyWithRetry(() => import('./auth/UserMenu').then((m) => ({ default: m.UserMenu })));
+const LoginModal = lazyWithRetry(() => import('./auth/LoginModal').then((m) => ({ default: m.LoginModal })));
+const PWAInstallModal = lazyWithRetry(() => import('./PWAInstallModal').then((m) => ({ default: m.PWAInstallModal })));
 import { useEnvironment, ENV_META, type SelectedEnvironment } from '../context/EnvironmentContext';
 import {
   TOTAL_LESSONS, TOTAL_COMMANDS,

--- a/src/app/lib/lazyWithRetry.ts
+++ b/src/app/lib/lazyWithRetry.ts
@@ -1,0 +1,75 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
+/**
+ * Stale chunk auto-recovery — shared between the router (routes.ts), lazily
+ * mounted sub-components (e.g. Landing's UserMenu/LoginModal/PWAInstallModal)
+ * and the global guards in main.tsx.
+ *
+ * After a new deployment, old chunk hashes no longer exist on the CDN. A user
+ * who kept a tab open before the deploy triggers a failed dynamic import when a
+ * lazy chunk is finally requested (e.g. `UserMenu-D4jfd8IN.js`). Vercel's SPA
+ * rewrite returns index.html (text/html) instead of the JS chunk, which strict
+ * browsers reject as an invalid MIME type.
+ *
+ * Single source of truth for: the detection heuristic, the once-per-session
+ * sessionStorage flag (prevents infinite reload loops if the failure is real —
+ * CDN outage, not just a deploy-cache mismatch), and the `lazyWithRetry`
+ * wrapper. Previously `lazyWithRetry` lived only in routes.ts, so sub-components
+ * lazy-loaded with a plain `lazy()` (Landing's UserMenu) escaped the retry and
+ * surfaced React Router's default error screen.
+ */
+
+export const STALE_CHUNK_RELOAD_KEY = 'chunk-reload';
+
+/**
+ * True when an error looks like a stale-chunk / failed dynamic import.
+ * 'text/html' covers the Vercel SPA-rewrite case (index.html served for a
+ * missing chunk). Broad on purpose — a false positive only costs one reload.
+ */
+export function isStaleChunkError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err ?? '');
+  return (
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('Importing a module script failed') ||
+    msg.includes('is not a valid JavaScript MIME type') ||
+    msg.includes('text/html')
+  );
+}
+
+/**
+ * Force a single hard reload to fetch the new build, guarded once per session.
+ * Returns true if a reload was triggered (caller should stop / stay pending).
+ */
+export function reloadOnceForStaleChunk(): boolean {
+  if (sessionStorage.getItem(STALE_CHUNK_RELOAD_KEY)) return false;
+  sessionStorage.setItem(STALE_CHUNK_RELOAD_KEY, '1');
+  window.location.reload();
+  return true;
+}
+
+/**
+ * `React.lazy` wrapper that auto-recovers from a stale-chunk failure. On a
+ * stale-chunk error it reloads once and returns a never-resolving promise so
+ * React stays in its Suspense fallback while the page reloads, instead of
+ * throwing to the nearest (React Router default) error boundary.
+ *
+ * The `ComponentType<any>` bound mirrors React's own `lazy` signature — it is
+ * required to preserve the wrapped component's prop types through inference
+ * (a `<unknown>` bound collapses props to `IntrinsicAttributes`, breaking
+ * callers that pass props, e.g. Landing's UserMenu/LoginModal).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors React.lazy's signature to preserve prop types
+export function lazyWithRetry<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(async () => {
+    try {
+      return await factory();
+    } catch (err) {
+      if (isStaleChunkError(err) && reloadOnceForStaleChunk()) {
+        return new Promise<{ default: T }>(() => {});
+      }
+      throw err;
+    }
+  });
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,44 +1,5 @@
-import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
 import { createBrowserRouter, redirect } from 'react-router';
-
-// Stale chunk auto-recovery wrapper — when a new deployment invalidates old
-// chunk hashes, users with the previous version still open trigger a failed
-// dynamic import. The guard in main.tsx catches unhandledrejection events,
-// but React Router 7 catches lazy() rejections BEFORE the browser fires
-// unhandledrejection, so the guard never sees them and the user sees the
-// default React Router error screen ("💿 Hey developer 👋").
-//
-// This wrapper intercepts the rejection at the source (before React Router
-// receives it) and forces a hard reload once per session — same sessionStorage
-// flag as main.tsx to prevent reload loops if the chunk failure is real
-// (e.g. CDN outage, not just a deployment-cache mismatch).
-const CHUNK_RELOAD_KEY = 'chunk-reload';
-
-function lazyWithRetry<T extends ComponentType<unknown>>(
-  factory: () => Promise<{ default: T }>
-): LazyExoticComponent<T> {
-  return lazy(async () => {
-    try {
-      return await factory();
-    } catch (err) {
-      const msg = String(err instanceof Error ? err.message : err ?? '');
-      const isStaleChunk =
-        msg.includes('Failed to fetch dynamically imported module') ||
-        msg.includes('Importing a module script failed') ||
-        msg.includes('is not a valid JavaScript MIME type') ||
-        msg.includes('text/html');
-      if (isStaleChunk && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
-        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
-        window.location.reload();
-        // Return a never-resolving promise — React stays in Suspense fallback
-        // (PageLoader) while the page reloads, instead of throwing to the
-        // React Router default ErrorBoundary.
-        return new Promise<{ default: T }>(() => {});
-      }
-      throw err;
-    }
-  });
-}
+import { lazyWithRetry } from './lib/lazyWithRetry';
 
 // Route-level code splitting — each route loads its own JS chunk on demand.
 // Layout is lazy so that Sidebar → curriculum.ts is excluded from the main bundle,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,25 +2,31 @@ import { createRoot } from 'react-dom/client';
 import App from './app/App.tsx';
 import './styles/index.css';
 import { initSentry } from './lib/sentry.ts';
+import { isStaleChunkError, reloadOnceForStaleChunk } from './app/lib/lazyWithRetry.ts';
 
 initSentry();
 
-// Stale chunk guard — after a new deployment, old chunk hashes no longer exist.
+// Stale chunk guards — after a new deployment, old chunk hashes no longer exist.
 // Vercel's SPA rewrite returns index.html (text/html) instead of the JS chunk,
-// which Mobile Safari (nosniff-strict) rejects as an invalid MIME type.
-// Detect this and force a hard reload to fetch the new build — once only per
-// session (sessionStorage flag) to prevent infinite reload loops.
+// which strict browsers reject as an invalid MIME type. Three complementary
+// layers, all sharing the same once-per-session sessionStorage flag (so at most
+// one reload happens regardless of which layer fires first):
+//   1. lazyWithRetry()      — per-component, keeps Suspense fallback (routes + Landing sub-components)
+//   2. vite:preloadError     — Vite's official hook for failed dynamic imports (catch-all, even unwrapped lazies)
+//   3. unhandledrejection    — last-resort net for rejections that escape the above
+
+// (2) Vite fires this when it fails to load a dynamic import (official API).
+// preventDefault() suppresses the throw so React Router never shows its default
+// error screen; we reload to fetch the fresh build.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  reloadOnceForStaleChunk();
+});
+
+// (3) Last-resort: rejections not already handled by the layers above.
 window.addEventListener('unhandledrejection', (event) => {
-  const reason = event.reason;
-  const msg = String(reason instanceof Error ? reason.message : reason ?? '');
-  const isStaleChunk =
-    msg.includes('text/html') ||
-    msg.includes('is not a valid JavaScript MIME type') ||
-    msg.includes('Failed to fetch dynamically imported module') ||
-    msg.includes('Importing a module script failed');
-  if (isStaleChunk && !sessionStorage.getItem('chunk-reload')) {
-    sessionStorage.setItem('chunk-reload', '1');
-    window.location.reload();
+  if (isStaleChunkError(event.reason)) {
+    reloadOnceForStaleChunk();
   }
 });
 

--- a/src/test/lazyWithRetry.test.ts
+++ b/src/test/lazyWithRetry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  isStaleChunkError,
+  reloadOnceForStaleChunk,
+  STALE_CHUNK_RELOAD_KEY,
+} from '../app/lib/lazyWithRetry';
+
+describe('isStaleChunkError', () => {
+  it.each([
+    'Failed to fetch dynamically imported module: https://x/assets/UserMenu-D4jfd8IN.js',
+    'Importing a module script failed.',
+    'Expected a JavaScript module script but the server responded with a MIME type of "text/html". ... is not a valid JavaScript MIME type',
+    'text/html',
+  ])('detects stale-chunk message: %s', (msg) => {
+    expect(isStaleChunkError(new Error(msg))).toBe(true);
+    expect(isStaleChunkError(msg)).toBe(true); // raw string reason too
+  });
+
+  it.each([
+    'TypeError: cannot read properties of undefined',
+    'Network request failed',
+    '',
+  ])('does NOT flag unrelated error: %s', (msg) => {
+    expect(isStaleChunkError(new Error(msg))).toBe(false);
+  });
+
+  it('handles null/undefined reason safely', () => {
+    expect(isStaleChunkError(null)).toBe(false);
+    expect(isStaleChunkError(undefined)).toBe(false);
+  });
+});
+
+describe('reloadOnceForStaleChunk — once-per-session guard', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadSpy = vi.fn();
+    // jsdom location.reload is non-configurable on some versions — redefine.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('reloads once and sets the flag', () => {
+    expect(reloadOnceForStaleChunk()).toBe(true);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(STALE_CHUNK_RELOAD_KEY)).toBe('1');
+  });
+
+  it('does NOT reload a second time in the same session (anti-loop)', () => {
+    reloadOnceForStaleChunk();
+    reloadSpy.mockClear();
+    expect(reloadOnceForStaleChunk()).toBe(false);
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug

Écran prod intermittent reporté @thierry :
> Unexpected Application Error! Failed to fetch dynamically imported module: `.../assets/UserMenu-D4jfd8IN.js`

Signature classique du **stale chunk** : onglet ouvert avant un deploy → l'ancien hash de chunk n'existe plus sur le CDN.

## Root cause

`lazyWithRetry` (auto-reload sur stale chunk, déjà en place) ne couvrait QUE les composants de **route**. `UserMenu` / `LoginModal` / `PWAInstallModal` (Landing.tsx) utilisaient un `lazy()` **nu** → le rejet est attrapé par React Router AVANT le guard `unhandledrejection` de main.tsx → écran d'erreur par défaut, sans reload.

## Fix — defense-in-depth (3 couches, 1 flag sessionStorage anti-boucle partagé)

1. **Extraction** `lazyWithRetry` + `isStaleChunkError` + `reloadOnceForStaleChunk` → `src/app/lib/lazyWithRetry.ts` (source unique). Signature `ComponentType<any>` (comme `React.lazy`) pour préserver les prop types.
2. **Landing.tsx** : les 3 sous-composants passent par `lazyWithRetry` → dégradation gracieuse en Suspense au lieu de l'écran d'erreur.
3. **main.tsx** : listener global **`vite:preloadError`** (API officielle Vite vérifiée doc — fire sur import dynamique échoué après deploy, `preventDefault()` supprime le throw) → catch-all même pour un lazy futur non-wrappé. `unhandledrejection` refactoré DRY.

## Tests
`src/test/lazyWithRetry.test.ts` (10) : détection des 4 messages stale-chunk + négatifs + null-safe + guard reload once / anti-boucle.

## Test plan
- [x] type-check OK · lint OK
- [x] full suite **1759/1779 PASS** (+10)
- [ ] CI verte
- [ ] Voie A Chrome MCP : Landing `/` (UserMenu/LoginModal lazy OK) + `/app` (routes OK après refactor) + console clean

## Voie A obligatoire
Runtime change (main.tsx + routes.ts + Landing.tsx). Pas de surface sécurité (pas auth/RLS/API). Validation visuelle preview requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)