### PR TITLE
fix(landing): github-collaboration card 6→7 + per-module drift guard + agent anti-count doctrine

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,7 +1,7 @@
 # Claude Agents — Terminal Learning
 
 > Index et guide d'usage des agents internes du projet.
-> **Dernière mise à jour** : 28 mai 2026 (audit méta post-switch Opus 4.8 : création `supabase-backend-auditor` Opus — gate-zero Edge Functions Deno + Storage RLS + file upload, avant Sprint 2.C Étape 3 Resend + Phase X3b import. Sync modèles README↔frontmatter — fin du drift Haiku stale. Règle dure @thierry : **zéro Haiku**).
+> **Dernière mise à jour** : 29 mai 2026 (doctrine anti-hallucination dénombrement — tous agents : aucun compteur descriptif de tête, source déterministe obligatoire ; suite content-auditor « 63 leçons » faux positif. + 28 mai : `supabase-backend-auditor` Opus, sync modèles, règle zéro-Haiku).
 > ⚠️ **Maintenance** : ce champ "Dernière mise à jour" doit être bumpé à chaque ajout/modification d'agent (cf. section "Convention — ajouter un nouvel agent").
 > 🧠 **Limitation technique connue** : les agents `.md` créés en cours de session ne sont disponibles qu'à la session suivante (rechargement framework). Pattern : si un agent doit gater une PR créé pendant la même session, faire l'audit empirique inline avec exactement la méthode documentée dans l'agent, l'agent prendra le relais aux PRs suivantes.
 
@@ -26,6 +26,12 @@ L'incident 24 avril 2026 (downgrade silencieux Opus → Haiku/Sonnet → push di
 **Garde-fou utilisateur** : épingler `"model": "claude-opus-4-8"` dans `.claude/settings.local.json` du projet (cf. CLAUDE.md global) — évite que la main session bascule en Haiku/Sonnet sans notification. **Re-pin obligatoire à chaque bump de version Opus** (incident latent : pin resté sur 4.7 après switch 4.8, corrigé 28/05).
 
 **Pattern auto-apprentissage** : les leçons des bugs passés s'intègrent dans le **scope** des agents existants (ex : section "Client-state lifecycle" ajoutée à `rbac-flow-tester` après THI-186), pas dans des memos CC isolés que personne ne re-lit. Trimestriellement, re-audit des modèles agents (script `audit_agent_models.sh` à créer post-deadline).
