### PR TITLE
fix(progress): [HOTFIX] guard curriculum dynamic import against iOS crash

### DIFF
--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -203,15 +203,43 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
   // ── Lazy-load curriculum + unlocking (excluded from main bundle) ──────────
   useEffect(() => {
     let cancelled = false;
+
+    // Recover from a failed/partial curriculum bundle load WITHOUT crashing.
+    // Both a rejected import (stale chunk after a deploy → SPA-rewrite serves
+    // index.html on ANY browser) and a resolved-but-incomplete module namespace
+    // (observed cross-platform: Sentry c666a960 iOS 18.7, a3bf3322 desktop
+    // Chrome) used to surface `…undefined (curriculum)` via onunhandledrejection.
+    // Strategy: one guarded reload (once/session) self-heals the common stale
+    // chunk; if that's already been spent, degrade to local-only mode and
+    // report genuinely unexpected (non-stale) failures so they stay observable.
+    const recover = (reason: unknown, stale: boolean) => {
+      if (cancelled) return;
+      if (reloadOnceForStaleChunk()) return;
+      setSyncStatus('local');
+      if (!stale) {
+        // Dynamic import so Sentry stays in its own chunk (no FCP bundle cost).
+        void import('@/lib/sentry')
+          .then(({ Sentry }) => Sentry.captureException(reason))
+          .catch(() => {});
+      }
+    };
+
     Promise.all([
       import('../data/curriculum'),
       import('../lib/unlocking'),
     ]).then(([currMod, unlockMod]) => {
       if (cancelled) return;
-      // Defensive: on iOS Safari a flaky/aborted chunk can resolve to an
-      // incomplete module namespace — guard before reading so we never throw
-      // `undefined is not an object (curriculum)` (Sentry c666a960, iOS 18.7).
-      if (!currMod?.curriculum || !unlockMod?.isModuleUnlocked) return;
+      // Validate the FULL bundle shape before reading any field — a partial
+      // namespace (stale/aborted chunk) is treated like a stale chunk.
+      if (
+        !currMod?.curriculum ||
+        typeof currMod.getTotalLessons !== 'function' ||
+        typeof unlockMod?.isModuleUnlocked !== 'function' ||
+        typeof unlockMod.getModuleUnlockTree !== 'function'
+      ) {
+        recover(new Error('curriculum bundle resolved with an incomplete module namespace'), false);
+        return;
+      }
       setCurrBundle({
         curriculum: currMod.curriculum,
         getTotalLessons: currMod.getTotalLessons,
@@ -219,14 +247,9 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
         getModuleUnlockTree: unlockMod.getModuleUnlockTree,
       });
     }).catch((err) => {
-      // No .catch previously → a failed dynamic import (stale chunk after a
-      // deploy, flaky iOS network) surfaced as an UNHANDLED rejection / crash.
-      // Stale chunk → self-heal with one guarded reload; otherwise stay usable
-      // in local-only mode rather than crashing.
-      if (cancelled) return;
-      if (isStaleChunkError(err)) reloadOnceForStaleChunk();
-      else setSyncStatus('local');
+      recover(err, isStaleChunkError(err));
     });
+
     return () => { cancelled = true; };
   }, []);
 

--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -6,6 +6,7 @@ import { mergeProgress, getDelta } from '../lib/progressSync';
 // loads in parallel with initial render, never blocking FCP.
 const supabaseLoader = import('../../lib/supabase');
 import type { ModuleUnlockStatus } from '../lib/unlocking';
