### PR TITLE
feat(sandbox): git rebase + cherry-pick runnable (THI-305 PR-3a)

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
               "name": "Combien de commandes et de leçons sont disponibles ?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Terminal Learning propose 66 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev. Plus de 75 commandes documentées avec syntaxe, exemples, erreurs courantes et variantes Linux/macOS/Windows."
+                "text": "Terminal Learning propose 66 leçons réparties en 11 modules progressifs : navigation, fichiers, lecture, permissions, processus, redirection, variables, réseau/SSH, Git, GitHub et l'IA comme outil dev. Plus de 76 commandes documentées avec syntaxe, exemples, erreurs courantes et variantes Linux/macOS/Windows."
               }
             },
             {

--- a/src/app/data/commandCatalogue.ts
+++ b/src/app/data/commandCatalogue.ts
@@ -1321,6 +1321,13 @@ const baseCatalogue: CategoryMeta[] = [
         examples: ['git rebase main', 'git rebase -i HEAD~3'],
         commonErrors: ['Ne jamais rebaser une branche déjà partagée/poussée publiquement'],
       },
+      {
+        id: 'git_cherry_pick', name: 'git cherry-pick', category: 'github-collaboration', level: 4,
+        recommendedFor: ['linux', 'macos', 'windows'], variants: [], compatibility: ['linux', 'macos', 'windows'],
+        syntax: 'git cherry-pick <commit>', summary: 'Ré-appliquer un commit précis sur la branche courante',
+        examples: ['git cherry-pick a1b2c3d', 'git cherry-pick a1b2c3d..e4f5g6h'],
+        commonErrors: ['Récupérer le hash via git log --oneline', 'Peut créer un conflit si le commit touche des lignes déjà modifiées'],
+      },
     ],
   },
 ];
