### PR TITLE
fix(sidebar): collapse modules by default, auto-expand active module

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { NavLink, useNavigate, useLocation } from 'react-router';
+import { NavLink, useNavigate, useMatch } from 'react-router';
 import { useFocusTrap } from '../../lib/hooks/useFocusTrap';
 import { useUserRole } from '../../lib/hooks/useUserRole';
 import {
@@ -21,6 +21,17 @@ import { EnvPill } from './ui/env-pill';
 interface SidebarProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+// État d'expansion effectif d'un module : un override utilisateur explicite prime,
+// sinon le module est ouvert seulement s'il est le module actif. Source unique
+// partagée par toggleModule et le rendu (évite toute divergence si la règle évolue).
+function isModuleExpanded(
+  overrides: Record<string, boolean>,
+  id: string,
+  activeModuleId: string | null,
+): boolean {
+  return overrides[id] ?? (id === activeModuleId);
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
@@ -61,10 +72,12 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       return next;
     });
   };
-  // Module actif déduit de la route leçon (/app/learn/:moduleId/:lessonId).
-  // null sur le dashboard ou toute page hors leçon.
-  const location = useLocation();
-  const activeModuleId = location.pathname.match(/\/app\/learn\/([^/]+)/)?.[1] ?? null;
+  // Module actif déduit de la route leçon (/app/learn/:moduleId/:lessonId) via le
+  // matching natif du routeur (useMatch) plutôt qu'une regex sur pathname : reste
+  // aligné sur la définition de route et ne casse pas silencieusement si la route
+  // évolue (base path, emboîtement). null sur le dashboard ou toute page hors leçon.
+  const learnMatch = useMatch('/app/learn/:moduleId/*');
+  const activeModuleId = learnMatch?.params.moduleId ?? null;
 
   // `expandedModules` ne stocke QUE les overrides explicites de l'utilisateur.
   // L'état effectif est dérivé au rendu : expandedModules[id] ?? (id === activeModuleId).
