### PR TITLE
refactor(ux): 2026 polish — FAB 48px, CTA auto-width, sidebar section labels (THI-308)

### DIFF
--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -150,11 +150,15 @@ export function Dashboard() {
       </div>
 
       {/* CTA */}
+      {/* THI-308 UX 2026 — full-width is a mobile pattern; on desktop a primary
+          pill should hug its content (sm:w-auto) so it reads as a deliberate
+          CTA rather than a stretched bar. Stays full-width at the thumb on
+          mobile. */}
       <Button
         variant="emerald"
         size="cta-pill"
         onClick={handleContinue}
-        className="w-full mb-8 min-h-11"
+        className="w-full sm:w-auto mb-8 min-h-11"
       >
         <Terminal size={18} aria-hidden="true" />
         <span>{totalCompleted === 0 ? 'Commencer l\'apprentissage' : totalCompleted === totalLessons ? 'Revoir depuis le début' : 'Continuer'}</span>

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -44,14 +44,18 @@ function isModuleExpanded(
  * promoting it to a heading would risk heading-order audit failures since the
  * sidebar <aside> is a landmark separate from the main-content heading tree.
  *
- * `className` carries only the top-padding variant so the shared typography
- * (size, tracking, mono, color) stays defined in one place.
+ * The base class holds the shared typography (size, tracking, mono, color,
+ * horizontal padding) so it stays defined in one place; `className` carries
+ * the per-usage vertical spacing (each nav cluster has its own top/bottom
+ * rhythm). This keeps the abstraction complete: every nav-zone label —
+ * Navigation, Compte & aide, Modules — routes through this component, so a
+ * future typography tweak applies to all of them at once.
  */
 function SidebarSectionLabel({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
     <p
       aria-hidden="true"
-      className={`text-xs text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pb-0.5 ${className}`}
+      className={`text-xs text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 ${className}`}
     >
       {children}
     </p>
@@ -212,7 +216,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               rhythm (NN/g grouped-sections) without the navigation cost of a
               second menu. Matches the existing "Modules"/"Environnement"
               uppercase micro-label idiom. Non-destructive: no route changes. */}
-          <SidebarSectionLabel className="pt-1">Navigation</SidebarSectionLabel>
+          <SidebarSectionLabel className="pt-1 pb-0.5">Navigation</SidebarSectionLabel>
           <NavLink
             to="/app"
             end
@@ -380,7 +384,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               )}
             </>
           )}
-          <SidebarSectionLabel className="pt-2">Compte &amp; aide</SidebarSectionLabel>
+          <SidebarSectionLabel className="pt-2 pb-0.5">Compte & aide</SidebarSectionLabel>
           <NavLink
             to="/app/settings"
             onClick={onClose}
@@ -407,14 +411,14 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               className="text-[var(--github-text-secondary)] hover:text-[var(--github-text-primary)]"
             >
               <LifeBuoy size={16} />
-              <span className="flex-1 text-left">Aide &amp; feedback</span>
+              <span className="flex-1 text-left">Aide & feedback</span>
             </Button>
           )}
         </nav>
 
         {/* Modules */}
         <div className="flex-1 overflow-y-auto p-2 space-y-1">
-          <p className="text-xs text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 py-2">Modules</p>
+          <SidebarSectionLabel className="py-2">Modules</SidebarSectionLabel>
           {curriculum.map((mod) => {
             const Icon = iconMap[mod.iconName] ?? BookOpen;
             const { completed, total } = getModuleProgress(mod.id);

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { NavLink, useNavigate, useMatch } from 'react-router';
 import { useFocusTrap } from '../../lib/hooks/useFocusTrap';
 import { useUserRole } from '../../lib/hooks/useUserRole';
@@ -32,6 +32,30 @@ function isModuleExpanded(
   activeModuleId: string | null,
 ): boolean {
   return overrides[id] ?? (id === activeModuleId);
+}
+
+/**
+ * Visual section micro-label for the sidebar nav (THI-308, NN/g grouped-sections).
+ *
+ * `aria-hidden` is intentional (Sourcery review PR #351): the nav links below
+ * are individually self-describing ("Tableau de bord", "Paramètres IA"…), so
+ * the label is a purely visual scannability aid. Exposing it to assistive tech
+ * would add a redundant pre-link announcement with no navigational value, and
+ * promoting it to a heading would risk heading-order audit failures since the
+ * sidebar <aside> is a landmark separate from the main-content heading tree.
+ *
+ * `className` carries only the top-padding variant so the shared typography
+ * (size, tracking, mono, color) stays defined in one place.
+ */
+function SidebarSectionLabel({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <p
+      aria-hidden="true"
+      className={`text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pb-0.5 ${className}`}
+    >
+      {children}
+    </p>
+  );
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
@@ -188,9 +212,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               rhythm (NN/g grouped-sections) without the navigation cost of a
               second menu. Matches the existing "Modules"/"Environnement"
               uppercase micro-label idiom. Non-destructive: no route changes. */}
-          <p className="text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pt-1 pb-0.5">
-            Navigation
-          </p>
+          <SidebarSectionLabel className="pt-1">Navigation</SidebarSectionLabel>
           <NavLink
             to="/app"
             end
@@ -358,9 +380,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               )}
             </>
           )}
