### PR TITLE
feat(reference): add git + github-collaboration categories (59→75 commands)

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
               "name": "Combien de commandes et de leçons sont disponibles ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Terminal Learning propose 66 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev. Plus de 59 commandes documentées avec syntaxe, exemples, erreurs courantes et variantes Linux/macOS/Windows."
+                "text": "Terminal Learning propose 66 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev. Plus de 75 commandes documentées avec syntaxe, exemples, erreurs courantes et variantes Linux/macOS/Windows."
               }
             },
             {

--- a/src/app/data/commandCatalogue.ts
+++ b/src/app/data/commandCatalogue.ts
@@ -1176,6 +1176,153 @@ const baseCatalogue: CategoryMeta[] = [
       },
     ],
   },
+
+  // ─── LEVEL 4 — GIT & COLLABORATION ────────────────────────
+  // Git is identical across Linux/macOS/Windows → no per-OS variants.
+
+  {
+    id: 'git',
+    label: 'Git Fondamentaux',
+    level: 4,
+    prerequisites: ['variables'],
+    unlocks: ['github-collaboration'],
+    exerciseIdeas: [
+      'Initialiser un dépôt et faire un premier commit',
+      'Configurer son identité Git',
+      'Consulter le statut et l\'historique',
+      'Créer une branche et la fusionner',
+    ],
+    commands: [
+      {
+        id: 'git_init', name: 'git init', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git init [chemin]', summary: 'Initialiser un nouveau dépôt Git',
+        examples: ['git init', 'git init mon-projet'],
+        commonErrors: ['Lancer git init dans le mauvais dossier (vérifier avec pwd)'],
+      },
+      {
+        id: 'git_config', name: 'git config', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git config [--global] clé valeur', summary: 'Configurer Git (identité, préférences)',
+        examples: ['git config --global user.name "Alice"', 'git config --global user.email "alice@example.com"'],
+        commonErrors: ['Oublier --global → config limitée au dépôt courant'],
+      },
+      {
+        id: 'git_add', name: 'git add', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git add <fichiers>', summary: 'Indexer des modifications pour le prochain commit',
+        examples: ['git add fichier.txt', 'git add .'],
+        commonErrors: ['git add . indexe TOUT — vérifier git status avant'],
+      },
+      {
+        id: 'git_commit', name: 'git commit', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git commit -m "message"', summary: 'Enregistrer un instantané des fichiers indexés',
+        examples: ['git commit -m "feat: ajoute la page contact"', 'git commit -am "fix: corrige le bug"'],
+        commonErrors: ['Commit sans git add préalable → rien n\'est enregistré', 'Message vide ou non descriptif'],
+      },
+      {
+        id: 'git_status', name: 'git status', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git status', summary: 'Afficher l\'état du dépôt (fichiers modifiés, indexés)',
+        examples: ['git status', 'git status -s'],
+        commonErrors: [],
+      },
+      {
+        id: 'git_log', name: 'git log', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git log [options]', summary: 'Afficher l\'historique des commits',
+        examples: ['git log', 'git log --oneline', 'git log --graph --oneline --all'],
+        commonErrors: ['Sortie longue : taper q pour quitter le pager'],
+      },
+      {
+        id: 'git_diff', name: 'git diff', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git diff [options]', summary: 'Comparer les modifications (working dir, index, commits)',
+        examples: ['git diff', 'git diff --staged', 'git diff main feature'],
+        commonErrors: ['git diff seul ne montre PAS les fichiers déjà indexés (utiliser --staged)'],
+      },
+      {
+        id: 'gitignore', name: '.gitignore', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: '.gitignore (fichier de motifs)', summary: 'Exclure des fichiers du suivi Git',
+        examples: ['node_modules/', '*.log', '.env'],
+        commonErrors: ['.gitignore n\'affecte PAS les fichiers déjà suivis (git rm --cached d\'abord)'],
+      },
+      {
+        id: 'git_branch', name: 'git branch', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git branch [nom]', summary: 'Lister, créer ou supprimer des branches',
+        examples: ['git branch', 'git branch feature/login', 'git switch -c feature/login'],
+        commonErrors: ['git branch crée la branche mais ne bascule pas dessus (git switch / checkout)'],
+      },
+      {
+        id: 'git_merge', name: 'git merge', category: 'git', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git merge <branche>', summary: 'Fusionner une branche dans la branche courante',
+        examples: ['git merge feature/login', 'git merge --no-ff feature/login'],
+        commonErrors: ['Conflits de merge : résoudre, git add, puis git commit'],
+      },
+    ],
+  },
+
+  {
+    id: 'github-collaboration',
+    label: 'GitHub & Collaboration',
+    level: 4,
+    prerequisites: ['git', 'reseau'],
+    unlocks: [],
+    exerciseIdeas: [
+      'Lier un dépôt local à GitHub',
+      'Pousser et récupérer des modifications',
+      'Cloner un dépôt existant',
+      'Rebaser une branche sur main',
+    ],
+    commands: [
+      {
+        id: 'git_remote', name: 'git remote', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git remote [add <nom> <url>]', summary: 'Gérer les dépôts distants (remotes)',
+        examples: ['git remote -v', 'git remote add origin https://github.com/user/repo.git'],
+        commonErrors: ['Confondre le nom du remote (origin) et le nom de la branche (main)'],
+      },
+      {
+        id: 'git_push', name: 'git push', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git push [remote] [branche]', summary: 'Envoyer les commits locaux vers le dépôt distant',
+        examples: ['git push', 'git push -u origin main'],
+        commonErrors: ['Premier push : utiliser -u pour lier la branche locale au remote'],
+      },
+      {
+        id: 'git_pull', name: 'git pull', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git pull [remote] [branche]', summary: 'Récupérer ET fusionner les modifications distantes',
+        examples: ['git pull', 'git pull origin main'],
+        commonErrors: ['git pull = git fetch + git merge — peut créer des conflits'],
+      },
+      {
+        id: 'git_fetch', name: 'git fetch', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git fetch [remote]', summary: 'Récupérer les modifications distantes SANS les fusionner',
+        examples: ['git fetch', 'git fetch origin'],
+        commonErrors: ['Contrairement à pull, fetch ne modifie pas votre branche de travail'],
+      },
+      {
+        id: 'git_clone', name: 'git clone', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git clone <url> [dossier]', summary: 'Cloner un dépôt distant en local',
+        examples: ['git clone https://github.com/user/repo.git', 'git clone git@github.com:user/repo.git'],
+        commonErrors: ['HTTPS vs SSH : le clone SSH nécessite une clé configurée'],
+      },
+      {
+        id: 'git_rebase', name: 'git rebase', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git rebase <branche>', summary: 'Réappliquer des commits sur une autre base (historique linéaire)',
+        examples: ['git rebase main', 'git rebase -i HEAD~3'],
+        commonErrors: ['Ne jamais rebaser une branche déjà partagée/poussée publiquement'],
+      },
+    ],
+  },
 ];
 
 /**
@@ -1206,6 +1353,7 @@ const PS = 'https://learn.microsoft.com/en-us/powershell/module/';
 const BASH = 'https://www.gnu.org/software/bash/manual/bash.html';
 const DEB = 'https://manpages.debian.org/';
 const OBSD = 'https://man.openbsd.org/';
+const GIT = 'https://git-scm.com/docs/';
 
 const OFFICIAL_DOCS: Record<string, OfficialDoc[]> = {
   // navigation
@@ -1364,6 +1512,23 @@ const OFFICIAL_DOCS: Record<string, OfficialDoc[]> = {
     { label: 'OpenSSH — ssh-keygen', url: `${OBSD}ssh-keygen` },
   ],
   scp: [{ label: 'OpenSSH — scp', url: `${OBSD}scp` }],
+  // git (identique cross-OS — doc officielle unique git-scm.com)
+  git_init: [{ label: 'git-scm.com — git init (officiel)', url: `${GIT}git-init` }],
+  git_config: [{ label: 'git-scm.com — git config (officiel)', url: `${GIT}git-config` }],
+  git_add: [{ label: 'git-scm.com — git add (officiel)', url: `${GIT}git-add` }],
+  git_commit: [{ label: 'git-scm.com — git commit (officiel)', url: `${GIT}git-commit` }],
+  git_status: [{ label: 'git-scm.com — git status (officiel)', url: `${GIT}git-status` }],
+  git_log: [{ label: 'git-scm.com — git log (officiel)', url: `${GIT}git-log` }],
+  git_diff: [{ label: 'git-scm.com — git diff (officiel)', url: `${GIT}git-diff` }],
+  gitignore: [{ label: 'git-scm.com — gitignore (officiel)', url: `${GIT}gitignore` }],
+  git_branch: [{ label: 'git-scm.com — git branch (officiel)', url: `${GIT}git-branch` }],
+  git_merge: [{ label: 'git-scm.com — git merge (officiel)', url: `${GIT}git-merge` }],
+  git_remote: [{ label: 'git-scm.com — git remote (officiel)', url: `${GIT}git-remote` }],
+  git_push: [{ label: 'git-scm.com — git push (officiel)', url: `${GIT}git-push` }],
+  git_pull: [{ label: 'git-scm.com — git pull (officiel)', url: `${GIT}git-pull` }],
+  git_fetch: [{ label: 'git-scm.com — git fetch (officiel)', url: `${GIT}git-fetch` }],
+  git_clone: [{ label: 'git-scm.com — git clone (officiel)', url: `${GIT}git-clone` }],
+  git_rebase: [{ label: 'git-scm.com — git rebase (officiel)', url: `${GIT}git-rebase` }],
 };
 
 /**

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -15,7 +15,7 @@ import type { SelectedEnvironment } from '../context/EnvironmentContext';
 // `src/test/landingTotals.test.ts` re-imports both and fails if these
 // constants get out of sync with the actual catalogue/curriculum.
 export const TOTAL_LESSONS = 66;
-export const TOTAL_COMMANDS = 59;
+export const TOTAL_COMMANDS = 75;
 /** Count of environments with `status: 'active'` in `types/curriculum.ts`. */
 export const ACTIVE_ENVIRONMENTS_COUNT = 3;
 

