### PR TITLE
docs(marketing): correction factuelle kit (Option A)

### DIFF
--- a/docs/marketing/kit-2026-05-18.md
+++ b/docs/marketing/kit-2026-05-18.md
@@ -2,7 +2,13 @@
 
 > Textes prêts-à-coller et templates pour les actions hors-code identifiées le 18 mai 2026 par l'agent challenge stratégique. Validé par @thierry « si tu peux le gérer, pas de soucis » pour les catalogs.
 
-**Status** : assets prêts. Inscriptions à exécuter par @thierry quand bon lui semble dans les 23 jours menant à la deadline 10 juin (chaque inscription = ~5 min copier-coller + valider email).
+> ⚠️ **MISE À JOUR FACTUELLE 29 mai 2026 (correction chirurgicale, pas réécriture)** — le cadrage d'origine (deadline « 10 juin 2026 / démo pilotes B2B ») est **SUPERSEDED** par la décision @thierry du 28/05 : **silence médiatique B2B jusqu'au gate-zéro release X6 (automne 2026)** — la plateforme B2B s'étend sur ~18 semaines (Phase X). Conséquences :
+> - ✅ **Toujours actionnable maintenant** (ne contredit pas le silence — listing d'un produit déjà live/gratuit) : §1-4 catalogs (Class Central, OER, MERLOT) + Awesome lists. Une fois le claim LTI corrigé (cf. ci-dessous).
+> - 🕐 **À réactualiser au prochain jalon réel** : posts sociaux datés (§5 post #1 hat-trick 18/05, §2 SEO #260) — events passés.
+> - 🔒 **Corrections promesse (on ne triche pas)** : le claim « LTI 1.3 en cours pour la rentrée 2026 » est **retiré** (LTI est en SPIKE gated `LTI_ENABLED=false`, PAS en cours actif daté). « Lighthouse 100/100 sécurité » corrigé (Lighthouse n'a pas de catégorie « sécurité » → c'est « Best Practices »).
+> - 📊 Chiffres : 65 leçons (vérifié ✓), tests en phrasing souple (~1760, plus de chiffre dur périmé « 1475 »), score sécurité 9.4/10 (l'audit IA spécifique était 9.2/10).
+
+**Status** : assets prêts. **Catalogs + Awesome lists** exécutables par @thierry quand bon lui semble (chaque inscription = ~5 min copier-coller + valider email). **Posts sociaux** : tenir jusqu'au prochain jalon (cf. silence B2B jusqu'à X6).
 
 ---
 
@@ -16,10 +22,10 @@
 
 ### Description courte (255 caractères max) — option B recommandée Google IA 18/05
 ```
-Terminal Learning — Plateforme pédagogique interactive Linux/macOS/Windows. 11 modules, 65 leçons, RGPD-conforme (UE), open source. Intégration LTI 1.3 (Moodle/Canvas/Smartschool) en cours pour la rentrée 2026. 100% gratuit, sans inscription.
+Terminal Learning — Plateforme pédagogique interactive Linux/macOS/Windows. 11 modules, 65 leçons, RGPD-conforme (UE), open source. 100% gratuit, sans inscription.
 ```
 
-> Insight Google IA 18/05 : « N'attendez pas que le backend LTI soit 100% fini pour faire les soumissions. Le simple fait d'annoncer 'LTI integration coming June 2026' va attirer l'œil des directeurs de programmes qui préparent la rentrée. » L'angle RGPD + souveraineté numérique différencie aussi des alternatives US (Codecademy, freeCodeCamp).
+> Insight Google IA 18/05 (RGPD/souveraineté toujours valide) : l'angle **RGPD + souveraineté numérique** différencie des alternatives US (Codecademy, freeCodeCamp). ⚠️ **Le conseil d'origine « annoncer 'LTI integration coming June 2026' » est RETIRÉ** — LTI est en SPIKE gated, non daté publiquement ; annoncer une date non tenable = promesse non respectée (cf. décision intégrité @thierry). Ne pas annoncer de date LTI tant que ce n'est pas livré.
 
 ### Description courte — option A neutre (si tu préfères sans annonce future)
 ```
@@ -195,8 +201,8 @@ Sprint 2 essentiellement clos en avance. Ce week-end on a livré 4 PRs sécurit�
 Pourquoi je raconte ça ? Parce que la cybersécurité dans les apps éducatives, c'est aussi pédagogique. Mes utilisateurs (étudiants, enseignants) méritent une plateforme audit-grade.
 
 🤖 Co-construit avec Claude (Anthropic)
-🛡️ Score sécurité 9.2/10 stable
-🎓 1475 tests verts
+🛡️ Score sécurité 9.4/10
+🎓 1700+ tests verts
 
 #OpenSource #Cybersecurite #Devops #Linux #ApprendreLeTerminal #EdTech #FrenchTech #BelgianTech #IndieHacker #SoloDeveloper #PassionProject
 ```
@@ -265,7 +271,7 @@ Concrètement : si tu demandes à une IA "où apprendre le terminal gratuitement
 ```
 Trois semaines pour préparer Terminal Learning à entrer dans les écoles et centres de formation. Voici comment j'ai abordé le sprint.
 
-🎯 Cible : 10 juin 2026 — démo pour pilotes B2B éducation
+🎯 Cible : release B2B complète automne 2026 (gate-zéro X6) — démo pilotes éducation à ce moment-là
 
 📊 Axes stratégiques équilibrés :
 • SEO/GEO/AEO — pour que les enseignants nous trouvent
@@ -276,7 +282,7 @@ Trois semaines pour préparer Terminal Learning à entrer dans les écoles et ce
 • 1 PR à la fois, scope chirurgical
 • security-auditor obligatoire sur chaque modif RBAC
 • Voie A Chrome MCP validation visuelle iPhone + desktop avant merge
-• Tests : 1475 → cible 1500+ post-sprint
+• Tests : 1700+ verts (suite Vitest complète)
 
 🤖 Co-construit avec Claude (Anthropic) en mode trio orchestrateur :
 • @cowork pour les décisions architecturales
@@ -302,8 +308,8 @@ Terminal Learning, mon projet open source pour apprendre les commandes Linux/mac
 
 ✅ Hébergé en UE (Supabase Frankfurt + Vercel EU + Sentry EU)
 ✅ RGPD-conforme par design (mode invité = 0 donnée backend)
-✅ Lighthouse 100/100 sur accessibilité, sécurité, SEO
-✅ Score sécurité audit-grade 9.2/10
+✅ Lighthouse 100 sur accessibilité, best practices, SEO
+✅ Score sécurité audit-grade 9.4/10
 ✅ Aucune donnée vendue, aucun tracker tiers, aucun cookie publicitaire
 ✅ Open source MIT — auditable, forkable, modifiable
 
@@ -311,7 +317,7 @@ Pourquoi je précise tout ça ? Parce que les outils éducatifs majoritaires (Co
 
 L'enseignement informatique mérite mieux que l'arbitrage permanent "gratuit US vs payant EU".
 
-Si vous êtes enseignant en informatique, formateur ou DSI école : Terminal Learning est utilisable demain matin, gratuitement, en classe, sans signer de DPA exotique. Et l'intégration LTI 1.3 (Moodle/Smartschool/Canvas) arrive pour la rentrée 2026.
+Si vous êtes enseignant en informatique, formateur ou DSI école : Terminal Learning est utilisable demain matin, gratuitement, en classe, sans signer de DPA exotique. (Intégration LTI 1.3 Moodle/Smartschool/Canvas en développement — annoncée quand livrée, pas avant.)
 
 terminallearning.dev
 
@@ -329,7 +335,7 @@ Terminal Learning est mon premier projet terminé.
 
 Il est gratuit. Open source. Construit avec une IA (Claude) parce que coder en solo après 5 ans de maladie chronique, c'est mathématiquement impossible sans aide.
 
-Aujourd'hui : 1475 tests verts, score sécurité 9.2/10, 11 modules pédagogiques live en production, et l'objectif d'entrer dans les écoles en septembre.
+Aujourd'hui : 1700+ tests verts, score sécurité 9.4/10, 11 modules pédagogiques live en production, et l'objectif d'entrer dans les écoles à terme.
 
 L'IA ne remplace pas. Elle augmente.
 


### PR DESCRIPTION
## Contexte
@thierry : kit `kit-2026-05-18.md` plus certain d'être à jour. Audit → significativement périmé + 2 risques promesse. **Option A** validée : correction factuelle chirurgicale (pas de réécriture, voix + story perso préservées).

## Corrections
- **Banner supersession** : deadline "10 juin / démo pilotes B2B" → décision 28/05 silence B2B jusqu'à X6 (automne). Catalogs + Awesome lists restent actionnables ; posts datés à réactualiser.
- **Promesses (on ne triche pas)** : claim "LTI 1.3 rentrée 2026" retiré (SPIKE gated, non daté) ×2 + insight. "Lighthouse 100/100 sécurité" → "Best Practices" (pas de catégorie sécurité Lighthouse).
- **Chiffres** : "1475 tests" → "1700+" (×3), "9.2/10" → "9.4/10", "10 juin"/"1500+" supprimés. "65 leçons" conservé (vérifié).

## Voie C
`docs/marketing/` non déployé (pas rendu SPA). 0 runtime. Pas de preview requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)