-          <p className="text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pt-2 pb-0.5">
-            Compte &amp; aide
-          </p>
+          <SidebarSectionLabel className="pt-2">Compte &amp; aide</SidebarSectionLabel>
           <NavLink
             to="/app/settings"
             onClick={onClose}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -51,7 +51,7 @@ function SidebarSectionLabel({ children, className = '' }: { children: ReactNode
   return (
     <p
       aria-hidden="true"
-      className={`text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pb-0.5 ${className}`}
+      className={`text-xs text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pb-0.5 ${className}`}
     >
       {children}
     </p>
@@ -414,7 +414,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
         {/* Modules */}
         <div className="flex-1 overflow-y-auto p-2 space-y-1">
-          <p className="text-xs text-[var(--github-text-secondary)] uppercase tracking-widest px-3 py-2">Modules</p>
+          <p className="text-xs text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 py-2">Modules</p>
           {curriculum.map((mod) => {
             const Icon = iconMap[mod.iconName] ?? BookOpen;
             const { completed, total } = getModuleProgress(mod.id);

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -184,6 +184,13 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
         {/* Nav */}
         <nav className="shrink-0 p-2 border-b border-[var(--github-border-primary)] space-y-0.5">
+          {/* THI-308 UX 2026 — light section labels give the nav a scannable
+              rhythm (NN/g grouped-sections) without the navigation cost of a
+              second menu. Matches the existing "Modules"/"Environnement"
+              uppercase micro-label idiom. Non-destructive: no route changes. */}
+          <p className="text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pt-1 pb-0.5">
+            Navigation
+          </p>
           <NavLink
             to="/app"
             end
@@ -351,6 +358,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               )}
             </>
           )}
+          <p className="text-[11px] text-[var(--github-text-secondary)] uppercase tracking-widest font-mono px-3 pt-2 pb-0.5">
+            Compte &amp; aide
+          </p>
           <NavLink
             to="/app/settings"
             onClick={onClose}

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -221,6 +221,10 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role, liftAboveMobile
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-label="Ouvrir le tuteur IA (Ctrl+I)"
+        // Hover tooltip (desktop) / long-press (touch) — keeps the icon-only FAB
+        // discoverable without adding a text pill that would defeat the size
+        // reduction. The aria-label remains the screen-reader source of truth.
+        title="Tuteur IA — Ctrl+I"
         aria-expanded={open}
         aria-controls="ai-tutor-panel"
         // bottom uses max(1rem, env(safe-area-inset-bottom)) so the FAB sits
@@ -235,24 +239,23 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role, liftAboveMobile
         // a scroll-to-top FAB. So the precaution was dead weight that
         // pushed the icon awkwardly off the corner.
         //
-        // Sizing (THI-152 brick 5/9 Option D — empirical recalibration):
+        // Sizing (THI-308 UX 2026 recalibration — supersedes THI-152 brick 5/9):
         // mobile 44 px (h-11, exact Apple HIG floor — comfort kept via the
         // 100% opacity + ring + shadow rather than extra surface area),
-        // desktop 56 px (md:h-14, Material/Apple FAB primary standard
-        // empirically validated by @thierry on preview as well-proportioned
-        // for desktop density).
+        // desktop 48 px (md:h-12, Material 3 "default" FAB). The previous
+        // 56 px (md:h-14) read as visually heavy on desktop density per
+        // @thierry empirical feedback (2026-05-31) — 48 px keeps the FAB a
+        // clear primary anchor without dominating the corner.
         //
         // The asymmetry is intentional: a FAB is the only desktop button
         // exempt from the "≤40 px compact density" rule because it is the
-        // primary visual anchor of the surface. The mobile 48 → 44 revert
-        // came from @thierry empirical feedback that 12% of a 393 px
-        // viewport felt visually heavy.
+        // primary visual anchor of the surface.
         //
         // Always-100% opacity so the Sparkles is unambiguously visible on
         // every background; active:scale-95 gives a tactile press feedback
         // on touch devices that the previous hover-only affordance could
         // not deliver on Safari iOS (no hover state).
-        className={`fixed ${fabBottomClass} right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white shadow-lg ring-1 ring-black/30 transition active:scale-95 hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 md:h-14 md:w-14`}
+        className={`fixed ${fabBottomClass} right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--github-accent)] text-white shadow-lg ring-1 ring-black/30 transition active:scale-95 hover:bg-[var(--github-accent-hover)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-0 md:h-12 md:w-12`}
       >
         <Sparkles size={20} strokeWidth={2} aria-hidden="true" />
       </button>


### PR DESCRIPTION
## Contexte

Affinages UX 2026 suite au feedback @thierry (31/05) : FAB Tuteur IA trop gros sur desktop, CTA « Continuer » full-width « pas très pro », sidebar admin/super-admin peu lisible.

**Décisions argumentées (challenge demandé par @thierry) :**

| Plainte | Décision | Pourquoi |
|---|---|---|
| FAB trop gros (desktop) | 56px → **48px** (Material 3 default), icône seule + tooltip | Un pill « Tuteur IA » serait *plus* gros = contre-productif. La gêne porte sur la taille, pas la découvrabilité (couverte par le `title`). Mobile 44px inchangé. |
| CTA « pas pro » | `w-full` → **`w-full sm:w-auto`** | Le full-width est un pattern mobile ; sur desktop un pill étiré bord-à-bord fait amateur. Taille-contenu sur desktop, pleine largeur au pouce sur mobile. |
| Sidebar peu lisible | **Micro-labels de section** (Navigation / Compte & aide) — **PAS** de split 2 menus | Code-verify : la sidebar est déjà refactorée (THI-240) avec section repliable « Mes outils » regroupant les 3 entrées role-gated. Splitter en 2 menus = sur-ingénierie (coût navigation). Labels = rythme visuel cohérent avec « Modules »/« Environnement », 0 route touchée. |

## Changements
- `src/app/components/ai/AiTutorPanel.tsx` — FAB `md:h-14 md:w-14` → `md:h-12 md:w-12` + `title`
- `src/app/components/Dashboard.tsx` — CTA `w-full` → `w-full sm:w-auto`
- `src/app/components/Sidebar.tsx` — 2 micro-labels de section

## Garanties
- ✅ Non-destructif : 0 changement de route, 0 changement de logique
- ✅ type-check + lint propres
- ⏳ Validation visuelle (Voie A desktop + mobile 390px) + gates ui-auditor / code-reviewer avant merge — **rien ne merge sans OK visuel @thierry**

Réfs design 2026 : NN/g grouped-sections, Material 3 FAB sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorer l’UX 2026 en redimensionnant le FAB du tuteur IA sur desktop, en ajustant la mise en page responsive du CTA principal du tableau de bord et en améliorant la lisibilité de la navigation dans la barre latérale grâce à des labels de section.

Enhancements:
- Réduire la taille du bouton d’action flottant du tuteur IA sur desktop pour l’aligner sur la valeur par défaut de Material 3, tout en conservant la taille actuelle sur mobile.
- Faire en sorte que le bouton d’appel à l’action principal du tableau de bord soit en pleine largeur uniquement sur les petits écrans et limité à la largeur du contenu sur les écrans plus larges.
- Ajouter des labels de section légers dans la barre latérale afin de clarifier la distinction entre la navigation et les entrées compte/aide, sans modifier les routes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish 2026 UX by resizing the AI tutor FAB on desktop, adjusting the primary dashboard CTA layout responsively, and improving sidebar navigation scannability with section labels.

Enhancements:
- Reduce desktop AI tutor floating action button size to align with Material 3 default while keeping mobile sizing unchanged.
- Make the primary dashboard call-to-action button full-width only on small screens and content-width on larger screens.
- Add lightweight section labels to the sidebar to clarify navigation versus account/help entries without changing routes.

</details>