### PR TITLE
fix(ui): visible emerald hover on landing UserMenu profil item

### DIFF
--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -186,11 +186,15 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions }: UserMen
             </div>
           </div>
           <div className="py-1" role="none">
+            {/* Survol emerald cohérent avec la variante card (sidebar /app) :
+                l'ancien hover:bg-[var(--github-border-secondary)] était IDENTIQUE
+                au fond du popover → survol invisible. Langage couleur unifié :
+                Mon profil = emerald, Se déconnecter = rouge (cf. card ci-dessus). */}
             <Link
               to="/app/profile"
               role="menuitem"
               onClick={() => setOpen(false)}
-              className="flex items-center w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[var(--github-text-primary)] font-mono hover:bg-[var(--github-border-secondary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+              className="flex items-center w-full justify-start gap-2.5 px-4 py-2.5 text-sm text-[var(--github-text-primary)] font-mono hover:bg-emerald-500/10 hover:text-emerald-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
             >
               <CircleUser size={14} aria-hidden="true" />
               Mon profil


### PR DESCRIPTION
## Problème
Sur le header de la **landing** (variante `compact` de `UserMenu`), le survol de l'item **« Mon profil »** était **invisible** : il utilisait `hover:bg-[var(--github-border-secondary)]`, soit **exactement la même couleur** que le fond du popover. « Se déconnecter » ayant déjà un survol rouge visible, l'incohérence sautait aux yeux.

J'avais poli la variante `card` (sidebar /app) avec le langage emerald, mais jamais répercuté sur la `compact` (landing).

## Fix
`hover:bg-emerald-500/10` + `hover:text-emerald-300` sur « Mon profil » compact → survol visible + langage couleur aligné sur la variante `card` (profil = emerald, déconnexion = rouge).

Intensité adaptée au pattern menu-item plat (repos transparent → `/10` au survol), vs le bouton pill de la card (`/10` repos → `/20` survol). `text-emerald-300` identique dans les deux variantes.

## Cohérence desktop / mobile
La landing utilise la **même** variante `compact` sur desktop **et** mobile (nav responsive, pas de burger séparé) → un seul fix couvre les deux. /app reste en `card` partout.

## Validation
- ✅ type-check + lint clean
- ✅ 15/15 tests `auth.test.tsx` (incl. variante compact landing)
- ✅ `ui-auditor` : OK — 0 CRITICAL, 0 HIGH, 0 couleur en dur, tokens emerald conformes
- 🔄 Preview Chrome (session loggée) — en cours

## Scope
1 fichier, 1 ligne CSS (hover). Zéro logique, zéro route, zéro data. Pur cosmétique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)