### PR TITLE
docs: codify code-review pre-merge gate + changelog #342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ La page `/app/reference` couvrait les 8 catégories shell mais **pas les deux mo
 - Compteurs synchronisés : `TOTAL_COMMANDS` 59→75, FAQ JSON-LD `index.html`, allow-list test (host `git-scm.com`), garde-fou superset ≥75. **Nouveau garde-fou anti-drift** : un test asserte que les compteurs FAQ de `index.html` == `TOTAL_COMMANDS`/`TOTAL_LESSONS` (suite review Sourcery — fini le drift silencieux du HTML).
 - **Voie A desktop + mobile** : 2 catégories rendues (Niv. 4), lien `git init` → git-scm correct + aria-label, **0px overflow à 390px**. CI + 104 tests verts.
 - **Suivi sandbox THI-305 (High)** : le terminal simule déjà ~21 sous-commandes git, mais `git rebase` manque et la profondeur (merge commits, conflits réels) est à auditer pour que **chaque leçon git ait un exercice exécutable**.
-- **Gates de rattrapage post-merge (PR #342)** : passes `content-auditor` (0 CRITICAL) + `feature-dev:code-reviewer` lancées à la demande — le code-review a attrapé un **drift SEO** (meta description `/app/reference` figée à 59) corrigé en `${TOTAL_COMMANDS}` + garde-fou test, plus couleurs de pills git/github (rose/violet). Leçon codifiée : `feature-dev:code-reviewer` devient un gate pré-merge pour les PRs de code (THI-306 pour le sweep full-codebase).
+- **Gates de rattrapage post-merge (PR #342)** : passes `content-auditor` (0 CRITICAL) + `feature-dev:code-reviewer` lancées à la demande — la review de code a attrapé un **drift SEO** (meta description `/app/reference` figée à 59) corrigé en `${TOTAL_COMMANDS}` + garde-fou test, plus couleurs de pills git/github (rose/violet). Leçon codifiée : `feature-dev:code-reviewer` devient un gate pré-merge pour les PRs de code (THI-306 pour le sweep full-codebase).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ La page `/app/reference` couvrait les 8 catégories shell mais **pas les deux mo
 - Compteurs synchronisés : `TOTAL_COMMANDS` 59→75, FAQ JSON-LD `index.html`, allow-list test (host `git-scm.com`), garde-fou superset ≥75. **Nouveau garde-fou anti-drift** : un test asserte que les compteurs FAQ de `index.html` == `TOTAL_COMMANDS`/`TOTAL_LESSONS` (suite review Sourcery — fini le drift silencieux du HTML).
 - **Voie A desktop + mobile** : 2 catégories rendues (Niv. 4), lien `git init` → git-scm correct + aria-label, **0px overflow à 390px**. CI + 104 tests verts.
 - **Suivi sandbox THI-305 (High)** : le terminal simule déjà ~21 sous-commandes git, mais `git rebase` manque et la profondeur (merge commits, conflits réels) est à auditer pour que **chaque leçon git ait un exercice exécutable**.
+- **Gates de rattrapage post-merge (PR #342)** : passes `content-auditor` (0 CRITICAL) + `feature-dev:code-reviewer` lancées à la demande — le code-review a attrapé un **drift SEO** (meta description `/app/reference` figée à 59) corrigé en `${TOTAL_COMMANDS}` + garde-fou test, plus couleurs de pills git/github (rose/violet). Leçon codifiée : `feature-dev:code-reviewer` devient un gate pré-merge pour les PRs de code (THI-306 pour le sweep full-codebase).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,12 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Issue In Progress + PR ouverte → **In Review**
 - Issue In Review + PR mergée → **Done**
 
+### Avant toute PR de code (`src/`, `api/`, `supabase/`) — gate code-review (codifié 31/05/2026)
+- Invoquer l'agent **`feature-dev:code-reviewer`** sur le diff → corriger les findings CRITICAL/IMPORTANT avant merge.
+- **En plus** de Sourcery (review automatique CI), pas à la place : ils sont complémentaires. *Incident #340 (31/05)* : Sourcery + mes vérifs manuelles ont laissé passer un drift SEO (compteur `/app/reference` figé 59→75) que `feature-dev:code-reviewer` a attrapé en post-merge (fix #342). Le code-review confidence-based attrape la correctness/maintainability que Sourcery ne flague pas toujours.
+- Ne remplace PAS les gates spécialisés ci-dessous (ui-auditor / prompt-guardrail / security-auditor / route-attack) — c'est une passe correctness générale qui s'ajoute.
+- Sweep full-codebase périodique des zones jamais review-agent : tracké **THI-306**.
+
 ### Avant toute PR touchant des composants UI
 - Invoquer l'agent **`ui-auditor`** → analyser le rapport, corriger les CRITICAL avant de proposer la PR
 - Tout CRITICAL dans le rapport bloque le merge — pas d'exception

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ App pédagogique pour apprendre le terminal. Bénévole, open source, 100% gratu
 - Invoquer l'agent **`feature-dev:code-reviewer`** sur le diff → corriger les findings CRITICAL/IMPORTANT avant merge.
 - **En plus** de Sourcery (review automatique CI), pas à la place : ils sont complémentaires. *Incident #340 (31/05)* : Sourcery + mes vérifs manuelles ont laissé passer un drift SEO (compteur `/app/reference` figé 59→75) que `feature-dev:code-reviewer` a attrapé en post-merge (fix #342). Le code-review confidence-based attrape la correctness/maintainability que Sourcery ne flague pas toujours.
 - Ne remplace PAS les gates spécialisés ci-dessous (ui-auditor / prompt-guardrail / security-auditor / route-attack) — c'est une passe correctness générale qui s'ajoute.
-- Sweep full-codebase périodique des zones jamais review-agent : tracké **THI-306**.
+- Sweep full-codebase périodique des zones jamais couvertes par un review-agent : tracké **THI-306**.
 
 ### Avant toute PR touchant des composants UI
 - Invoquer l'agent **`ui-auditor`** → analyser le rapport, corriger les CRITICAL avant de proposer la PR


### PR DESCRIPTION
Voie C — docs-only (CLAUDE.md + CHANGELOG), 0 runtime. Codifies feature-dev:code-reviewer as a pre-merge gate for code PRs (THI-306 = full-codebase sweep) + folds the #342 SEO-drift fix into the PR #5 changelog entry. Smoke test à confirmer.

## Résumé par Sourcery

Formaliser l’utilisation de l’agent feature-dev:code-reviewer comme étape de validation pré-fusion obligatoire pour les changements de code et documenter, dans le changelog, la correction post-fusion de la dérive SEO.

Documentation :
- Documenter une étape de validation pré-fusion (pre-merge gate) de revue de code imposant l’utilisation de l’agent feature-dev:code-reviewer pour les pull requests liées au code.
- Mettre à jour le changelog pour consigner la correction post-fusion de la dérive SEO ainsi que la décision de promouvoir feature-dev:code-reviewer au rang d’étape de validation pré-fusion.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Codify the use of the feature-dev:code-reviewer agent as a mandatory pre-merge gate for code changes and document the post-merge SEO drift fix in the changelog.

Documentation:
- Document a pre-merge code-review gate requiring the feature-dev:code-reviewer agent for code-related pull requests.
- Update the changelog to record the post-merge SEO drift fix and the decision to promote feature-dev:code-reviewer to a pre-merge gate.

</details>