--- a/src/test/commandCatalogue.test.ts
+++ b/src/test/commandCatalogue.test.ts
@@ -216,6 +216,7 @@ describe('commandCatalogue', () => {
       'manpages.debian.org',
       'learn.microsoft.com',
       'docs.brew.sh',
+      'git-scm.com',
     ]);
 
     it('every official doc URL is https and points to an allow-listed official host', () => {

--- a/src/test/commandReferenceSource.test.ts
+++ b/src/test/commandReferenceSource.test.ts
@@ -63,8 +63,8 @@ describe('catalogue retains every historically-visible command (no regression)',
     expect(getCommandById(id), `command "${id}" disappeared from commandCatalogue`).toBeDefined();
   });
 
-  it('catalogue is a superset (>= the 59 unified commands)', () => {
+  it('catalogue is a superset (>= the 75 unified commands)', () => {
     const total = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
-    expect(total).toBeGreaterThanOrEqual(59);
+    expect(total).toBeGreaterThanOrEqual(75);
   });
 });

--- a/src/test/landingTotals.test.ts
+++ b/src/test/landingTotals.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   TOTAL_LESSONS,
   TOTAL_COMMANDS,
@@ -59,5 +61,26 @@ describe('landingContent — totals drift guard (THI-118)', () => {
   it('sum of MODULE_PREVIEWS.lessonCount equals TOTAL_LESSONS (hero = cards)', () => {
     const cardsSum = MODULE_PREVIEWS.reduce((sum, p) => sum + p.lessonCount, 0);
     expect(cardsSum).toBe(TOTAL_LESSONS);
+  });
+
+  // index.html carries hardcoded counts in the FAQ JSON-LD ("66 leçons",
+  // "Plus de 75 commandes") that are NOT generated from TOTAL_LESSONS /
+  // TOTAL_COMMANDS — they would drift silently (Sourcery PR #340). Rather than
+  // wire HTML templating into the build, this guard ties the static FAQ numbers
+  // to the canonical constants so CI fails loudly if they diverge.
+  describe('index.html FAQ counts stay in sync with constants', () => {
+    const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf-8');
+
+    it('FAQ "Plus de N commandes" matches TOTAL_COMMANDS', () => {
+      const m = html.match(/Plus de (\d+) commandes/);
+      expect(m, 'FAQ command-count sentence not found in index.html').not.toBeNull();
+      expect(Number(m![1])).toBe(TOTAL_COMMANDS);
+    });
+
+    it('FAQ "N leçons" matches TOTAL_LESSONS', () => {
+      const m = html.match(/propose (\d+) leçons/);
+      expect(m, 'FAQ lesson-count sentence not found in index.html').not.toBeNull();
+      expect(Number(m![1])).toBe(TOTAL_LESSONS);
+    });
   });
 });


### PR DESCRIPTION
PR-2 of the references chantier — completes the catalogue with the two Git curriculum modules.

## What
- **git** (level 4): init, config, add, commit, status, log, diff, .gitignore, branch, merge
- **github-collaboration** (level 4): remote, push, pull, fetch, clone, rebase
- Official sources: **git-scm.com** (every URL verified HTTP 200). Git is identical cross-OS → no per-OS variants, single canonical source per command.
- Categories mirror the curriculum modules' `level` + `prerequisites` (consistency guard `curriculumTypes.test`).
- Drift synced: `TOTAL_COMMANDS` 59→75, index.html FAQ, allow-list host `git-scm.com`, superset guard ≥75.

## Scope decision: ia-dev excluded
`ia-dev` lessons teach AI usage; their "commands" are app-specific `ai-help` pseudo-commands with **no official CLI doc**. Adding them to a command reference with official sources would violate the official-sources-only principle. Stays curriculum-only (flagged to @thierry).

## Sandbox note (follow-up)
The git sandbox (`commands/git.ts`, ~21 subcommands) is already strong, but **`git rebase` is not simulated** (newly referenced, taught in merge-strategies lesson). Tracked as a separate sandbox-depth ticket.

## Verification
- 104 tests pass (catalogue + reference + landing + consistency), type-check + lint clean.
- Gates: `content-auditor` (catalogue↔curriculum) + Voie A desktop+mobile à valider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter des catégories de commandes de collaboration Git et GitHub de niveau 4 au catalogue de commandes et mettre à jour en conséquence les totaux globaux et les références.

Nouvelles fonctionnalités :
- Introduire une catégorie « notions fondamentales de Git » avec les commandes Git locales de base documentées et liées à la documentation officielle sur git-scm.com.
- Introduire une catégorie « collaboration GitHub » couvrant les workflows avec dépôt distant et le rebase, avec des références officielles git-scm.com pour chaque commande.

Améliorations :
- Enregistrer git-scm.com en tant qu’hôte de documentation officielle autorisé (allow-listed) pour les références de commandes.
- Augmenter le nombre de commandes documentées de 59 à 75 et aligner les tests ainsi que le contenu de la page d’accueil avec le catalogue étendu.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add level-4 Git and GitHub collaboration command categories to the command catalogue and update global totals and references accordingly.

New Features:
- Introduce a Git fundamentals category with core local Git commands documented and linked to official git-scm.com docs.
- Introduce a GitHub collaboration category covering remote workflows and rebase, with official git-scm.com references for each command.

Enhancements:
- Register git-scm.com as an allow-listed official documentation host for command references.
- Increase the documented command count from 59 to 75 and align tests and landing content with the expanded catalogue.

</details>