+
+**⛔ Règle anti-hallucination — dénombrement (tous agents, effective 29/05/2026)** : aucun agent ne **dénombre du code ou de la data de tête**. Tout nombre **descriptif** (leçons, modules, tests, `describe`, commandes, % de commits, leçons complétées par un user…) doit venir d'une **source déterministe exécutée** (commande `Bash` + citation), jamais d'une estimation mentale du LLM. Distinction :
+- ✅ **Compteur prescriptif** (taille de la checklist propre à l'agent : « 16 checks », « 5 personas », « 11 sections ») = constante définie dans l'agent, pas un risque.
+- ❌ **Compteur descriptif** (mesure du code/data réel) = **commande obligatoire**. Ex : `npx tsx -e "import('./src/app/data/curriculum.ts').then(m=>console.log(m.getTotalLessons()))"`, `grep -c`, `npx vitest run` (sortie réelle), `git log --pretty` piped. Si la source n'est pas exécutable → écrire « compte non vérifié », jamais un nombre approximatif présenté comme exact.
+
+Incidents fondateurs : `content-auditor` « 356+ describes » (réel 62, 23/05) puis « 63 leçons » (réel 65, 28/05 — a failli faire corriger une comm publique correcte). La vérité des compteurs leçons est verrouillée par `src/test/landingTotals.test.ts` (total + par-module) + `src/test/seo.test.ts` (Schema.org dérivé de `getTotalLessons()`). `content-auditor.md` porte la règle détaillée ; les autres agents qui produisent des compteurs descriptifs (`test-runner` via vitest, `sustain-auditor` via git log, `user-forensics-auditor` via SQL/REST) tirent déjà de commandes — cette doctrine le codifie pour eux + tout futur agent.
 
 **Patterns récurrents** :
 - **Début de session** : invoquer `linear-sync` (status PR↔Linear) puis optionnellement `session-orchestrator` mode `startup` pour récap freshness + tickets In Progress

--- a/.claude/agents/content-auditor.md
+++ b/.claude/agents/content-auditor.md
@@ -9,6 +9,17 @@ Tu es un auditeur de contenu pédagogique pour Terminal Learning.
 
 Analyse en profondeur l'ensemble du curriculum + les docs narratifs et produis un rapport structuré A→Z.
 
+## ⛔ Règle anti-hallucination — JAMAIS de dénombrement à la main
+
+**Tu ne comptes JAMAIS de tête** (leçons, modules, tests, `describe`, commandes). Le comptage mental d'un LLM est non-fiable — deux incidents avérés : « 356+ describes » (réel 62) le 23/05, et « 63 leçons » (réel 65 — tu avais sous-compté `reseau` à 5 au lieu de 6 et `github-collaboration` à 6 au lieu de 7) le 28/05. Ce dernier a failli faire corriger une communication publique correcte.
+
+Pour tout nombre, exécute la **source déterministe** via `Bash` et cite-la :
+- Leçons (total + par module) : `npx tsx -e "import('./src/app/data/curriculum.ts').then(m=>{const c=m.curriculum;console.log('total',m.getTotalLessons());c.forEach(x=>console.log(x.id,x.lessons.length));})"`
+- Cohérence affichage : la vérité est verrouillée par `src/test/landingTotals.test.ts` (sum + par-module) et `src/test/seo.test.ts` (Schema.org dérivé). Si tu soupçonnes un écart, lance ces tests plutôt que de compter.
+- `describe`/tests : `grep -c` sur le fichier, jamais une estimation.
+
+Si tu ne peux pas exécuter la source déterministe, écris **« compte non vérifié »** — ne donne JAMAIS un nombre approximatif présenté comme exact.
+
 ## Fichiers à analyser
 
 - `src/app/data/curriculum.ts` — modules et leçons

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -240,7 +240,7 @@ export const MODULE_PREVIEWS: ModulePreview[] = [
   { id: 'variables', title: 'Variables & Scripts', description: "Maîtrisez les variables d'environnement, les fichiers de config et l'automatisation", iconName: 'Code2', color: '#f59e0b', level: 3, firstLessonId: 'env-vars', lessonCount: 6 },
   { id: 'reseau', title: 'Réseau & SSH', description: 'Testez la connectivité, effectuez des requêtes HTTP et connectez-vous à des serveurs distants', iconName: 'Globe', color: '#06b6d4', level: 3, firstLessonId: 'ping', lessonCount: 6 },
   { id: 'git', title: 'Git Fondamentaux', description: "Maîtrisez le contrôle de version avec Git — l'outil indispensable de tout développeur professionnel", iconName: 'GitBranch', color: '#f97316', level: 4, firstLessonId: 'git-init', lessonCount: 7 },
-  { id: 'github-collaboration', title: 'GitHub & Collaboration', description: 'Synchronisez avec des dépôts distants, ouvrez des Pull Requests et collaborez comme en entreprise', iconName: 'GitFork', color: '#8b5cf6', level: 4, firstLessonId: 'git-remote', lessonCount: 6 },
+  { id: 'github-collaboration', title: 'GitHub & Collaboration', description: 'Synchronisez avec des dépôts distants, ouvrez des Pull Requests et collaborez comme en entreprise', iconName: 'GitFork', color: '#8b5cf6', level: 4, firstLessonId: 'git-remote', lessonCount: 7 },
   { id: 'ia-dev', title: "L'IA comme outil dev", description: "Maîtrisez l'IA comme amplificateur de vos compétences — du prompt au déploiement", iconName: 'Bot', color: '#a78bfa', level: 5, firstLessonId: 'ia-dev-intro', lessonCount: 12 },
 ];
 

--- a/src/test/landingTotals.test.ts
+++ b/src/test/landingTotals.test.ts
@@ -3,6 +3,7 @@ import {
   TOTAL_LESSONS,
   TOTAL_COMMANDS,
   ACTIVE_ENVIRONMENTS_COUNT,
+  MODULE_PREVIEWS,
 } from '../app/data/landingContent';
 import { curriculum } from '../app/data/curriculum';
 import { commandCatalogue } from '../app/data/commandCatalogue';
@@ -29,5 +30,34 @@ describe('landingContent — totals drift guard (THI-118)', () => {
   it('ACTIVE_ENVIRONMENTS_COUNT matches active env list', () => {
     const computed = ENVIRONMENTS.filter((e) => e.status === 'active').length;
     expect(ACTIVE_ENVIRONMENTS_COUNT).toBe(computed);
+  });
+
+  // Per-module guard — the landing module CARDS use MODULE_PREVIEWS[].lessonCount,
+  // a separate hardcoded array from TOTAL_LESSONS. The hero (TOTAL_LESSONS) was
+  // correct (65) but a card (github-collaboration) under-reported (6 vs real 7),
+  // so the cards summed to 64 while the hero said 65 — a visible inconsistency a
+  // visitor could spot. This guard ties EACH card count to the real curriculum
+  // module so a per-module drift fails CI (closes the gap the TOTAL_LESSONS
+  // check above did not cover).
+  it('every MODULE_PREVIEWS.lessonCount matches its curriculum module', () => {
+    for (const preview of MODULE_PREVIEWS) {
+      const mod = curriculum.find((m) => m.id === preview.id);
+      expect(mod, `MODULE_PREVIEWS id "${preview.id}" has no matching curriculum module`).toBeDefined();
+      expect(
+        preview.lessonCount,
+        `MODULE_PREVIEWS "${preview.id}" lessonCount=${preview.lessonCount} but curriculum has ${mod!.lessons.length}`,
+      ).toBe(mod!.lessons.length);
+    }
+  });
+
+  it('MODULE_PREVIEWS covers every curriculum module (no missing/extra card)', () => {
+    const previewIds = MODULE_PREVIEWS.map((p) => p.id).sort();
+    const curriculumIds = curriculum.map((m) => m.id).sort();
+    expect(previewIds).toEqual(curriculumIds);
+  });
+
+  it('sum of MODULE_PREVIEWS.lessonCount equals TOTAL_LESSONS (hero = cards)', () => {
+    const cardsSum = MODULE_PREVIEWS.reduce((sum, p) => sum + p.lessonCount, 0);
+    expect(cardsSum).toBe(TOTAL_LESSONS);
   });
 });


### PR DESCRIPTION
## Bug visible
Hero landing = 65 leçons (correct) mais **somme des 11 cartes = 64** : `MODULE_PREVIEWS` hardcodait `github-collaboration: lessonCount: 6` alors que le module a **7 leçons réelles** (toutes complètes — exercise+instruction+validate vérifiés). Incohérence qu'un visiteur peut repérer.

**Vérité empirique** : `getTotalLessons()=65`, 0 doublon, 65 ids distincts. Instagram/LinkedIn (65) **honnête** → on aligne l'affichage sur le réel.

## Fix
1. `landingContent.ts` : github-collaboration 6 → 7
2. `landingTotals.test.ts` : 3 gardes (le garde `TOTAL_LESSONS` existant ne couvrait PAS le tableau des cartes) :
   - chaque `MODULE_PREVIEWS.lessonCount === curriculum module.lessons.length`
   - couverture exacte des modules (0 manquant/extra)
   - `Σ MODULE_PREVIEWS === TOTAL_LESSONS` (hero = cartes)

## Agent reliability (demande @thierry)
content-auditor a halluciné « 63 » en comptant de tête (2e fois après « 356+ describes »).
3. `content-auditor.md` : règle ⛔ anti-hallucination (source déterministe obligatoire).
4. `README.md agents` : **doctrine globale tous agents** — compteur prescriptif (OK) vs descriptif (commande obligatoire). Audit cross-agent : seul content-auditor hallucinait ; test-runner/sustain/user-forensics tirent déjà de commandes.

## Test plan
- [x] type-check OK · lint OK
- [x] landingTotals 6/6 · full suite **1762/1782 PASS**
- [ ] CI verte
- [ ] Voie A Chrome MCP : carte github-collaboration affiche **7** + somme cartes = 65

## Observation séparée (non bloquante)
Flaky pré-existant `AiSettings.test "Oublier"` (timing async, passe au retry, sans rapport) → à stabiliser à part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)