### PR TITLE
security(sentry-tunnel): harden scrub against /g regex lastIndex leak (route-attack H1)

### DIFF
--- a/api/sentry-tunnel.ts
+++ b/api/sentry-tunnel.ts
@@ -88,9 +88,16 @@ export function scrubEnvelopeItem(itemBody: string): { scrubbed: string; stats: 
     // Non-JSON body: fall back to text-level scrub
     let scrubbed = itemBody;
     Object.entries(SCRUB_PATTERNS).forEach(([key, pattern]) => {
-      if (pattern.test(scrubbed)) {
+      // SCRUB_PATTERNS are module-scoped /g regexes whose stateful lastIndex
+      // leaks across scrub calls — a stale lastIndex can make a later .test()
+      // skip a real match (false-negative scrub of a secret en route to Sentry,
+      // route-attack H1 29/05). Mirror the proven client scrubber (src/lib/sentry.ts):
+      // reset lastIndex, replace directly (no stateful prescan), detect hit by diff.
+      pattern.lastIndex = 0;
+      const replaced = scrubbed.replace(pattern, `[REDACTED:${key}]`);
+      if (replaced !== scrubbed) {
         stats.patterns_hit.push(key as PatternKey);
-        scrubbed = scrubbed.replace(pattern, `[REDACTED:${key}]`);
+        scrubbed = replaced;
       }
     });
     return { scrubbed, stats };
@@ -100,9 +107,16 @@ export function scrubEnvelopeItem(itemBody: string): { scrubbed: string; stats: 
     if (typeof val !== 'string') return val;
     let scrubbed = val;
     Object.entries(SCRUB_PATTERNS).forEach(([key, pattern]) => {
-      if (pattern.test(scrubbed)) {
+      // SCRUB_PATTERNS are module-scoped /g regexes whose stateful lastIndex
+      // leaks across scrub calls — a stale lastIndex can make a later .test()
+      // skip a real match (false-negative scrub of a secret en route to Sentry,
+      // route-attack H1 29/05). Mirror the proven client scrubber (src/lib/sentry.ts):
+      // reset lastIndex, replace directly (no stateful prescan), detect hit by diff.
+      pattern.lastIndex = 0;
+      const replaced = scrubbed.replace(pattern, `[REDACTED:${key}]`);
+      if (replaced !== scrubbed) {
         stats.patterns_hit.push(key as PatternKey);
-        scrubbed = scrubbed.replace(pattern, `[REDACTED:${key}]`);
+        scrubbed = replaced;
       }
     });
     return scrubbed;

--- a/src/test/sentry-scrubber.test.ts
+++ b/src/test/sentry-scrubber.test.ts
@@ -229,4 +229,49 @@ describe('Sentry tunnel scrubber — coverage matrix (THI-140)', () => {
       expect(stats.patterns_hit).toEqual([]);
     });
   });
+
+  // route-attack H1 (29/05) — SCRUB_PATTERNS are module-scoped /g regexes; a
+  // stateful lastIndex leaking across calls could skip a real match. These
+  // regression tests prove a secret is scrubbed on EVERY call regardless of
+  // prior-call state (the fix replaces directly instead of a stateful .test()).
+  describe('regex state isolation across calls (H1 regression)', () => {
+    it('scrubs the key on repeated calls — no lastIndex leak between invocations', () => {
+      for (let i = 0; i < 5; i++) {
+        const item = JSON.stringify({
+          type: 'event',
+          exception: { values: [{ type: 'Error', value: `Boom ${FAKE_OPENROUTER_KEY}` }] },
+        });
+        const { scrubbed, stats } = scrubEnvelopeItem(item);
+        expect(scrubbed, `call #${i} leaked the key`).not.toContain(FAKE_OPENROUTER_KEY);
+        expect(stats.patterns_hit).toContain('openrouter');
+      }
+    });
+
+    it('scrubs a key positioned earlier than a previous match (lastIndex would skip it)', () => {
+      // Call 1: key late in the value (a stateful lastIndex would advance far).
+      scrubEnvelopeItem(JSON.stringify({
+        type: 'event',
+        exception: { values: [{ type: 'Error', value: `${'x'.repeat(200)} ${FAKE_OPENROUTER_KEY}` }] },
+      }));
+      // Call 2: key at the very start — a leaked lastIndex would make a stateful scan miss it.
+      const { scrubbed } = scrubEnvelopeItem(JSON.stringify({
+        type: 'event',
+        exception: { values: [{ type: 'Error', value: `${FAKE_OPENROUTER_KEY} trailing` }] },
+      }));
+      const value = JSON.parse(scrubbed).exception.values[0].value;
+      expect(value).not.toContain(FAKE_OPENROUTER_KEY);
+      expect(value).toContain('[REDACTED:openrouter]');
+    });
+
+    it('scrubs multiple occurrences of the same secret in one value', () => {
+      const item = JSON.stringify({
+        type: 'event',
+        exception: { values: [{ type: 'Error', value: `${FAKE_OPENROUTER_KEY} and again ${FAKE_OPENROUTER_KEY}` }] },
+      });
+      const { scrubbed } = scrubEnvelopeItem(item);
+      const value = JSON.parse(scrubbed).exception.values[0].value;
+      expect(value).not.toContain(FAKE_OPENROUTER_KEY);
+      expect(value.match(/\[REDACTED:openrouter\]/g)?.length).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Finding (route-attack-auditor, audit global 29/05 — H1)
`api/sentry-tunnel.ts` `scrubEnvelopeItem()` faisait `pattern.test()` puis `.replace()` sur des regex `/g` module-scoped. Le `lastIndex` stateful partagé entre appels peut faire **sauter une correspondance** → clé API/JWT potentiellement **en clair vers Sentry**.

**Honnêteté** : exploit exact borderline (`.replace()` /g reset lastIndex après), mais le `.test()`-puis-`.replace()` à état partagé est fragile + **asymétrique** avec le scrubber client (`src/lib/sentry.ts:33`) qui fait déjà `lastIndex=0` + replace direct.

## Fix
Aligne le tunnel sur le pattern client prouvé : `pattern.lastIndex = 0` + `.replace()` direct (plus de `.test()` à état), détection du hit par comparaison. Élimine footgun + double-scan, restaure symétrie client/tunnel.

## Tests
3 régressions (boucle 5× même pattern · clé en position antérieure à un match précédent · occurrences multiples). **19/19** sentry-scrubber, full suite **1765/1785**.

## Notes (→ Linear umbrella, non bloquant)
- 6 `no-explicit-any` pré-existants dans `api/` (hors scope CI `eslint src`).
- `event.message` top-level non scrubé tunnel-side (couvert par beforeSend client).
- M1 no-store /api/*, H2/M2/M3 LTI-gated, L3 rate-limit partagé → backlog (LTI off).

## Test plan
- [x] type-check OK · scrubber 19/19 · full suite 1765/1785
- [ ] CI · Sourcery (rate-limit probable)
- [ ] route-attack a déjà validé empiriquement le finding

Touche `api/` → `route-attack-auditor` (déjà passé, a trouvé le finding) + couvert par les tests régression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)