### PR TITLE
fix(reference): SEO count drift 59→75 + git/github pill colors

### DIFF
--- a/src/app/components/CommandReference.tsx
+++ b/src/app/components/CommandReference.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Search, Terminal, ChevronDown, ChevronRight, ExternalLink, BookOpen } from 'lucide-react';
 import { useEnvironment } from '../context/EnvironmentContext';
 import { commandCatalogue } from '../data/commandCatalogue';
+import { TOTAL_COMMANDS } from '../data/landingContent';
 import type { EnrichedCommand, EnvironmentId } from '../types/curriculum';
 import { usePageSEO } from '../hooks/useLessonSEO';
 import { Button } from './ui/button';
@@ -46,6 +47,8 @@ const categoryColors: Record<string, string> = {
   'Archives & Compression': 'text-orange-400 bg-orange-500/10 border-orange-500/20',
   'Variables & Scripts': 'text-yellow-400 bg-yellow-500/10 border-yellow-500/20',
   'Réseau & SSH': 'text-sky-400 bg-sky-500/10 border-sky-500/20',
+  'Git Fondamentaux': 'text-rose-400 bg-rose-500/10 border-rose-500/20',
+  'GitHub & Collaboration': 'text-violet-400 bg-violet-500/10 border-violet-500/20',
 };
 
 // Per-OS metadata. `lit` is used when the command supports the OS, `dim` when not.
@@ -107,7 +110,7 @@ export function CommandReference() {
   usePageSEO({
     title: 'Référence des commandes — Terminal Learning',
     description:
-      'Référence complète de 59 commandes terminal : compatibilité et variantes par OS (Linux / macOS / Windows PowerShell), syntaxe, exemples et erreurs courantes. Navigation, fichiers, permissions, réseau, Git.',
+      `Référence complète de ${TOTAL_COMMANDS} commandes terminal : compatibilité et variantes par OS (Linux / macOS / Windows PowerShell), syntaxe, exemples, erreurs courantes et sources officielles. Navigation, fichiers, permissions, réseau, Git/GitHub.`,
     path: '/app/reference',
   });
 

--- a/src/app/data/commandCatalogue.ts
+++ b/src/app/data/commandCatalogue.ts
@@ -1245,7 +1245,7 @@ const baseCatalogue: CategoryMeta[] = [
       {
         id: 'gitignore', name: '.gitignore', category: 'git', level: 4,
         recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
-        syntax: '.gitignore (fichier de motifs)', summary: 'Exclure des fichiers du suivi Git',
+        syntax: '# un motif par ligne dans le fichier .gitignore', summary: 'Exclure des fichiers du suivi Git',
         examples: ['node_modules/', '*.log', '.env'],
         commonErrors: ['.gitignore n\'affecte PAS les fichiers déjà suivis (git rm --cached d\'abord)'],
       },

--- a/src/test/commandReferenceSource.test.ts
+++ b/src/test/commandReferenceSource.test.ts
@@ -31,6 +31,15 @@ describe('CommandReference — single source of truth (catalogue)', () => {
     expect(componentSource).not.toMatch(/const\s+commands\s*:/);
     expect(componentSource).not.toMatch(/interface\s+CommandEntry/);
   });
+
+  it('SEO meta description uses TOTAL_COMMANDS, not a hardcoded count (no drift)', () => {
+    // PR #340 bumped 59→75 but the SEO description string lagged at "59 commandes"
+    // (caught by code-review). The description must be templated from the constant.
+    expect(componentSource).toMatch(/\$\{TOTAL_COMMANDS\}\s*commandes/);
+    expect(componentSource, 'SEO description must not hardcode a command count').not.toMatch(
+      /de \d+ commandes terminal/,
+    );
+  });
 });
 
 describe('catalogue retains every historically-visible command (no regression)', () => {

--- a/src/test/commandReferenceSource.test.ts
+++ b/src/test/commandReferenceSource.test.ts
@@ -37,7 +37,7 @@ describe('CommandReference — single source of truth (catalogue)', () => {
     // (caught by code-review). The description must be templated from the constant.
     expect(componentSource).toMatch(/\$\{TOTAL_COMMANDS\}\s*commandes/);
     expect(componentSource, 'SEO description must not hardcode a command count').not.toMatch(
-      /de \d+ commandes terminal/,
+      /\b\d+\s+commandes\b/,
     );
   });
 });


### PR DESCRIPTION
Closes the gaps surfaced by the post-merge **code-review** + **content-auditor** gates on the references work.

## Fixes
- 🔴 **SEO description drift** (code-review, conf. 95): `/app/reference` meta/OG description said "59 commandes" while the catalogue is 75. Now `${TOTAL_COMMANDS}` — templated, can't drift. **Guard test** rejects re-hardcoding a count literal.
- 🟡 **git/github pill colors**: the two new categories fell back to gray (no `categoryColors` entry). Added rose (Git) + violet (GitHub) Tailwind tokens — no hardcoded hex.
- 🟡 **content-auditor W5**: clarified the `.gitignore` `syntax` field (was "`.gitignore (fichier de motifs)`", now "`# un motif par ligne dans le fichier .gitignore`").

## Audit results (for the record)
- **content-auditor**: 0 CRITICAL. Catalogue↔curriculum consistency exact, all 16 git URLs HTTP 200 (WebFetch-confirmed), ia-dev exclusion validated. 5 minor warnings (W1/W2 commonErrors enrichment + W3 dedicated rebase lesson → THI-305 scope).
- **code-review**: 0 CRITICAL, 1 important (this SEO fix). Merge logic / types / perf / id-uniqueness all clean.

## Verification
89 tests pass, type-check + lint clean. Voie A desktop+mobile à confirmer (pill colors + no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Veiller à ce que les métadonnées SEO et le contenu de la page de référence des commandes restent cohérents avec le catalogue de commandes dynamique et les nouvelles catégories liées à Git.

Corrections de bugs :
- Faire en sorte que la meta description SEO de la référence de commandes récupère le nombre de commandes à partir de `TOTAL_COMMANDS` au lieu d’une valeur codée en dur afin d’éviter tout décalage à l’avenir.
- Clarifier la description de la syntaxe de la commande `.gitignore` pour mieux expliquer le format basé sur des modèles (patterns).

Améliorations :
- Assigner des jetons de couleur Tailwind spécifiques aux nouvelles pastilles de catégories « Git Fondamentaux » et « GitHub & Collaboration » pour correspondre au style des catégories existantes.

Tests :
- Ajouter un test de régression pour s’assurer que la meta description SEO utilise `TOTAL_COMMANDS` et ne réintroduit pas un nombre de commandes codé en dur.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the command reference page SEO metadata and content remain consistent with the dynamic command catalogue and new Git-related categories.

Bug Fixes:
- Make the command reference SEO meta description derive the command count from TOTAL_COMMANDS instead of a hardcoded value to prevent future drift.
- Clarify the .gitignore command syntax description to better explain the pattern-based format.

Enhancements:
- Assign specific Tailwind color tokens to the new Git Fondamentaux and GitHub & Collaboration category pills to match existing category styling.

Tests:
- Add a regression test to ensure the SEO meta description uses TOTAL_COMMANDS and does not reintroduce a hardcoded command count.

</details>