@@ -75,10 +88,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [expandedModules, setExpandedModules] = useState<Record<string, boolean>>({});
 
   const toggleModule = (id: string) => {
-    setExpandedModules((prev) => {
-      const effective = prev[id] ?? (id === activeModuleId);
-      return { ...prev, [id]: !effective };
-    });
+    setExpandedModules((prev) => ({ ...prev, [id]: !isModuleExpanded(prev, id, activeModuleId) }));
   };
 
   const handleLessonClick = (moduleId: string, lessonId: string) => {
@@ -378,7 +388,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           {curriculum.map((mod) => {
             const Icon = iconMap[mod.iconName] ?? BookOpen;
             const { completed, total } = getModuleProgress(mod.id);
-            const isExpanded = expandedModules[mod.id] ?? (mod.id === activeModuleId);
+            const isExpanded = isModuleExpanded(expandedModules, mod.id, activeModuleId);
             const unlockStatus = unlockTree.find((u) => u.moduleId === mod.id);
             const locked = unlockStatus ? !unlockStatus.unlocked : false;
 

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { NavLink, useNavigate } from 'react-router';
+import { NavLink, useNavigate, useLocation } from 'react-router';
 import { useFocusTrap } from '../../lib/hooks/useFocusTrap';
 import { useUserRole } from '../../lib/hooks/useUserRole';
 import {
@@ -61,14 +61,24 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       return next;
     });
   };
-  const [expandedModules, setExpandedModules] = useState<Record<string, boolean>>(() => {
-    const init: Record<string, boolean> = {};
-    curriculum.forEach((m) => { init[m.id] = true; });
-    return init;
-  });
+  // Module actif déduit de la route leçon (/app/learn/:moduleId/:lessonId).
+  // null sur le dashboard ou toute page hors leçon.
+  const location = useLocation();
+  const activeModuleId = location.pathname.match(/\/app\/learn\/([^/]+)/)?.[1] ?? null;
+
+  // `expandedModules` ne stocke QUE les overrides explicites de l'utilisateur.
+  // L'état effectif est dérivé au rendu : expandedModules[id] ?? (id === activeModuleId).
+  // → par défaut seul le module actif est ouvert (les autres repliés), ce qui supprime
+  // la sidebar interminable d'avant (tous forcés ouverts = 65 leçons d'un coup, pénible
+  // sur mobile). Le module précédemment actif se replie en changeant de leçon, sauf si
+  // l'utilisateur l'a explicitement ouvert. Dérivation pure = pas de setState en effet.
+  const [expandedModules, setExpandedModules] = useState<Record<string, boolean>>({});
 
   const toggleModule = (id: string) => {
-    setExpandedModules((prev) => ({ ...prev, [id]: !prev[id] }));
+    setExpandedModules((prev) => {
+      const effective = prev[id] ?? (id === activeModuleId);
+      return { ...prev, [id]: !effective };
+    });
   };
 
   const handleLessonClick = (moduleId: string, lessonId: string) => {
@@ -368,7 +378,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           {curriculum.map((mod) => {
             const Icon = iconMap[mod.iconName] ?? BookOpen;
             const { completed, total } = getModuleProgress(mod.id);
-            const isExpanded = expandedModules[mod.id];
+            const isExpanded = expandedModules[mod.id] ?? (mod.id === activeModuleId);
             const unlockStatus = unlockTree.find((u) => u.moduleId === mod.id);
             const locked = unlockStatus ? !unlockStatus.unlocked : false;
 


### PR DESCRIPTION
## Problème (reporté par @thierry)
Le menu des leçons dans la sidebar gardait **tous les modules dépliés** en permanence → les 65 leçons affichées d'un coup, **sidebar interminable surtout sur mobile**, et bruyant pour les modules déjà complétés.

Cause : [Sidebar.tsx](src/app/components/Sidebar.tsx) initialisait `expandedModules` à `true` pour les 11 modules.

## Fix
`expandedModules` ne stocke plus que les **overrides explicites** de l'utilisateur (init `{}`). L'état effectif est **dérivé au rendu** :
```ts
const isExpanded = expandedModules[mod.id] ?? (mod.id === activeModuleId);
```
- `activeModuleId` vient de la route `/app/learn/:moduleId/:lessonId` (`useLocation`).
- **Par défaut** : seul le module actif est ouvert, les autres repliés.
- Le module précédent **se replie tout seul** au changement de leçon (sauf si ouvert manuellement).
- **Dérivation pure** → pas de `setState` dans un effet (respecte `react-hooks/set-state-in-effect`).

## Comportement
- `/app` (dashboard) : tous repliés → 11 headers scannables, sidebar courte.
- Dans une leçon : son module ouvert (contexte), les autres repliés.
- Toggle manuel respecté pendant la session.

## Validation
- ✅ type-check + lint clean
- ✅ Suite complète **1785 passed** (0 error sur re-run propre)
- ✅ `ui-auditor` OK — 0 CRITICAL/HIGH, 0 valeur en dur introduite (diff = logique d'état pure)
- 🔄 Preview Chrome desktop + mobile — en cours

## Scope
1 fichier, logique d'état uniquement. Zéro markup/couleur/composant modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Réduire les modules de la barre latérale par défaut et développer automatiquement le module actif en fonction de la route de la leçon actuelle.

Améliorations :
- Déduire l’état de développement des modules à partir de la route actuelle et des surcharges utilisateur, au lieu d’initialiser tous les modules comme développés.
- Ajuster le comportement du bouton de bascule des modules pour prendre en compte l’état de développement effectif plutôt que seulement les surcharges enregistrées.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Collapse sidebar modules by default and auto-expand the active module based on the current lesson route.

Enhancements:
- Derive module expansion state from the current route and user overrides instead of initializing all modules as expanded.
- Adjust module toggle behavior to take into account the effective expansion state rather than only stored overrides.

</details>