@@ -1529,6 +1536,7 @@ const OFFICIAL_DOCS: Record<string, OfficialDoc[]> = {
   git_fetch: [{ label: 'git-scm.com — git fetch (officiel)', url: `${GIT}git-fetch` }],
   git_clone: [{ label: 'git-scm.com — git clone (officiel)', url: `${GIT}git-clone` }],
   git_rebase: [{ label: 'git-scm.com — git rebase (officiel)', url: `${GIT}git-rebase` }],
+  git_cherry_pick: [{ label: 'git-scm.com — git cherry-pick (officiel)', url: `${GIT}git-cherry-pick` }],
 };
 
 /**

--- a/src/app/data/commands/git.ts
+++ b/src/app/data/commands/git.ts
@@ -529,6 +529,70 @@ export function handleGit(newState: TerminalState, args: string[], _env: Termina
       return { lines: [{ text: `git config ${key || '--list'}`, type: 'info' }], newState };
     }
 
+    // ── git cherry-pick ─────────────────────────────────────────────────────────
+    case 'cherry-pick': {
+      const repoErr = requireRepo();
+      if (repoErr) return { lines: [repoErr], newState };
+      const g = newState.git!;
+      const ref = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+      if (!ref) {
+        return { lines: [{ text: "Usage: git cherry-pick <commit>\nHint: récupère le hash via 'git log --oneline'.", type: 'error' }], newState };
+      }
+      if (g.commits.length === 0) {
+        return { lines: [{ text: 'fatal: your current branch does not have any commits yet.', type: 'error' }], newState };
+      }
+      const picked = g.commits.find((c) => c.hash.startsWith(ref));
+      if (!picked) {
+        return { lines: [{ text: `fatal: bad revision '${ref}'`, type: 'error' }], newState };
+      }
+      const hash = makeHash();
+      const commit: GitCommit = { hash, message: picked.message, author: newState.user, date: new Date().toISOString().slice(0, 10) };
+      newState = { ...newState, git: { ...g, commits: [commit, ...g.commits] } };
+      return {
+        lines: [
+          { text: `[${g.branch} ${hash}] ${picked.message}`, type: 'success' },
+          { text: ` (cherry-pické depuis ${picked.hash} — le commit est ré-appliqué sur ${g.branch})`, type: 'info' },
+        ],
+        newState,
+      };
+    }
+
+    // ── git rebase ────────────────────────────────────────────────────────────
+    case 'rebase': {
+      const repoErr = requireRepo();
+      if (repoErr) return { lines: [repoErr], newState };
+      const g = newState.git!;
+      const interactive = args.includes('-i') || args.includes('--interactive');
+      if (interactive) {
+        return {
+          lines: [
+            { text: 'Rebase interactif (simulé) — réécriture de l\'historique.', type: 'info' },
+            { text: 'En réel : un éditeur s\'ouvre avec pick/reword/squash/drop pour chaque commit.', type: 'output' },
+            { text: '⚠️  Ne JAMAIS réécrire un historique déjà poussé sur une branche partagée.', type: 'error' },
+          ],
+          newState,
+        };
+      }
+      const target = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
+      if (!target) {
+        return { lines: [{ text: 'Usage: git rebase <branche-de-base> | git rebase -i HEAD~N', type: 'error' }], newState };
+      }
+      if (!g.branches.includes(target)) {
+        return { lines: [{ text: `fatal: invalid upstream '${target}'`, type: 'error' }], newState };
+      }
+      if (target === g.branch) {
+        return { lines: [{ text: `Current branch ${g.branch} is up to date.`, type: 'info' }], newState };
+      }
+      return {
+        lines: [
+          { text: `Successfully rebased and updated refs/heads/${g.branch}.`, type: 'success' },
+          { text: `Les commits de ${g.branch} sont rejoués au-dessus de ${target} (historique linéaire, pas de merge commit).`, type: 'info' },
+          { text: '⚠️  Rebaser réécrit les hashes — à éviter sur une branche déjà partagée.', type: 'output' },
+        ],
+        newState,
+      };
+    }
+
     // ── git --version / --help ────────────────────────────────────────────────
     case '--version':
       return { lines: [{ text: 'git version 2.45.0 (simulated)', type: 'output' }], newState };
@@ -551,6 +615,8 @@ export function handleGit(newState: TerminalState, args: string[], _env: Termina
           { text: '  checkout  Changer de branche ou restaurer des fichiers', type: 'output' },
           { text: '  switch    Changer de branche (commande moderne)', type: 'output' },
           { text: '  merge     Fusionner une branche dans la branche active', type: 'output' },
+          { text: '  rebase    Rejouer des commits sur une autre base (historique linéaire)', type: 'output' },
+          { text: '  cherry-pick  Ré-appliquer un commit précis sur la branche courante', type: 'output' },
           { text: '  remote    Gérer les dépôts distants', type: 'output' },
           { text: '  push      Envoyer les commits vers le dépôt distant', type: 'output' },
           { text: '  pull      Récupérer et intégrer les commits distants', type: 'output' },

--- a/src/app/data/commands/git.ts
+++ b/src/app/data/commands/git.ts
@@ -534,12 +534,13 @@ export function handleGit(newState: TerminalState, args: string[], _env: Termina
       const repoErr = requireRepo();
       if (repoErr) return { lines: [repoErr], newState };
       const g = newState.git!;
+      // No commits → no ref can ever be valid; give the contextual error first (like git log/tag).
+      if (g.commits.length === 0) {
+        return { lines: [{ text: 'fatal: your current branch does not have any commits yet.', type: 'error' }], newState };
+      }
       const ref = args.find((a) => !a.startsWith('-') && a !== sub) ?? '';
       if (!ref) {
         return { lines: [{ text: "Usage: git cherry-pick <commit>\nHint: récupère le hash via 'git log --oneline'.", type: 'error' }], newState };
-      }
-      if (g.commits.length === 0) {
-        return { lines: [{ text: 'fatal: your current branch does not have any commits yet.', type: 'error' }], newState };
       }
       const picked = g.commits.find((c) => c.hash.startsWith(ref));
       if (!picked) {

--- a/src/app/data/landingContent.ts
+++ b/src/app/data/landingContent.ts
@@ -15,7 +15,7 @@ import type { SelectedEnvironment } from '../context/EnvironmentContext';
 // `src/test/landingTotals.test.ts` re-imports both and fails if these
 // constants get out of sync with the actual catalogue/curriculum.
 export const TOTAL_LESSONS = 66;
-export const TOTAL_COMMANDS = 75;
+export const TOTAL_COMMANDS = 76;
 /** Count of environments with `status: 'active'` in `types/curriculum.ts`. */
 export const ACTIVE_ENVIRONMENTS_COUNT = 3;
 

--- a/src/test/commandReferenceSource.test.ts
+++ b/src/test/commandReferenceSource.test.ts
@@ -72,8 +72,8 @@ describe('catalogue retains every historically-visible command (no regression)',
     expect(getCommandById(id), `command "${id}" disappeared from commandCatalogue`).toBeDefined();
   });
 
-  it('catalogue is a superset (>= the 75 unified commands)', () => {
+  it('catalogue is a superset (>= the 76 unified commands)', () => {
     const total = commandCatalogue.reduce((sum, cat) => sum + cat.commands.length, 0);
-    expect(total).toBeGreaterThanOrEqual(75);
+    expect(total).toBeGreaterThanOrEqual(76);
   });
 });

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -2099,10 +2099,18 @@ describe('git', () => {
   });
 
   // ── git cherry-pick (THI-305) ─────────────────────────────────────────────────
