### PR TITLE
test(catalogue): variant⊆compatibility + syntax/examples invariants

### DIFF
--- a/src/test/commandCatalogue.test.ts
+++ b/src/test/commandCatalogue.test.ts
@@ -174,5 +174,33 @@ describe('commandCatalogue', () => {
         }
       }
     });
+
+    it('every variant environment must be within the command compatibility (no orphan variant)', () => {
+      // A variant for an environment the command is not compatible with would
+      // render a command line for an OS where the command is flagged unavailable.
+      for (const cat of commandCatalogue) {
+        for (const cmd of cat.commands) {
+          for (const variant of cmd.variants) {
+            // `wsl` variants are an allowed refinement of `linux` compatibility.
+            const covered =
+              cmd.compatibility.includes(variant.environment) ||
+              (variant.environment === 'wsl' && cmd.compatibility.includes('linux'));
+            expect(
+              covered,
+              `"${cmd.id}" has a "${variant.environment}" variant but compatibility is [${cmd.compatibility.join(', ')}]`,
+            ).toBe(true);
+          }
+        }
+      }
+    });
+
+    it('every command should have a non-empty syntax and at least one example', () => {
+      for (const cat of commandCatalogue) {
+        for (const cmd of cat.commands) {
+          expect(cmd.syntax.length, `"${cmd.id}" has empty syntax`).toBeGreaterThan(0);
+          expect(cmd.examples.length, `"${cmd.id}" has no example`).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
   });
 });

--- a/src/test/commandCatalogue.test.ts
+++ b/src/test/commandCatalogue.test.ts
@@ -197,7 +197,7 @@ describe('commandCatalogue', () => {
     it('every command should have a non-empty syntax and at least one example', () => {
       for (const cat of commandCatalogue) {
         for (const cmd of cat.commands) {
-          expect(cmd.syntax.length, `"${cmd.id}" has empty syntax`).toBeGreaterThan(0);
+          expect(cmd.syntax.trim().length, `"${cmd.id}" has empty/whitespace-only syntax`).toBeGreaterThan(0);
           expect(cmd.examples.length, `"${cmd.id}" has no example`).toBeGreaterThanOrEqual(1);
         }
       }


### PR DESCRIPTION
Tightens `commandCatalogue.test.ts` coverage after the 38→59 unification (PR #333).

Two new structural invariants (iterate over all 59 commands):
- **variant ⊆ compatibility** — a `variant.environment` must be within the command's `compatibility[]` (an orphan variant would render a command line for an OS flagged unavailable on the page). `wsl` variant allowed as a refinement of `linux`.
- **non-empty syntax + ≥1 example** — every command must have a syntax string and at least one example (both rendered on `/app/reference`).

Data is already clean (26/26 pass) — these lock it against future drift. Test-only, no runtime/UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Renforcer les tests du catalogue de commandes avec des invariants structurels supplémentaires sur les variantes et les métadonnées des commandes.

Tests :
- Ajouter un test garantissant que chaque environnement de variante de commande est couvert par la liste de compatibilité de la commande, en autorisant `wsl` comme raffinement de `linux`.
- Ajouter un test vérifiant que chaque commande définit une chaîne de syntaxe non vide et au moins un exemple.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten command catalogue tests with additional structural invariants on variants and command metadata.

Tests:
- Add test ensuring each command variant environment is covered by the command's compatibility list, allowing wsl as a refinement of linux.
- Add test asserting every command defines a non-empty syntax string and at least one example.

</details>