### PR TITLE
fix(lessons): render **bold** markdown in lesson content (was leaking literal **)

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../context/AuthContext';
 import { useEnvironment } from '../context/EnvironmentContext';
 import { useLessonSEO } from '../hooks/useLessonSEO';
 import { toUnixUsername } from '../../lib/username';
+import { renderInlineMarkdown } from '../../lib/renderInlineMarkdown';
 import { TerminalState } from '../data/terminalEngine';
 import { TerminalEmulator } from './TerminalEmulator';
 import { Button } from './ui/button';
@@ -24,18 +25,8 @@ function BlockRenderer({ block, env = 'linux' }: { block: ContentBlock; env?: En
   const content = block.contentByEnv?.[env] ?? block.content;
   const label = block.labelByEnv?.[env] ?? block.label;
 
-  const renderText = (text: string) => {
-    const parts = text.split(/(`[^`]+`)/g);
-    return parts.map((part, i) =>
-      part.startsWith('`') && part.endsWith('`') ? (
-        <code key={i} className="px-1.5 py-0.5 bg-[#21262d] text-emerald-400 rounded text-sm font-mono border border-[var(--github-border-primary)]">
-          {part.slice(1, -1)}
-        </code>
-      ) : (
-        <span key={i}>{part}</span>
-      )
-    );
-  };
+  // Inline markdown (code + bold) shared with tests — see renderInlineMarkdown.
+  const renderText = (text: string) => renderInlineMarkdown(text);
 
   switch (block.type) {
     case 'text':

--- a/src/lib/renderInlineMarkdown.tsx
+++ b/src/lib/renderInlineMarkdown.tsx
@@ -16,9 +16,14 @@ import type { ReactNode } from 'react';
  * literal text inside the <strong> rather than nesting, which is acceptable.
  *
  * Tokens that do not match either pattern render as plain <span> text, so a
- * stray single `*` or backtick is shown verbatim (never swallowed).
+ * stray single `*`, an unclosed `**`, or a lone backtick is shown verbatim
+ * (never swallowed).
+ *
+ * The bold sub-pattern allows a single `*` inside the span (e.g. `**a * b**`)
+ * via `\*(?!\*)` — it only stops at the closing `**` — so legitimate bold
+ * containing an asterisk is not missed (Sourcery PR #332).
  */
-const INLINE_TOKEN_RX = /(`[^`]+`|\*\*[^*]+\*\*)/g;
+const INLINE_TOKEN_RX = /(`[^`]+`|\*\*(?:[^*]|\*(?!\*))+\*\*)/g;
 
 export function renderInlineMarkdown(text: string): ReactNode[] {
   return text.split(INLINE_TOKEN_RX).map((part, i) => {

--- a/src/lib/renderInlineMarkdown.tsx
+++ b/src/lib/renderInlineMarkdown.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Minimal inline-markdown renderer for lesson content blocks.
+ *
+ * Historically `LessonPage` only parsed backtick `` `code` `` spans, so the
+ * `**bold**` markdown that ~22 lessons authored leaked to learners as literal
+ * asterisks (caught visually 30/05/2026). This helper renders BOTH:
+ *
+ *  - `` `code` `` → <code> (monospace chip, unchanged styling)
+ *  - `**bold**`   → <strong>
+ *
+ * Scope is deliberately inline-only: no lists, headings, or links (lesson
+ * structure uses dedicated `ContentBlock` types — tip/info/warning/code — for
+ * those). Nested code inside bold (`` **`x`** ``) is rare; it falls back to
+ * literal text inside the <strong> rather than nesting, which is acceptable.
+ *
+ * Tokens that do not match either pattern render as plain <span> text, so a
+ * stray single `*` or backtick is shown verbatim (never swallowed).
+ */
+const INLINE_TOKEN_RX = /(`[^`]+`|\*\*[^*]+\*\*)/g;
+
+export function renderInlineMarkdown(text: string): ReactNode[] {
+  return text.split(INLINE_TOKEN_RX).map((part, i) => {
+    if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+      return (
+        <code
+          key={i}
+          className="px-1.5 py-0.5 bg-[#21262d] text-emerald-400 rounded text-sm font-mono border border-[var(--github-border-primary)]"
+        >
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+    if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+      return (
+        <strong key={i} className="font-semibold text-[var(--github-text-primary)]">
+          {part.slice(2, -2)}
+        </strong>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}

--- a/src/test/renderInlineMarkdown.test.tsx
+++ b/src/test/renderInlineMarkdown.test.tsx
@@ -44,6 +44,25 @@ describe('renderInlineMarkdown', () => {
     expect(container.textContent).toBe('2 * 3 = 6');
   });
 
+  it('renders bold that itself contains a single asterisk (Sourcery PR #332)', () => {
+    const { container } = renderInline('glob **a * b** pattern');
+    const strong = container.querySelector('strong');
+    expect(strong?.textContent).toBe('a * b');
+    expect(container.textContent).toBe('glob a * b pattern');
+  });
+
+  it('leaves an unclosed ** marker verbatim (no swallowing)', () => {
+    const { container } = renderInline('un **gras pas fermé ici');
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.textContent).toBe('un **gras pas fermé ici');
+  });
+
+  it('leaves an unclosed backtick verbatim', () => {
+    const { container } = renderInline('un `code pas fermé');
+    expect(container.querySelector('code')).toBeNull();
+    expect(container.textContent).toBe('un `code pas fermé');
+  });
+
   it('leaves plain text without markup', () => {
     const { container } = renderInline('juste du texte normal');
     expect(container.querySelector('strong')).toBeNull();

--- a/src/test/renderInlineMarkdown.test.tsx
+++ b/src/test/renderInlineMarkdown.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { renderInlineMarkdown } from '@/lib/renderInlineMarkdown';
+
+function renderInline(text: string) {
+  return render(<div data-testid="out">{renderInlineMarkdown(text)}</div>);
+}
+
+describe('renderInlineMarkdown', () => {
+  it('renders `code` spans as <code> with the backticks stripped', () => {
+    const { container } = renderInline('use `ls -la` here');
+    const code = container.querySelector('code');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe('ls -la');
+    expect(container.textContent).toBe('use ls -la here');
+  });
+
+  it('renders **bold** as <strong> with the asterisks stripped (the 30/05 fix)', () => {
+    const { container } = renderInline('a **modèle universel** here');
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong?.textContent).toBe('modèle universel');
+    // The literal asterisks must NOT leak to the learner.
+    expect(container.textContent).toBe('a modèle universel here');
+    expect(container.textContent).not.toContain('**');
+  });
+
+  it('renders both bold and code in the same string', () => {
+    const { container } = renderInline('**Les options** comme `-l` ou `-a`');
+    expect(container.querySelectorAll('strong')).toHaveLength(1);
+    expect(container.querySelectorAll('code')).toHaveLength(2);
+    expect(container.textContent).not.toContain('**');
+  });
+
+  it('handles multiple separate bold spans without merging them', () => {
+    const { container } = renderInline('**un** et **deux**');
+    expect(container.querySelectorAll('strong')).toHaveLength(2);
+    expect(container.textContent).toBe('un et deux');
+  });
+
+  it('leaves a lone asterisk untouched (no false bold)', () => {
+    const { container } = renderInline('2 * 3 = 6');
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.textContent).toBe('2 * 3 = 6');
+  });
+
+  it('leaves plain text without markup', () => {
+    const { container } = renderInline('juste du texte normal');
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.querySelector('code')).toBeNull();
+    expect(container.textContent).toBe('juste du texte normal');
+  });
+});


### PR DESCRIPTION
## Problème
`LessonPage` `renderText` ne parsait que les backticks `` `code` `` — le **gras** markdown (`**…**`) écrit dans **~22 leçons** (dont `navigation/orientation`) s'affichait en **astérisques littérales** aux apprenants, en prod, depuis toujours. Découvert lors de la validation visuelle Voie A de la leçon `command-anatomy` (30/05).

## Fix
Extraction de la logique de rendu inline dans un helper **testable** `src/lib/renderInlineMarkdown.tsx` qui gère désormais **deux** patterns :
- `` `code` `` → `<code>` (styling **identique** à l'existant — classes relocalisées mot pour mot)
- `**bold**` → `<strong>` (token CSS `--github-text-primary`)

`LessonPage` délègue à ce helper (1 ligne). **Inline-only par design** (listes/titres/liens passent par les `ContentBlock` dédiés tip/info/warning/code). Un `*` isolé ou un backtick non apparié rend verbatim (jamais avalé). Le fix corrige les **22 leçons d'un coup** (respecte l'intention des auteurs) plutôt que de stripper le gras.

## Gates
- ✅ **6 tests unitaires** dédiés (`renderInlineMarkdown.test.tsx`) : code, gras, mixte, gras multiples, `*` isolé, texte brut.
- ✅ `ui-auditor` **SHIP** (0 CRITICAL ; 3 WARNINGS tous relocalisés/cohérents — aucune nouvelle dette hex ; `<strong>` = token CSS).
- ✅ **1840 tests PASS**, type-check + lint clean.

## Validation
- [ ] CI verte
- [ ] Sourcery
- [ ] Voie A : `/app/learn/navigation/orientation` (leçon avec `**`) rend le gras correctement + `command-anatomy` toujours propre, 0 erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rendre le markdown gras en ligne dans le contenu des leçons et partager le rendu du markdown en ligne entre LessonPage et les tests.

New Features:
- Introduire un helper réutilisable `renderInlineMarkdown` pour rendre le code en ligne et le markdown gras dans le contenu des leçons.

Bug Fixes:
- Corriger l’affichage du contenu des leçons qui montrait les caractères `**` littéraux au lieu du texte en gras, en analysant les segments `**bold**` en éléments `<strong>`.

Tests:
- Ajouter des tests unitaires couvrant le rendu du markdown en ligne pour le code, le gras, le contenu mixte, plusieurs segments en gras, les astérisques isolés et le texte simple.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render inline bold markdown in lesson content and share inline markdown rendering between LessonPage and tests.

New Features:
- Introduce a reusable renderInlineMarkdown helper to render inline code and bold markdown in lesson content.

Bug Fixes:
- Fix lesson content displaying literal ** instead of bold text by parsing **bold** spans into <strong> elements.

Tests:
- Add unit tests covering inline markdown rendering for code, bold, mixed content, multiple bold spans, stray asterisks, and plain text.

</details>