+import { isStaleChunkError, reloadOnceForStaleChunk } from '../lib/lazyWithRetry';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -206,14 +207,25 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
       import('../data/curriculum'),
       import('../lib/unlocking'),
     ]).then(([currMod, unlockMod]) => {
-      if (!cancelled) {
-        setCurrBundle({
-          curriculum: currMod.curriculum,
-          getTotalLessons: currMod.getTotalLessons,
-          isModuleUnlocked: unlockMod.isModuleUnlocked,
-          getModuleUnlockTree: unlockMod.getModuleUnlockTree,
-        });
-      }
+      if (cancelled) return;
+      // Defensive: on iOS Safari a flaky/aborted chunk can resolve to an
+      // incomplete module namespace — guard before reading so we never throw
+      // `undefined is not an object (curriculum)` (Sentry c666a960, iOS 18.7).
+      if (!currMod?.curriculum || !unlockMod?.isModuleUnlocked) return;
+      setCurrBundle({
+        curriculum: currMod.curriculum,
+        getTotalLessons: currMod.getTotalLessons,
+        isModuleUnlocked: unlockMod.isModuleUnlocked,
+        getModuleUnlockTree: unlockMod.getModuleUnlockTree,
+      });
+    }).catch((err) => {
+      // No .catch previously → a failed dynamic import (stale chunk after a
+      // deploy, flaky iOS network) surfaced as an UNHANDLED rejection / crash.
+      // Stale chunk → self-heal with one guarded reload; otherwise stay usable
+      // in local-only mode rather than crashing.
+      if (cancelled) return;
+      if (isStaleChunkError(err)) reloadOnceForStaleChunk();
+      else setSyncStatus('local');
     });
     return () => { cancelled = true; };
   }, []);


### PR DESCRIPTION
## [HOTFIX] Crash prod iOS — `undefined is not an object ('curriculum')`

**Sentry** : [c666a960](https://terminallearning.dev) · `/app` · **iOS Safari 18.7 iPhone** · `onunhandledrejection` · release e4b4b5d (#346). Survenu pendant le debug progression de @thierry sur son iPhone.

### Cause
`ProgressContext` faisait `Promise.all([import(curriculum), import(unlocking)]).then(([currMod]) => setCurrBundle({ curriculum: currMod.curriculum, ... }))` **sans `.catch()` ni garde**. Sur iOS Safari, un chunk lazy qui échoue/stalle → rejet non géré, ou résout un namespace incomplet → `currMod.curriculum` sur `undefined`. Dans les deux cas le bundle curriculum ne charge pas → `currBundle` reste `null` → **probablement un contributeur au « iPhone 0% / modules verrouillés »** vu aujourd'hui.

### Fix (cross-platform)
- **Garde défensive** : abandon si `currMod?.curriculum`/`unlockMod?.isModuleUnlocked` absent (cas résolu-undefined → plus de throw).
- **`.catch`** : stale chunk → self-heal `reloadOnceForStaleChunk()` (1×/session, même mécanisme que `lazyWithRetry`) ; sinon mode local dégradé au lieu de crasher.

### Audit complet des imports dynamiques
routes (15) + modals Landing (3) → `lazyWithRetry` ✓ · AuthCallback → `try/catch` ✓ · AuthContext principal → `.catch` ✓ · curriculum → **ce fix** ✓. Spots mineurs restants (completeLesson upsert, useUserRole import) → **THI-310** (faible proba, chemin critique, PR séparée).

### Validation
tsc + lint clean · `progress.test.tsx` 12/12 · happy path inchangé (garde passe quand les modules sont définis). Voie A : Dashboard charge bien les modules en preview.

Closes (crash) · ref THI-310 (durcissement restant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Renforcement du chargement du curriculum du contexte de progression contre les imports dynamiques instables qui faisaient planter Safari sur iOS.

Corrections de bugs :
- Empêcher les plantages lorsque les imports dynamiques du curriculum ou du déverrouillage aboutissent à des modules `undefined` ou incomplets, en particulier sur Safari iOS.
- Gérer les imports de curriculum/déverrouillage rejetés en auto-réparant les chunks obsolètes via un rechargement protégé ou en se dégradant vers un mode local uniquement, au lieu de provoquer un plantage.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden progress context curriculum loading against flaky dynamic imports that were crashing iOS Safari.

Bug Fixes:
- Prevent crashes when curriculum or unlocking dynamic imports resolve to undefined or incomplete modules, particularly on iOS Safari.
- Handle rejected curriculum/unlocking imports by self-healing stale chunks via a guarded reload or degrading to local-only mode instead of crashing.

</details>