-  it('git cherry-pick without a ref returns usage', () => {
-    const s = processCommand(makeState(), 'git init').newState;
+  it('git cherry-pick without a ref returns usage (repo has commits)', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add mon-fichier.txt').newState;
+    s = processCommand(s, 'git commit -m "base"').newState;
     const r = processCommand(s, 'git cherry-pick');
     expect(r.lines[0].text).toContain('Usage: git cherry-pick');
+  });
+
+  it('git cherry-pick on a repo with no commits returns "no commits yet"', () => {
+    const s = processCommand(makeState(), 'git init').newState;
+    const r = processCommand(s, 'git cherry-pick');
+    expect(r.lines[0].text).toContain('does not have any commits yet');
   });
 
   it('git cherry-pick a bad revision returns fatal', () => {

--- a/src/test/terminalEngine.test.ts
+++ b/src/test/terminalEngine.test.ts
@@ -2065,6 +2065,65 @@ describe('git', () => {
     expect(r.lines.some((l) => l.text.includes('commit'))).toBe(true);
   });
 
+  // ── git rebase (THI-305) ──────────────────────────────────────────────────────
+  it('git rebase without init returns fatal error', () => {
+    const r = processCommand(makeState(), 'git rebase main');
+    expect(r.lines[0].text).toContain('not a git repository');
+  });
+
+  it('git rebase <branch> rejoue les commits (historique linéaire)', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git branch feature').newState;
+    s = processCommand(s, 'git checkout feature').newState;
+    const r = processCommand(s, 'git rebase main');
+    expect(r.lines.some((l) => l.text.includes('Successfully rebased'))).toBe(true);
+  });
+
+  it('git rebase on the same branch is up to date', () => {
+    const s = processCommand(makeState(), 'git init').newState;
+    const r = processCommand(s, 'git rebase main');
+    expect(r.lines[0].text).toContain('up to date');
+  });
+
+  it('git rebase -i shows interactive rebase guidance + shared-branch warning', () => {
+    const s = processCommand(makeState(), 'git init').newState;
+    const r = processCommand(s, 'git rebase -i HEAD~3');
+    expect(r.lines.some((l) => l.text.toLowerCase().includes('interactif'))).toBe(true);
+    expect(r.lines.some((l) => l.text.includes('partagée'))).toBe(true);
+  });
+
+  it('git rebase invalid upstream returns error', () => {
+    const s = processCommand(makeState(), 'git init').newState;
+    const r = processCommand(s, 'git rebase nope');
+    expect(r.lines[0].text).toContain('invalid upstream');
+  });
+
+  // ── git cherry-pick (THI-305) ─────────────────────────────────────────────────
+  it('git cherry-pick without a ref returns usage', () => {
+    const s = processCommand(makeState(), 'git init').newState;
+    const r = processCommand(s, 'git cherry-pick');
+    expect(r.lines[0].text).toContain('Usage: git cherry-pick');
+  });
+
+  it('git cherry-pick a bad revision returns fatal', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add mon-fichier.txt').newState;
+    s = processCommand(s, 'git commit -m "first"').newState;
+    const r = processCommand(s, 'git cherry-pick deadbee');
+    expect(r.lines[0].text).toContain("bad revision");
+  });
+
+  it('git cherry-pick <hash> re-applies the commit on the current branch', () => {
+    let s = processCommand(makeState(), 'git init').newState;
+    s = processCommand(s, 'git add mon-fichier.txt').newState;
+    s = processCommand(s, 'git commit -m "feat: base"').newState;
+    const { hash } = s.git!.commits[0];
+    const before = s.git!.commits.length;
+    const r = processCommand(s, `git cherry-pick ${hash}`);
+    expect(r.newState.git!.commits.length).toBe(before + 1);
+    expect(r.lines.some((l) => l.text.includes('cherry-pické'))).toBe(true);
+  });
+
   // ── unknown git subcommand ────────────────────────────────────────────────────
   it('unknown git subcommand returns error', () => {
     const r = processCommand(makeState(), 'git foobar');


### PR DESCRIPTION
First slice of **THI-305** (« le terminal doit être à la hauteur pour les exercices git »). Closes the "documented but not runnable" gap.

## What
- **`git rebase`** in the sandbox: `<branch>` (linear-history + shared-branch warning), `-i` (interactive guidance), invalid-upstream + same-branch-up-to-date paths.
- **`git cherry-pick <commit>`**: re-applies a commit found by hash prefix → new commit; bad-revision + usage paths. (Discovered/flagged by @thierry.)
- **Catalogue**: `git cherry-pick` added to github-collaboration + **git-scm.com** official source (HTTP 200 verified). `git rebase` was already referenced. 75 → **76** commands; drift synced (TOTAL_COMMANDS, index.html FAQ, superset guard).
- **+8 terminalEngine tests** (rebase ×5, cherry-pick ×3). 395 affected tests green, type-check + lint clean.

## Audit (THI-305 deliverable 1)
Sandbox git is strong (~21 subcommands real-state) but: `diff` is canned, `merge` has **no conflict path**, `commits[]` is **global not per-branch** → branches don't truly diverge. Deeper model (per-branch histories + real conflicts + real diff) = **THI-305 phase 2** (separate, bigger).

## Gates
- `feature-dev:code-reviewer` (newly-codified gate) + Voie A desktop+mobile (cherry-pick renders on /app/reference) — à lancer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)