### PR TITLE
fix(progress): sticky module unlock — no retroactive re-lock (THI-309)

### DIFF
--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -177,8 +177,8 @@ const ProgressContext = createContext<ProgressContextValue | null>(null);
 type CurriculumBundle = {
   curriculum: Module[];
   getTotalLessons: () => number;
-  isModuleUnlocked: (id: string, completed: Set<string>) => boolean;
-  getModuleUnlockTree: (completed: Set<string>) => ModuleUnlockStatus[];
+  isModuleUnlocked: (id: string, completed: Set<string>, started: Set<string>) => boolean;
+  getModuleUnlockTree: (completed: Set<string>, started: Set<string>) => ModuleUnlockStatus[];
 };
 
 export function ProgressProvider({ children }: { children: ReactNode }) {
@@ -467,15 +467,30 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
     return ids;
   }, [progress, currBundle]);
 
+  // Derive *started* module IDs (≥1 lesson completed). A started module stays
+  // unlocked even if a prerequisite later drops below 100% — prevents the
+  // retroactive re-lock when a new lesson is inserted into an early module
+  // (THI-309). Distinct from completedModuleIds (ALL lessons), which still
+  // gates fresh unlocking of never-touched modules.
+  const startedModuleIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const mod of currBundle?.curriculum ?? []) {
+      if (mod.lessons.some((l) => progress.completedLessons[`${mod.id}/${l.id}`])) {
+        ids.add(mod.id);
+      }
+    }
+    return ids;
+  }, [progress, currBundle]);
+
   const isModUnlocked = useCallback(
     (moduleId: string) =>
-      currBundle?.isModuleUnlocked(moduleId, completedModuleIds) ?? true,
-    [completedModuleIds, currBundle],
+      currBundle?.isModuleUnlocked(moduleId, completedModuleIds, startedModuleIds) ?? true,
+    [completedModuleIds, startedModuleIds, currBundle],
   );
 
   const unlockTree = useMemo(
-    () => currBundle?.getModuleUnlockTree(completedModuleIds) ?? [],
-    [completedModuleIds, currBundle],
+    () => currBundle?.getModuleUnlockTree(completedModuleIds, startedModuleIds) ?? [],
+    [completedModuleIds, startedModuleIds, currBundle],
   );
 
   return (

--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -177,8 +177,8 @@ const ProgressContext = createContext<ProgressContextValue | null>(null);
 type CurriculumBundle = {
   curriculum: Module[];
   getTotalLessons: () => number;
-  isModuleUnlocked: (id: string, completed: Set<string>, started: Set<string>) => boolean;
-  getModuleUnlockTree: (completed: Set<string>, started: Set<string>) => ModuleUnlockStatus[];
+  isModuleUnlocked: (id: string, completed: Set<string>, started?: Set<string>) => boolean;
+  getModuleUnlockTree: (completed: Set<string>, started?: Set<string>) => ModuleUnlockStatus[];
 };
 
 export function ProgressProvider({ children }: { children: ReactNode }) {
@@ -456,30 +456,26 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
   const totalLessons = currBundle?.getTotalLessons() ?? 0;
   const overallProgress = totalLessons > 0 ? Math.round((totalCompleted / totalLessons) * 100) : 0;
 
-  // Derive completed module IDs from lesson-level progress
-  const completedModuleIds = useMemo(() => {
-    const ids = new Set<string>();
+  // Derive both module ID sets from lesson-level progress in a single pass:
+  //  • completedModuleIds — ALL lessons done; satisfies downstream prerequisites.
+  //  • startedModuleIds    — ≥1 lesson done; stays unlocked even if a prerequisite
+  //    later drops below 100% (sticky access, THI-309) — prevents the retroactive
+  //    re-lock when a new lesson is inserted into an early module. The strict gate
+  //    (completedModuleIds) still controls fresh unlocking of never-touched modules.
+  const { completedModuleIds, startedModuleIds } = useMemo(() => {
+    const completed = new Set<string>();
+    const started = new Set<string>();
     for (const mod of currBundle?.curriculum ?? []) {
-      if (mod.lessons.every((l) => progress.completedLessons[`${mod.id}/${l.id}`])) {
-        ids.add(mod.id);
+      let all = true;
+      let any = false;
+      for (const l of mod.lessons) {
+        if (progress.completedLessons[`${mod.id}/${l.id}`]) any = true;
+        else all = false;
       }
+      if (all) completed.add(mod.id);
+      if (any) started.add(mod.id);
     }
-    return ids;
-  }, [progress, currBundle]);
-
-  // Derive *started* module IDs (≥1 lesson completed). A started module stays
-  // unlocked even if a prerequisite later drops below 100% — prevents the
-  // retroactive re-lock when a new lesson is inserted into an early module
-  // (THI-309). Distinct from completedModuleIds (ALL lessons), which still
-  // gates fresh unlocking of never-touched modules.
-  const startedModuleIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const mod of currBundle?.curriculum ?? []) {
-      if (mod.lessons.some((l) => progress.completedLessons[`${mod.id}/${l.id}`])) {
-        ids.add(mod.id);
-      }
-    }
-    return ids;
+    return { completedModuleIds: completed, startedModuleIds: started };
   }, [progress, currBundle]);
 
   const isModUnlocked = useCallback(

--- a/src/app/lib/unlocking.ts
+++ b/src/app/lib/unlocking.ts
@@ -114,13 +114,18 @@ export function getModuleUnlockTree(
   startedModuleIds: Set<string> = new Set(),
 ): ModuleUnlockStatus[] {
   return curriculum.map((mod) => {
-    const missing = getMissingPrerequisites(mod.id, completedModuleIds);
+    const unlocked = isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds);
+    // Invariant: an unlocked module exposes no missing prerequisites. With sticky
+    // access a started module can be unlocked while its prerequisites are still
+    // < 100% — surfacing those as "missing" would be misleading to consumers, so
+    // normalise to empty once the module is reachable.
+    const missing = unlocked ? [] : getMissingPrerequisites(mod.id, completedModuleIds);
     return {
       moduleId: mod.id,
       title: mod.title,
       color: mod.color,
       iconName: mod.iconName,
-      unlocked: isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds),
+      unlocked,
       completed: completedModuleIds.has(mod.id),
       missingPrerequisites: missing,
       missingPrerequisiteLabels: missing.map(

--- a/src/app/lib/unlocking.ts
+++ b/src/app/lib/unlocking.ts
@@ -7,18 +7,36 @@ import type { Module } from '../data/curriculum';
  * A module is unlocked when ALL of its prerequisites are completed.
  * Modules with no prerequisites (e.g. "navigation") are always unlocked.
  *
- * This module is stateless — it takes completed module IDs as input
+ * **Sticky access (THI-309)**: a module the learner has already entered — i.e.
+ * completed at least one of its lessons — stays unlocked forever, even if a
+ * prerequisite module later gains a new lesson and drops below 100%. Without
+ * this, inserting a lesson into an early module (e.g. `command-anatomy` added
+ * to Navigation) retroactively re-locks every downstream module for existing
+ * users who had already progressed — a trust-breaking regression. The strict
+ * 100%-of-prerequisites gate is preserved for modules the learner has NOT yet
+ * touched, so the pedagogical sequence still holds for newcomers.
+ *
+ * This module is stateless — it takes completed/started module IDs as input
  * and returns unlock status. The actual progress state lives in
  * ProgressContext.
  */
 
-/** Check if a single module is unlocked given a set of completed module IDs. */
+/**
+ * Check if a single module is unlocked.
+ *
+ * @param completedModuleIds Modules with ALL lessons completed (satisfy prereqs).
+ * @param startedModuleIds   Modules with ≥1 lesson completed (sticky-unlocked).
+ */
 export function isModuleUnlocked(
   moduleId: string,
   completedModuleIds: Set<string>,
+  startedModuleIds: Set<string> = new Set(),
 ): boolean {
   const mod = curriculum.find((m) => m.id === moduleId);
   if (!mod) return false;
+
+  // Sticky: already entered → stays accessible regardless of prerequisite drift.
+  if (startedModuleIds.has(moduleId)) return true;
 
   const prerequisites = mod.prerequisites ?? [];
 
@@ -29,31 +47,34 @@ export function isModuleUnlocked(
   return prerequisites.every((prereqId) => completedModuleIds.has(prereqId));
 }
 
-/** Get all unlocked module IDs given a set of completed module IDs. */
+/** Get all unlocked module IDs given completed + started module IDs. */
 export function getUnlockedModules(
   completedModuleIds: Set<string>,
+  startedModuleIds: Set<string> = new Set(),
 ): string[] {
   return curriculum
-    .filter((mod) => isModuleUnlocked(mod.id, completedModuleIds))
+    .filter((mod) => isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds))
     .map((mod) => mod.id);
 }
 
-/** Get all locked module IDs given a set of completed module IDs. */
+/** Get all locked module IDs given completed + started module IDs. */
 export function getLockedModules(
   completedModuleIds: Set<string>,
+  startedModuleIds: Set<string> = new Set(),
 ): string[] {
   return curriculum
-    .filter((mod) => !isModuleUnlocked(mod.id, completedModuleIds))
+    .filter((mod) => !isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds))
     .map((mod) => mod.id);
 }
 
 /** Get the next recommended module (first unlocked but not yet completed). */
 export function getNextRecommendedModule(
   completedModuleIds: Set<string>,
+  startedModuleIds: Set<string> = new Set(),
 ): Module | null {
   const unlocked = curriculum.filter(
     (mod) =>
-      isModuleUnlocked(mod.id, completedModuleIds) &&
+      isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds) &&
       !completedModuleIds.has(mod.id),
   );
   return unlocked[0] ?? null;
@@ -90,6 +111,7 @@ export interface ModuleUnlockStatus {
 
 export function getModuleUnlockTree(
   completedModuleIds: Set<string>,
+  startedModuleIds: Set<string> = new Set(),
 ): ModuleUnlockStatus[] {
   return curriculum.map((mod) => {
     const missing = getMissingPrerequisites(mod.id, completedModuleIds);
@@ -98,7 +120,7 @@ export function getModuleUnlockTree(
       title: mod.title,
       color: mod.color,
       iconName: mod.iconName,
-      unlocked: isModuleUnlocked(mod.id, completedModuleIds),
+      unlocked: isModuleUnlocked(mod.id, completedModuleIds, startedModuleIds),
       completed: completedModuleIds.has(mod.id),
       missingPrerequisites: missing,
       missingPrerequisiteLabels: missing.map(

--- a/src/test/unlocking.test.ts
+++ b/src/test/unlocking.test.ts
@@ -115,6 +115,43 @@ describe('unlocking logic', () => {
     });
   });
 
+  // THI-309 — sticky access: a module already entered (≥1 lesson done) stays
+  // unlocked even if a prerequisite later drops below 100% (e.g. a new lesson
+  // is inserted into Navigation). Prevents retroactive re-locking of modules
+  // existing users had already progressed in.
+  describe('sticky unlock (THI-309)', () => {
+    it('keeps a started module unlocked even when its prerequisite is no longer complete', () => {
+      // navigation NOT in completed (e.g. command-anatomy added → 5/6), but the
+      // learner already did lessons in fichiers → fichiers must stay accessible.
+      const completed = new Set<string>(); // navigation incomplete
+      const started = new Set(['fichiers']);
+      expect(isModuleUnlocked('fichiers', completed, started)).toBe(true);
+    });
+
+    it('still locks a never-started module when its prerequisite is incomplete', () => {
+      // permissions never touched + prereqs incomplete → stays locked (gate intact).
+      expect(isModuleUnlocked('permissions', new Set(), new Set(['fichiers']))).toBe(false);
+    });
+
+    it('getUnlockedModules includes every started module regardless of prereqs', () => {
+      const started = new Set(['fichiers', 'lecture', 'permissions', 'processus', 'redirection']);
+      const unlocked = getUnlockedModules(new Set(), started);
+      for (const id of started) expect(unlocked).toContain(id);
+    });
+
+    it('reproduces the regression scenario: Navigation 5/6 must not re-lock entered modules', () => {
+      // Navigation incomplete (not in completed), learner started 5 downstream modules.
+      const completed = new Set<string>();
+      const started = new Set(['fichiers', 'lecture', 'permissions', 'processus', 'redirection']);
+      const tree = getModuleUnlockTree(completed, started);
+      for (const id of started) {
+        expect(tree.find((m) => m.moduleId === id)?.unlocked, `${id} should stay unlocked`).toBe(true);
+      }
+      // A module the learner never entered and whose prereqs are incomplete stays locked.
+      expect(tree.find((m) => m.moduleId === 'variables')?.unlocked).toBe(false);
+    });
+  });
+
   describe('getModuleUnlockTree', () => {
     it('should return status for every module in curriculum', () => {
       const tree = getModuleUnlockTree(new Set());

--- a/src/test/unlocking.test.ts
+++ b/src/test/unlocking.test.ts
@@ -150,6 +150,16 @@ describe('unlocking logic', () => {
       // A module the learner never entered and whose prereqs are incomplete stays locked.
       expect(tree.find((m) => m.moduleId === 'variables')?.unlocked).toBe(false);
     });
+
+    it('a sticky-unlocked module exposes no missing prerequisites (invariant)', () => {
+      // fichiers started but its prereq (navigation) is incomplete → unlocked,
+      // and missingPrerequisites must be normalised to [] (unlocked ⟹ none missing).
+      const tree = getModuleUnlockTree(new Set(), new Set(['fichiers']));
+      const fichiers = tree.find((m) => m.moduleId === 'fichiers');
+      expect(fichiers?.unlocked).toBe(true);
+      expect(fichiers?.missingPrerequisites).toEqual([]);
+      expect(fichiers?.missingPrerequisiteLabels).toEqual([]);
+    });
   });
 
   describe('getModuleUnlockTree', () => {


### PR DESCRIPTION
## THI-309 (Urgent) — Re-verrouillage rétroactif des modules

**Symptôme** (confirmé @thierry, desktop + iPhone) : tous les modules après Navigation verrouillés alors que 24 leçons complétées sur 6 modules.

**Cause** : `command-anatomy` ajoutée à Navigation (PR #331, 30/05) → Navigation 5→6 leçons → users existants à 5/6 → Navigation « non complété » → tout l'aval (prérequis = navigation) **re-verrouillé**. Défaut de conception : chaque ajout de leçon dans un module-prérequis re-verrouille les users existants.

**Fix** (option « déverrouillage persistant » validée @thierry) : un module **déjà entamé (≥1 leçon)** reste déverrouillé même si un prérequis repasse sous 100%. Gate strict 100% conservé pour les modules **jamais touchés** (séquence pédagogique intacte pour nouveaux users). Dérivé des données existantes, **zéro nouveau stockage**.

### Fichiers
- `src/app/lib/unlocking.ts` — `startedModuleIds` (branche sticky) threadé dans toutes les fonctions (param optionnel, défaut vide → rétro-compat).
- `src/app/context/ProgressContext.tsx` — dérive `startedModuleIds` (≥1 leçon), passe aux fns unlock.
- `src/test/unlocking.test.ts` — +4 tests dont la reproduction exacte de la régression.

### Edge case assumé
Module déverrouillé-mais-jamais-commencé peut se re-verrouiller si prérequis gagne une leçon (0 travail perdu ; stickiness totale = persister events unlock, hors scope).

### Validation
- tsc + lint clean · **suite complète 1931 passed** · 4 tests régression ciblés verts.
- ⚠️ Validation finale = @thierry vérifie son compte (24 leçons, modules ré-ouverts) après déploiement — la régression ne se reproduit qu'avec une progression réelle existante.

Closes THI-309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Préserver l’accès aux modules qu’un apprenant a déjà commencés, même si leurs modules prérequis deviennent ensuite incomplets en raison de l’ajout de nouvelles leçons.

Bug Fixes:
- Empêcher le verrouillage rétroactif des modules en aval lorsque de nouvelles leçons sont ajoutées aux modules prérequis, en faisant en sorte que les modules déjà commencés restent déverrouillés.
- Dériver et propager les identifiants des modules commencés à travers la logique de progression et de déverrouillage afin que le comportement d’accès « persistant » soit appliqué de manière cohérente à toutes les requêtes de déverrouillage.
- Ajouter des tests de régression pour couvrir le comportement de déverrouillage persistant et le scénario spécifique THI-309 afin d’éviter de futures régressions.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve access to modules that a learner has already started, even if their prerequisite modules later become incomplete due to added lessons.

Bug Fixes:
- Prevent retroactive re-locking of downstream modules when new lessons are added to prerequisite modules by making started modules stay unlocked.
- Derive and thread started module IDs through progress and unlocking logic so sticky access behavior is applied consistently across all unlock queries.
- Add regression tests to cover sticky unlock behavior and the specific THI-309 scenario to avoid future regressions.

</details>