### PR TITLE
feat(terminal): mobile special-character key bar (THI-307)

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -423,6 +423,8 @@ export function LessonPage() {
       <AiTutorPanel
         lang="fr"
         role={role}
+        // Raise the FAB above the terminal mobile key bar on touch (THI-307).
+        liftAboveMobileBar
         lessonContext={{
           moduleSlug: moduleId,
           lessonSlug: lessonId,

--- a/src/app/components/TerminalEmulator.tsx
+++ b/src/app/components/TerminalEmulator.tsx
@@ -261,10 +261,16 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
     const el = inputRef.current;
     const start = el?.selectionStart ?? input.length;
     const end = el?.selectionEnd ?? input.length;
-    const { value, cursor } = spliceAtSelection(input, start, end, text);
+    const { value } = spliceAtSelection(input, start, end, text);
     const sanitized = sanitiseInput(value);
     setInput(sanitized);
-    const pos = Math.min(cursor, sanitized.length);
+    // Place the caret after the *sanitised* inserted token. The chars before
+    // the insertion point are already clean (input is always sanitised), so the
+    // caret = clamped start + sanitised-token length, clamped to the final
+    // length (covers the 500-char truncation). Deriving from sanitiseInput(text)
+    // keeps the caret correct even if a control char were ever inserted.
+    const safeStart = Math.max(0, Math.min(start, input.length));
+    const pos = Math.min(safeStart + sanitiseInput(text).length, sanitized.length);
     requestAnimationFrame(() => {
       const node = inputRef.current;
       if (!node) return;

--- a/src/app/components/TerminalEmulator.tsx
+++ b/src/app/components/TerminalEmulator.tsx
@@ -122,8 +122,17 @@ function useCoarsePointer(): boolean {
     const mq = window.matchMedia('(pointer: coarse)');
     const update = () => setCoarse(mq.matches);
     update();
-    mq.addEventListener('change', update);
-    return () => mq.removeEventListener('change', update);
+    // Older iOS Safari / WebKit only expose the deprecated addListener — calling
+    // the missing addEventListener would throw, so feature-detect first.
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', update);
+      return () => mq.removeEventListener('change', update);
+    }
+    if (typeof mq.addListener === 'function') {
+      mq.addListener(update);
+      return () => mq.removeListener(update);
+    }
+    return;
   }, []);
   return coarse;
 }
@@ -261,8 +270,8 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
     const el = inputRef.current;
     const start = el?.selectionStart ?? input.length;
     const end = el?.selectionEnd ?? input.length;
-    const { value } = spliceAtSelection(input, start, end, text);
-    const sanitized = sanitiseInput(value);
+    const spliced = spliceAtSelection(input, start, end, text);
+    const sanitized = sanitiseInput(spliced);
     setInput(sanitized);
     // Place the caret after the *sanitised* inserted token. The chars before
     // the insertion point are already clean (input is always sanitised), so the

--- a/src/app/components/TerminalEmulator.tsx
+++ b/src/app/components/TerminalEmulator.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect, useCallback, useMemo, startTransition } from 'react';
 import { TerminalState, OutputLine, processCommand, displayPathForEnv, getTabCompletions, createInitialState } from '../data/terminalEngine';
 import type { SelectedEnvironment } from '../context/EnvironmentContext';
+import { spliceAtSelection } from './terminalKeyInsert';
+import { TerminalKeyBar } from './TerminalKeyBar';
 
 // ─── Security helpers ─────────────────────────────────────────────────────────
 
@@ -107,6 +109,25 @@ interface TerminalEmulatorProps {
 let lineCounter = 0;
 const nextId = () => ++lineCounter;
 
+/**
+ * Reactive coarse-pointer detection (THI-307). True on touch devices (phones,
+ * tablets) where the mobile key bar is useful; false on desktop so it never
+ * pollutes the pointer/keyboard experience. Starts `false` and flips after
+ * mount — the SPA has no SSR so there is no hydration mismatch to worry about.
+ */
+function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(pointer: coarse)');
+    const update = () => setCoarse(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+  return coarse;
+}
+
 export function TerminalEmulator({ onCommand, welcomeMessage, className = '', username, environment = 'linux' }: TerminalEmulatorProps) {
   const [termState, setTermState] = useState<TerminalState>(createInitialState);
   const [lines, setLines] = useState<TerminalLine[]>(() => {
@@ -117,6 +138,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
   const [historyIndex, setHistoryIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
+  const isCoarse = useCoarsePointer();
 
   // Instant scroll — smooth triggers a separate animation that delays the next
   // paint and inflates INP on mid-range mobile devices (measured: +200–400 ms).
@@ -199,31 +221,68 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
     [input, activeState, onCommand, environment]
   );
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+  // Recall the previous command (history ↑). Shared by the keyboard handler
+  // and the mobile key bar.
+  const historyPrev = useCallback(() => {
     const history = activeState.commandHistory;
+    if (history.length === 0) return;
+    const newIndex = Math.min(historyIndex + 1, history.length - 1);
+    setHistoryIndex(newIndex);
+    setInput(history[history.length - 1 - newIndex] ?? '');
+  }, [activeState, historyIndex]);
+
+  // Recall the next command (history ↓), back to an empty line at the bottom.
+  const historyNext = useCallback(() => {
+    const history = activeState.commandHistory;
+    const newIndex = Math.max(historyIndex - 1, -1);
+    setHistoryIndex(newIndex);
+    setInput(newIndex === -1 ? '' : history[history.length - 1 - newIndex] ?? '');
+  }, [activeState, historyIndex]);
+
+  // Tab autocompletion. Shared by the keyboard handler and the mobile key bar.
+  const triggerTabCompletion = useCallback(() => {
+    const completions = getTabCompletions(input, activeState);
+    if (completions.length === 1) {
+      setInput(completions[0]);
+    } else if (completions.length > 1) {
+      const prompt = getEnvPrompt(activeState, environment);
+      setLines((prev) => appendLines(
+        prev,
+        { id: nextId(), type: 'prompt', text: input, prompt },
+        { id: nextId(), type: 'output', text: completions.join('  ') },
+      ));
+    }
+  }, [input, activeState, environment]);
+
+  // Insert text at the caret (mobile key bar). Replaces any selection, then
+  // restores focus + caret after React commits the controlled value so the
+  // native keyboard stays open and the learner keeps typing in place.
+  const insertAtCursor = useCallback((text: string) => {
+    const el = inputRef.current;
+    const start = el?.selectionStart ?? input.length;
+    const end = el?.selectionEnd ?? input.length;
+    const { value, cursor } = spliceAtSelection(input, start, end, text);
+    const sanitized = sanitiseInput(value);
+    setInput(sanitized);
+    const pos = Math.min(cursor, sanitized.length);
+    requestAnimationFrame(() => {
+      const node = inputRef.current;
+      if (!node) return;
+      node.focus();
+      node.setSelectionRange(pos, pos);
+    });
+  }, [input]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowUp') {
       e.preventDefault();
-      const newIndex = Math.min(historyIndex + 1, history.length - 1);
-      setHistoryIndex(newIndex);
-      setInput(history[history.length - 1 - newIndex] ?? '');
+      historyPrev();
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
-      const newIndex = Math.max(historyIndex - 1, -1);
-      setHistoryIndex(newIndex);
-      setInput(newIndex === -1 ? '' : history[history.length - 1 - newIndex] ?? '');
+      historyNext();
     } else if (e.key === 'Tab') {
       e.preventDefault();
-      const completions = getTabCompletions(input, activeState);
-      if (completions.length === 1) {
-        setInput(completions[0]);
-      } else if (completions.length > 1) {
-        const prompt = getEnvPrompt(activeState, environment);
-        setLines((prev) => appendLines(
-          prev,
-          { id: nextId(), type: 'prompt', text: input, prompt },
-          { id: nextId(), type: 'output', text: completions.join('  ') },
-        ));
-      }
+      triggerTabCompletion();
     } else if (e.key === 'c' && e.ctrlKey) {
       e.preventDefault();
       setLines((prev) => appendLines(
@@ -237,7 +296,7 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
       setLines([]);
       setHistoryIndex(-1);
     }
-  }, [activeState, historyIndex, input, environment]);
+  }, [historyPrev, historyNext, triggerTabCompletion, input, activeState, environment]);
 
   const prompt = getEnvPrompt(activeState, environment);
   const promptColor = ENV_PROMPT_COLOR[environment];
@@ -301,6 +360,17 @@ export function TerminalEmulator({ onCommand, welcomeMessage, className = '', us
           />
         </form>
       </div>
+
+      {/* Mobile special-character bar — touch viewports only (THI-307).
+          Sits outside the scroll area so it stays pinned above the keyboard. */}
+      {isCoarse && (
+        <TerminalKeyBar
+          onInsert={insertAtCursor}
+          onTab={triggerTabCompletion}
+          onHistoryPrev={historyPrev}
+          onHistoryNext={historyNext}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -90,12 +90,10 @@ export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }
       role="toolbar"
       aria-label="Touches spéciales du terminal"
       aria-orientation="horizontal"
-      // mr-16: shrink the bar's footprint so its right edge never reaches under
-      // the lesson AI-tutor FAB (fixed bottom-right, ~56px). A scrollable bar
-      // overflows under the FAB at most scroll offsets, so trailing *padding*
-      // is not enough — only a *margin* keeps every key tappable at any scroll
-      // position. The FAB floats in the cleared gap.
-      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 mr-16 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
+      // Full-width strip. The lesson AI-tutor FAB is raised above this bar on
+      // touch (AiTutorPanel `liftAboveMobileBar`), so no horizontal clearance is
+      // needed here — every key spans the full width and stays tappable.
+      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
     >
       <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
       <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -67,10 +67,14 @@ function KeyButton({
   return (
     <button
       type="button"
+      // Touch-only bar — keep it out of the physical-keyboard Tab order (the
+      // input already exposes ↑/↓/Tab). VoiceOver can still reach it by swipe.
+      tabIndex={-1}
       // Keep the input focused so the native mobile keyboard stays open while
-      // tapping keys. preventDefault on mousedown blocks the focus shift; the
-      // subsequent click still fires the action.
-      onMouseDown={(e) => e.preventDefault()}
+      // tapping keys. preventDefault on pointerdown blocks the focus shift on
+      // both touch (iOS Safari fires pointerdown, not mousedown, on buttons)
+      // and mouse; the subsequent click still fires the action.
+      onPointerDown={(e) => e.preventDefault()}
       onClick={onPress}
       aria-label={label}
       className="flex shrink-0 items-center justify-center min-w-[2.75rem] h-11 px-2 rounded-md font-mono text-sm text-[var(--github-text-primary)] bg-[var(--github-bg)] border border-[var(--github-border-primary)] active:bg-[var(--github-border-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0"

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -90,10 +90,12 @@ export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }
       role="toolbar"
       aria-label="Touches spéciales du terminal"
       aria-orientation="horizontal"
-      // pr-16: trailing scroll clearance so the last keys can scroll clear of
-      // the lesson AI-tutor FAB (fixed bottom-right, ~56px) — otherwise the
-      // rightmost keys sit under it and can't be tapped.
-      className="flex shrink-0 items-stretch gap-1 overflow-x-auto pl-2 pr-16 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
+      // mr-16: shrink the bar's footprint so its right edge never reaches under
+      // the lesson AI-tutor FAB (fixed bottom-right, ~56px). A scrollable bar
+      // overflows under the FAB at most scroll offsets, so trailing *padding*
+      // is not enough — only a *margin* keeps every key tappable at any scroll
+      // position. The FAB floats in the cleared gap.
+      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 mr-16 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
     >
       <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
       <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Mobile special-character toolbar for the terminal sandbox (THI-307).
+ *
+ * On soft keyboards (iOS/Android) the shell characters that unlock the
+ * redirection / pipes / options lessons (`|` `>` `~` `-` …) are buried 2–4
+ * taps deep or simply absent. This horizontal, scrollable bar surfaces them as
+ * 44px tap targets right above the input. It is rendered only on coarse-pointer
+ * (touch) viewports by the parent — never on desktop.
+ *
+ * Keyboard-persistence: every button prevents the default `mousedown` action so
+ * the input never loses focus (the battle-tested editor-toolbar pattern). The
+ * native keyboard stays open while keys are tapped; the `click` still fires.
+ */
+
+interface TerminalKeyBarProps {
+  /** Insert text at the current caret position in the terminal input. */
+  onInsert: (text: string) => void;
+  /** Trigger Tab autocompletion. */
+  onTab: () => void;
+  /** Recall the previous command (history ↑). */
+  onHistoryPrev: () => void;
+  /** Recall the next command (history ↓). */
+  onHistoryNext: () => void;
+}
+
+interface InsertKey {
+  /** Character(s) inserted at the caret. */
+  value: string;
+  /** Visible glyph on the key. */
+  display: string;
+  /** Accessible name (announced by screen readers). */
+  label: string;
+}
+
+// Shell characters buried deep on (or absent from) mobile soft keyboards,
+// ordered by beginner frequency — the pipe and redirections lead because they
+// unlock the redirection/pipes lessons that are otherwise untypable on a phone.
+const INSERT_KEYS: InsertKey[] = [
+  { value: '|', display: '|', label: 'pipe (barre verticale)' },
+  { value: '>', display: '>', label: 'redirection sortie' },
+  { value: '>>', display: '>>', label: 'redirection en ajout' },
+  { value: '<', display: '<', label: 'redirection entrée' },
+  { value: '~', display: '~', label: 'tilde (dossier personnel)' },
+  { value: '/', display: '/', label: 'slash' },
+  { value: '-', display: '-', label: 'tiret (options)' },
+  { value: '*', display: '*', label: 'astérisque (joker)' },
+  { value: '&', display: '&', label: 'esperluette (arrière-plan)' },
+  { value: '&&', display: '&&', label: 'et logique' },
+  { value: '$', display: '$', label: 'dollar (variable)' },
+  { value: ';', display: ';', label: 'point-virgule' },
+  { value: '"', display: '"', label: 'guillemet double' },
+  { value: "'", display: "'", label: 'apostrophe' },
+  { value: '`', display: '`', label: 'accent grave (backtick)' },
+];
+
+function KeyButton({
+  children,
+  onPress,
+  label,
+}: {
+  children: ReactNode;
+  onPress: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      // Keep the input focused so the native mobile keyboard stays open while
+      // tapping keys. preventDefault on mousedown blocks the focus shift; the
+      // subsequent click still fires the action.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onPress}
+      aria-label={label}
+      className="flex shrink-0 items-center justify-center min-w-[2.75rem] h-11 px-2 rounded-md font-mono text-sm text-[var(--github-text-primary)] bg-[var(--github-bg)] border border-[var(--github-border-primary)] active:bg-[var(--github-border-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }: TerminalKeyBarProps) {
+  return (
+    <div
+      role="toolbar"
+      aria-label="Touches spéciales du terminal"
+      aria-orientation="horizontal"
+      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
+    >
+      <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
+      <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>
+      <KeyButton onPress={onTab} label="autocomplétion (Tab)">⇥</KeyButton>
+      <span
+        className="w-px self-center h-6 mx-0.5 shrink-0 bg-[var(--github-border-primary)]"
+        aria-hidden="true"
+      />
+      {INSERT_KEYS.map((k) => (
+        <KeyButton key={k.value} onPress={() => onInsert(k.value)} label={`insérer ${k.label}`}>
+          {k.display}
+        </KeyButton>
+      ))}
+    </div>
+  );
+}
+
+// Exported for the invariants test (every key must be labelled and non-empty).
+export { INSERT_KEYS };

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 
 /**
  * Mobile special-character toolbar for the terminal sandbox (THI-307).
@@ -9,9 +9,14 @@ import type { ReactNode } from 'react';
  * 44px tap targets right above the input. It is rendered only on coarse-pointer
  * (touch) viewports by the parent — never on desktop.
  *
- * Keyboard-persistence: every button prevents the default `mousedown` action so
- * the input never loses focus (the battle-tested editor-toolbar pattern). The
- * native keyboard stays open while keys are tapped; the `click` still fires.
+ * The full set never fits a phone width, so the row scrolls horizontally and
+ * shows edge fades (right while more keys remain, left once scrolled) to make
+ * the scrollability obvious — otherwise a clipped key reads as a bug.
+ *
+ * Keyboard-persistence: every button prevents the default `pointerdown` action
+ * so the input never loses focus (iOS Safari fires pointerdown, not mousedown,
+ * on buttons). The native keyboard stays open while keys are tapped; the
+ * `click` still fires.
  */
 
 interface TerminalKeyBarProps {
@@ -85,28 +90,66 @@ function KeyButton({
 }
 
 export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }: TerminalKeyBarProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [atStart, setAtStart] = useState(true);
+  const [atEnd, setAtEnd] = useState(true);
+
+  const updateEdges = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    setAtStart(el.scrollLeft <= 1);
+    setAtEnd(el.scrollLeft >= max - 1);
+  }, []);
+
+  useEffect(() => {
+    updateEdges();
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateEdges, { passive: true });
+    window.addEventListener('resize', updateEdges);
+    return () => {
+      el.removeEventListener('scroll', updateEdges);
+      window.removeEventListener('resize', updateEdges);
+    };
+  }, [updateEdges]);
+
   return (
-    <div
-      role="toolbar"
-      aria-label="Touches spéciales du terminal"
-      aria-orientation="horizontal"
-      // Full-width strip. The lesson AI-tutor FAB is raised above this bar on
-      // touch (AiTutorPanel `liftAboveMobileBar`), so no horizontal clearance is
-      // needed here — every key spans the full width and stays tappable.
-      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
-    >
-      <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
-      <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>
-      <KeyButton onPress={onTab} label="autocomplétion (Tab)">⇥</KeyButton>
-      <span
-        className="w-px self-center h-6 mx-0.5 shrink-0 bg-[var(--github-border-primary)]"
-        aria-hidden="true"
-      />
-      {INSERT_KEYS.map((k) => (
-        <KeyButton key={k.value} onPress={() => onInsert(k.value)} label={`insérer ${k.label}`}>
-          {k.display}
-        </KeyButton>
-      ))}
+    <div className="relative shrink-0 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)]">
+      <div
+        ref={scrollRef}
+        role="toolbar"
+        aria-label="Touches spéciales du terminal"
+        aria-orientation="horizontal"
+        className="flex items-stretch gap-1 overflow-x-auto px-2 py-1.5 [scrollbar-width:none]"
+      >
+        <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
+        <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>
+        <KeyButton onPress={onTab} label="autocomplétion (Tab)">⇥</KeyButton>
+        <span
+          className="w-px self-center h-6 mx-0.5 shrink-0 bg-[var(--github-border-primary)]"
+          aria-hidden="true"
+        />
+        {INSERT_KEYS.map((k) => (
+          <KeyButton key={k.value} onPress={() => onInsert(k.value)} label={`insérer ${k.label}`}>
+            {k.display}
+          </KeyButton>
+        ))}
+      </div>
+
+      {/* Scroll affordances — fade the edge that still hides keys. */}
+      {!atStart && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-[var(--github-border-secondary)] to-transparent"
+        />
+      )}
+      {!atEnd && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[var(--github-border-secondary)] to-transparent"
+        />
+      )}
     </div>
   );
 }

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -92,7 +92,10 @@ function KeyButton({
 export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }: TerminalKeyBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atStart, setAtStart] = useState(true);
-  const [atEnd, setAtEnd] = useState(true);
+  // Starts false: on a phone the key set always overflows, so the right fade
+  // must be present from the first paint (updateEdges corrects it after mount
+  // for the rare non-overflowing case). Avoids a one-frame missing-fade flash.
+  const [atEnd, setAtEnd] = useState(false);
 
   const updateEdges = useCallback(() => {
     const el = scrollRef.current;

--- a/src/app/components/TerminalKeyBar.tsx
+++ b/src/app/components/TerminalKeyBar.tsx
@@ -90,7 +90,10 @@ export function TerminalKeyBar({ onInsert, onTab, onHistoryPrev, onHistoryNext }
       role="toolbar"
       aria-label="Touches spéciales du terminal"
       aria-orientation="horizontal"
-      className="flex shrink-0 items-stretch gap-1 overflow-x-auto px-2 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
+      // pr-16: trailing scroll clearance so the last keys can scroll clear of
+      // the lesson AI-tutor FAB (fixed bottom-right, ~56px) — otherwise the
+      // rightmost keys sit under it and can't be tapped.
+      className="flex shrink-0 items-stretch gap-1 overflow-x-auto pl-2 pr-16 py-1.5 border-t border-[var(--github-border-primary)] bg-[var(--github-border-secondary)] [scrollbar-width:none]"
     >
       <KeyButton onPress={onHistoryPrev} label="commande précédente">↑</KeyButton>
       <KeyButton onPress={onHistoryNext} label="commande suivante">↓</KeyButton>

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -58,6 +58,13 @@ interface Props {
    * dispatcher (defense-in-depth: pending teachers are not yet approved).
    */
   role?: UserRole | null;
+  /**
+   * When true, the floating trigger (FAB) is raised on coarse-pointer (touch)
+   * viewports so it clears the terminal mobile key bar (THI-307) — that bar is
+   * only rendered inside the lesson terminal, so pages without it omit this and
+   * keep the FAB in the bottom-right corner.
+   */
+  liftAboveMobileBar?: boolean;
 }
 
 function readEnabled(): boolean {
@@ -74,7 +81,7 @@ function readStoredProvider(): Provider {
   return 'openrouter';
 }
 
-export function AiTutorPanel({ lang = 'fr', lessonContext, role }: Props) {
+export function AiTutorPanel({ lang = 'fr', lessonContext, role, liftAboveMobileBar = false }: Props) {
   const [enabled] = useState<boolean>(() => readEnabled());
   const [open, setOpen] = useState(false);
   const [provider, setProviderState] = useState<Provider>(() => readStoredProvider());
@@ -200,6 +207,13 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role }: Props) {
 
   if (!enabled) return null;
 
+  // On touch viewports inside a lesson, raise the FAB above the terminal mobile
+  // key bar (~57px) so it never overlaps it. Desktop / non-lesson pages keep the
+  // standard bottom-right corner anchor.
+  const fabBottomClass = liftAboveMobileBar
+    ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] [@media(pointer:coarse)]:bottom-[calc(max(1rem,env(safe-area-inset-bottom))+4rem)]'
+    : 'bottom-[max(1rem,env(safe-area-inset-bottom))]';
+
   return (
     <>
       <button
@@ -238,7 +252,7 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role }: Props) {
         // every background; active:scale-95 gives a tactile press feedback
         // on touch devices that the previous hover-only affordance could
         // not deliver on Safari iOS (no hover state).
-        className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white shadow-lg ring-1 ring-black/30 transition active:scale-95 hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 md:h-14 md:w-14"
+        className={`fixed ${fabBottomClass} right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white shadow-lg ring-1 ring-black/30 transition active:scale-95 hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 md:h-14 md:w-14`}
       >
         <Sparkles size={20} strokeWidth={2} aria-hidden="true" />
       </button>

--- a/src/app/components/terminalKeyInsert.ts
+++ b/src/app/components/terminalKeyInsert.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure cursor-insertion helper for the terminal input (THI-307).
+ *
+ * Extracted from the component so the splice logic is unit-testable without a
+ * DOM. The mobile key bar inserts shell characters (`|`, `>`, `~`, …) at the
+ * caret rather than always appending — a learner editing the middle of a
+ * command must keep typing where they were.
+ */
+
+export interface SpliceResult {
+  /** The new input value after the insertion. */
+  value: string;
+  /** Where to place the caret — immediately after the inserted text. */
+  cursor: number;
+}
+
+/**
+ * Insert `insert` into `value`, replacing the `[start, end)` selection.
+ *
+ * Indices are clamped to `[0, value.length]` and `start <= end` is enforced so
+ * a stale or out-of-range selection can never throw or corrupt the string.
+ * When there is no selection (`start === end`) the text is inserted at the
+ * caret; when there is one, the selected range is replaced.
+ */
+export function spliceAtSelection(
+  value: string,
+  start: number,
+  end: number,
+  insert: string,
+): SpliceResult {
+  const len = value.length;
+  const s = Math.max(0, Math.min(start, len));
+  const e = Math.max(s, Math.min(end, len));
+  return {
+    value: value.slice(0, s) + insert + value.slice(e),
+    cursor: s + insert.length,
+  };
+}

--- a/src/app/components/terminalKeyInsert.ts
+++ b/src/app/components/terminalKeyInsert.ts
@@ -4,15 +4,10 @@
  * Extracted from the component so the splice logic is unit-testable without a
  * DOM. The mobile key bar inserts shell characters (`|`, `>`, `~`, …) at the
  * caret rather than always appending — a learner editing the middle of a
- * command must keep typing where they were.
+ * command must keep typing where they were. Caret restoration is the caller's
+ * concern (it owns the sanitiser + the input ref), so this stays a focused
+ * "safe string splice".
  */
-
-export interface SpliceResult {
-  /** The new input value after the insertion. */
-  value: string;
-  /** Where to place the caret — immediately after the inserted text. */
-  cursor: number;
-}
 
 /**
  * Insert `insert` into `value`, replacing the `[start, end)` selection.
@@ -27,12 +22,9 @@ export function spliceAtSelection(
   start: number,
   end: number,
   insert: string,
-): SpliceResult {
+): string {
   const len = value.length;
   const s = Math.max(0, Math.min(start, len));
   const e = Math.max(s, Math.min(end, len));
-  return {
-    value: value.slice(0, s) + insert + value.slice(e),
-    cursor: s + insert.length,
-  };
+  return value.slice(0, s) + insert + value.slice(e);
 }

--- a/src/test/terminalKeyBar.test.tsx
+++ b/src/test/terminalKeyBar.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TerminalKeyBar, INSERT_KEYS } from '../app/components/TerminalKeyBar';
+
+function setup() {
+  const onInsert = vi.fn();
+  const onTab = vi.fn();
+  const onHistoryPrev = vi.fn();
+  const onHistoryNext = vi.fn();
+  render(
+    <TerminalKeyBar
+      onInsert={onInsert}
+      onTab={onTab}
+      onHistoryPrev={onHistoryPrev}
+      onHistoryNext={onHistoryNext}
+    />,
+  );
+  return { onInsert, onTab, onHistoryPrev, onHistoryNext };
+}
+
+describe('TerminalKeyBar (THI-307)', () => {
+  it('renders an accessible toolbar', () => {
+    setup();
+    const toolbar = screen.getByRole('toolbar', { name: /touches spéciales du terminal/i });
+    expect(toolbar).toBeInTheDocument();
+    expect(toolbar).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('renders every insert key with a non-empty value and label', () => {
+    expect(INSERT_KEYS.length).toBeGreaterThanOrEqual(10);
+    for (const key of INSERT_KEYS) {
+      expect(key.value.length).toBeGreaterThan(0);
+      expect(key.display.length).toBeGreaterThan(0);
+      expect(key.label.trim().length).toBeGreaterThan(0);
+    }
+    // The pipe is the headline key — it must be present and first.
+    expect(INSERT_KEYS[0].value).toBe('|');
+  });
+
+  it('inserts the pipe character on tap', () => {
+    const { onInsert } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /insérer pipe/i }));
+    expect(onInsert).toHaveBeenCalledWith('|');
+  });
+
+  it('inserts the append-redirection token', () => {
+    const { onInsert } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /insérer redirection en ajout/i }));
+    expect(onInsert).toHaveBeenCalledWith('>>');
+  });
+
+  it('wires the Tab and history controls', () => {
+    const { onTab, onHistoryPrev, onHistoryNext } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /autocomplétion/i }));
+    fireEvent.click(screen.getByRole('button', { name: /commande précédente/i }));
+    fireEvent.click(screen.getByRole('button', { name: /commande suivante/i }));
+    expect(onTab).toHaveBeenCalledTimes(1);
+    expect(onHistoryPrev).toHaveBeenCalledTimes(1);
+    expect(onHistoryNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the input focused (prevents default mousedown so the keyboard stays open)', () => {
+    setup();
+    const pipe = screen.getByRole('button', { name: /insérer pipe/i });
+    const ev = fireEvent.mouseDown(pipe);
+    // fireEvent returns false when a handler called preventDefault().
+    expect(ev).toBe(false);
+  });
+
+  it('uses type="button" so taps never submit the surrounding form', () => {
+    setup();
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn).toHaveAttribute('type', 'button');
+    }
+  });
+
+  it('gives every key a ≥44px tap target (h-11)', () => {
+    setup();
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn.className).toMatch(/\bh-11\b/);
+      expect(btn.className).toMatch(/min-w-\[2\.75rem\]/);
+    }
+  });
+});

--- a/src/test/terminalKeyBar.test.tsx
+++ b/src/test/terminalKeyBar.test.tsx
@@ -59,10 +59,12 @@ describe('TerminalKeyBar (THI-307)', () => {
     expect(onHistoryNext).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the input focused (prevents default mousedown so the keyboard stays open)', () => {
+  it('keeps the input focused (prevents default pointerdown so the keyboard stays open)', () => {
     setup();
     const pipe = screen.getByRole('button', { name: /insérer pipe/i });
-    const ev = fireEvent.mouseDown(pipe);
+    // iOS Safari fires pointerdown (not mousedown) on buttons; preventing its
+    // default is what keeps the input focused so the keyboard stays open.
+    const ev = fireEvent.pointerDown(pipe);
     // fireEvent returns false when a handler called preventDefault().
     expect(ev).toBe(false);
   });
@@ -71,6 +73,13 @@ describe('TerminalKeyBar (THI-307)', () => {
     setup();
     for (const btn of screen.getAllByRole('button')) {
       expect(btn).toHaveAttribute('type', 'button');
+    }
+  });
+
+  it('keeps touch keys out of the physical-keyboard Tab order (tabIndex=-1)', () => {
+    setup();
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn).toHaveAttribute('tabindex', '-1');
     }
   });
 

--- a/src/test/terminalKeyInsert.test.ts
+++ b/src/test/terminalKeyInsert.test.ts
@@ -4,46 +4,32 @@ import { spliceAtSelection } from '../app/components/terminalKeyInsert';
 describe('spliceAtSelection (THI-307 cursor insertion)', () => {
   it('inserts at the caret when there is no selection', () => {
     // "ls -l" with caret after "ls " (index 3) → insert "|"
-    const r = spliceAtSelection('ls -l', 3, 3, '|');
-    expect(r.value).toBe('ls |-l');
-    expect(r.cursor).toBe(4);
+    expect(spliceAtSelection('ls -l', 3, 3, '|')).toBe('ls |-l');
   });
 
   it('appends at the end', () => {
-    const r = spliceAtSelection('cat file', 8, 8, ' | grep x');
-    expect(r.value).toBe('cat file | grep x');
-    expect(r.cursor).toBe('cat file | grep x'.length);
+    expect(spliceAtSelection('cat file', 8, 8, ' | grep x')).toBe('cat file | grep x');
   });
 
   it('inserts into an empty string', () => {
-    const r = spliceAtSelection('', 0, 0, '~');
-    expect(r.value).toBe('~');
-    expect(r.cursor).toBe(1);
+    expect(spliceAtSelection('', 0, 0, '~')).toBe('~');
   });
 
   it('replaces a selected range', () => {
     // select "abc" in "abc-l" → replace with ">>"
-    const r = spliceAtSelection('abc-l', 0, 3, '>>');
-    expect(r.value).toBe('>>-l');
-    expect(r.cursor).toBe(2);
+    expect(spliceAtSelection('abc-l', 0, 3, '>>')).toBe('>>-l');
   });
 
   it('clamps out-of-range indices instead of throwing', () => {
-    const r = spliceAtSelection('ab', 99, 99, '*');
-    expect(r.value).toBe('ab*');
-    expect(r.cursor).toBe(3);
+    expect(spliceAtSelection('ab', 99, 99, '*')).toBe('ab*');
   });
 
   it('enforces start <= end (swapped/invalid selection is treated as a caret)', () => {
-    const r = spliceAtSelection('hello', 4, 1, '$');
     // end is clamped up to start (4) → caret insert at 4
-    expect(r.value).toBe('hell$o');
-    expect(r.cursor).toBe(5);
+    expect(spliceAtSelection('hello', 4, 1, '$')).toBe('hell$o');
   });
 
   it('handles multi-character tokens', () => {
-    const r = spliceAtSelection('ab', 1, 1, '&&');
-    expect(r.value).toBe('a&&b');
-    expect(r.cursor).toBe(3);
+    expect(spliceAtSelection('ab', 1, 1, '&&')).toBe('a&&b');
   });
 });

--- a/src/test/terminalKeyInsert.test.ts
+++ b/src/test/terminalKeyInsert.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { spliceAtSelection } from '../app/components/terminalKeyInsert';
+
+describe('spliceAtSelection (THI-307 cursor insertion)', () => {
+  it('inserts at the caret when there is no selection', () => {
+    // "ls -l" with caret after "ls " (index 3) → insert "|"
+    const r = spliceAtSelection('ls -l', 3, 3, '|');
+    expect(r.value).toBe('ls |-l');
+    expect(r.cursor).toBe(4);
+  });
+
+  it('appends at the end', () => {
+    const r = spliceAtSelection('cat file', 8, 8, ' | grep x');
+    expect(r.value).toBe('cat file | grep x');
+    expect(r.cursor).toBe('cat file | grep x'.length);
+  });
+
+  it('inserts into an empty string', () => {
+    const r = spliceAtSelection('', 0, 0, '~');
+    expect(r.value).toBe('~');
+    expect(r.cursor).toBe(1);
+  });
+
+  it('replaces a selected range', () => {
+    // select "abc" in "abc-l" → replace with ">>"
+    const r = spliceAtSelection('abc-l', 0, 3, '>>');
+    expect(r.value).toBe('>>-l');
+    expect(r.cursor).toBe(2);
+  });
+
+  it('clamps out-of-range indices instead of throwing', () => {
+    const r = spliceAtSelection('ab', 99, 99, '*');
+    expect(r.value).toBe('ab*');
+    expect(r.cursor).toBe(3);
+  });
+
+  it('enforces start <= end (swapped/invalid selection is treated as a caret)', () => {
+    const r = spliceAtSelection('hello', 4, 1, '$');
+    // end is clamped up to start (4) → caret insert at 4
+    expect(r.value).toBe('hell$o');
+    expect(r.cursor).toBe(5);
+  });
+
+  it('handles multi-character tokens', () => {
+    const r = spliceAtSelection('ab', 1, 1, '&&');
+    expect(r.value).toBe('a&&b');
+    expect(r.cursor).toBe(3);
+  });
+});


### PR DESCRIPTION
## THI-307 — Barre de touches spéciales mobile

Sur clavier mobile (iOS/Android), les caractères shell essentiels (`|` `>` `~` `-` `/` `*` `$` `&` `;` …) sont enfouis 2-4 taps profond ou introuvables → les leçons **redirection / pipes / options** sont quasi impraticables au doigt. Cette PR ajoute une barre horizontale scrollable au-dessus de l'input du terminal, **uniquement sur viewport tactile**.

### Changements
- **`TerminalKeyBar.tsx`** (nouveau) — toolbar `role="toolbar"`, touches d'insertion (`|` `>` `>>` `<` `~` `/` `-` `*` `&` `&&` `$` `;` `"` `'` `` ` ``) + contrôles `⇥` `↑` `↓`. Tap targets **44px** (`h-11` / `min-w-[2.75rem]`).
- **`terminalKeyInsert.ts`** (nouveau) — helper pur `spliceAtSelection` (insertion au curseur / remplacement de sélection / clamp d'index), testé sans DOM.
- **`TerminalEmulator.tsx`** — hook réactif `useCoarsePointer()` (desktop ne voit jamais la barre), `insertAtCursor` avec restauration du caret, extraction de `historyPrev`/`historyNext`/`triggerTabCompletion` partagés clavier + barre.

### Persistance du clavier (clé de la feature)
`onPointerDown` + `preventDefault` garde l'input focus → le clavier natif **reste ouvert** pendant qu'on tape les touches (iOS Safari émet `pointerdown`, pas `mousedown`, sur les `<button>` ; le `click` survit pour l'action + VoiceOver).

### Qualité
- **16 tests** (7 splice + 9 render/interaction/a11y), suite complète verte.
- **ui-auditor** : 0 CRITICAL (W1 ring-token + W4 webkit-scrolling corrigés ; couleurs terminal en dur = dette pré-existante hors scope).
- **feature-dev:code-reviewer** : 3 IMPORTANT corrigés dans la PR (iOS pointerdown, tabIndex=-1, caret robuste).
- Type-check + lint clean. Build prod ✅.

### ⚠️ Validation requise
Émulation Playwright/Chrome ≠ clavier natif iOS. **Validation @thierry sur iPhone réel requise** (la barre reste-t-elle au-dessus du clavier, le clavier ne se ferme pas au tap) — cf. `feedback_empirical_pwa_validation`. Si le clavier se ferme malgré pointerdown, follow-up = positionnement `visualViewport` fixe.

Closes THI-307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter une barre d’outils de caractères spéciaux, utilisable au toucher uniquement, à l’entrée du terminal sur les appareils mobiles, et l’intégrer à la navigation dans l’historique ainsi qu’à l’auto-complétion (tab completion).

New Features:
- Introduire une barre de touches pour terminal sur mobile, exposant les caractères spéciaux courants du shell ainsi que des contrôles d’historique/complétion par tabulation au-dessus du champ de saisie sur les affichages à pointeur grossier.

Enhancements:
- Refactoriser la navigation dans l’historique du terminal et la complétion par tabulation en callbacks réutilisables, partagés entre les raccourcis clavier et la barre de touches mobile.
- Ajouter un helper réutilisable de découpage (splice) pour l’insertion de texte tenant compte de la position du curseur dans le champ de saisie du terminal.

Tests:
- Ajouter des tests unitaires et des tests d’interaction pour la barre de touches du terminal mobile et pour le helper d’insertion avec gestion du curseur.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a touch-only special-character toolbar to the terminal input on mobile devices and wire it into history navigation and tab completion.

New Features:
- Introduce a mobile terminal key bar exposing common shell special characters and history/tab controls above the input on coarse-pointer viewports.

Enhancements:
- Refactor terminal history navigation and tab completion into reusable callbacks shared between keyboard shortcuts and the mobile key bar.
- Add a reusable splice helper for cursor-aware text insertion in the terminal input.

Tests:
- Add unit and interaction tests for the mobile terminal key bar and the cursor insertion helper.

</details>