### PR TITLE
fix(reliability): harden catch-less async imports in auth/progress/role (THI-310)

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -65,6 +65,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (cancelled) return;
         setSession(data.session);
         setLoading(false);
+      }).catch(() => {
+        // getSession() can reject on a transient SDK/network error. This
+        // promise is not chained to the outer .catch below (it's fired, not
+        // returned), so without its own handler a rejection would surface as
+        // an unhandled rejection AND leave the app stuck in `loading`. Degrade
+        // to "no session" so the UI renders (THI-310).
+        if (!cancelled) setLoading(false);
       });
 
       const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
@@ -82,29 +89,42 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    const { supabase } = await supabaseLoader;
-    if (!supabase) return;
-    // Run all client-side teardown steps before clearing the session so the
-    // next user signing in on the same device sees a clean slate (defense
-    // against THI-186-class cross-account leaks via stale in-memory or
-    // localStorage state).
+    // Local logout must ALWAYS complete, even if the Supabase SDK chunk failed
+    // to load (network / stale chunk). The previous order awaited `supabaseLoader`
+    // FIRST — so a rejected loader threw before `setSession(null)` ever ran, and
+    // clicking "sign out" did nothing visible (THI-310 latent bug). We now run
+    // the client-side teardown + clear the local session UNCONDITIONALLY first.
+    //
+    // Teardown clears THI-186-class cross-account leak vectors (AI session data +
+    // in-memory role cache) so the next user on the same device sees a clean slate.
     await teardownClientState();
-    // Clear local session immediately — the UI reacts instantly.
-    // Then revoke the server-side refresh token in the background (fire-and-forget).
+    setSession(null);
+
+    // Then revoke the server-side refresh token, best-effort. A failed chunk
+    // load or a rejected revocation call must NOT resurface as an unhandled
+    // rejection — the user is already logged out locally.
     // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the
     // server-side session active, causing Supabase to re-sign the user immediately
     // via onAuthStateChange — making sign-out appear broken.
-    // We don't await the API call: the local session is already gone, and token
-    // revocation completing a few seconds later is an acceptable trade-off.
     // See: https://supabase.com/docs/reference/javascript/auth-signout
-    setSession(null);
-    supabase.auth.signOut({ scope: 'global' }).then(({ error }) => {
-      if (error) {
-        // Log revocation failures — token may still be valid server-side until expiry.
-        // Not fatal: local session is already cleared and the user is logged out in the UI.
-        console.error('[auth] signOut revocation failed:', error.message);
-      }
-    });
+    try {
+      const { supabase } = await supabaseLoader;
+      if (!supabase) return;
+      supabase.auth
+        .signOut({ scope: 'global' })
+        .then(({ error }) => {
+          if (error) {
+            // Token may still be valid server-side until expiry. Not fatal:
+            // local session is already cleared and the user is logged out in the UI.
+            console.error('[auth] signOut revocation failed:', error.message);
+          }
+        })
+        .catch((err) => {
+          console.error('[auth] signOut revocation threw (non-fatal):', err);
+        });
+    } catch {
+      // Supabase SDK chunk unavailable — local logout above already succeeded.
+    }
   }, []);
 
   return (

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -89,42 +89,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    // Local logout must ALWAYS complete, even if the Supabase SDK chunk failed
-    // to load (network / stale chunk). The previous order awaited `supabaseLoader`
-    // FIRST — so a rejected loader threw before `setSession(null)` ever ran, and
-    // clicking "sign out" did nothing visible (THI-310 latent bug). We now run
-    // the client-side teardown + clear the local session UNCONDITIONALLY first.
-    //
-    // Teardown clears THI-186-class cross-account leak vectors (AI session data +
-    // in-memory role cache) so the next user on the same device sees a clean slate.
-    await teardownClientState();
+    // Local logout FIRST so it ALWAYS completes and the UI reacts instantly,
+    // independent of the SDK chunk or teardown internals. The previous order
+    // awaited `supabaseLoader` before `setSession(null)`, so a rejected loader
+    // threw before the local logout ran (THI-310 latent bug). `setSession(null)`
+    // is ordered before teardown so the guarantee holds even if a future
+    // teardown step were to throw (Sourcery bug_risk) — `teardownClientState`
+    // is itself per-step try/caught today and clears THI-186-class cross-account
+    // vectors (AI session data + in-memory role cache) before the next user.
     setSession(null);
+    await teardownClientState();
 
-    // Then revoke the server-side refresh token, best-effort. A failed chunk
-    // load or a rejected revocation call must NOT resurface as an unhandled
-    // rejection — the user is already logged out locally.
-    // scope:'global' is required for OAuth (GitHub, Google): scope:'local' left the
-    // server-side session active, causing Supabase to re-sign the user immediately
-    // via onAuthStateChange — making sign-out appear broken.
-    // See: https://supabase.com/docs/reference/javascript/auth-signout
-    try {
-      const { supabase } = await supabaseLoader;
-      if (!supabase) return;
-      supabase.auth
-        .signOut({ scope: 'global' })
-        .then(({ error }) => {
-          if (error) {
-            // Token may still be valid server-side until expiry. Not fatal:
-            // local session is already cleared and the user is logged out in the UI.
-            console.error('[auth] signOut revocation failed:', error.message);
-          }
-        })
-        .catch((err) => {
-          console.error('[auth] signOut revocation threw (non-fatal):', err);
-        });
-    } catch {
-      // Supabase SDK chunk unavailable — local logout above already succeeded.
-    }
+    // Server-side token revocation is fire-and-forget (deliberately NOT awaited)
+    // so logout navigation stays snappy — the local session is already gone.
+    // scope:'global' is required for OAuth (GitHub, Google): scope:'local' leaves
+    // the server session active, re-signing the user via onAuthStateChange.
+    // A failed chunk load or a rejected/errored revocation must not surface as an
+    // unhandled rejection. https://supabase.com/docs/reference/javascript/auth-signout
+    void (async () => {
+      try {
+        const { supabase } = await supabaseLoader;
+        if (!supabase) return;
+        const { error } = await supabase.auth.signOut({ scope: 'global' });
+        if (error) {
+          // Token may still be valid server-side until expiry. Not fatal:
+          // local session is already cleared and the user is logged out.
+          console.error('[auth] signOut revocation failed:', error.message);
+        }
+      } catch (err) {
+        console.error('[auth] signOut revocation threw (non-fatal):', err);
+      }
+    })();
   }, []);
 
   return (

--- a/src/app/context/ProgressContext.tsx
+++ b/src/app/context/ProgressContext.tsx
@@ -423,26 +423,35 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
 
       // Fire-and-forget upsert — supabaseLoader is already resolved by the time
       // a user completes a lesson (loads within ~200 ms of app mount).
-      supabaseLoader.then(({ supabase }) => {
-        if (!supabase) return;
-        supabase.auth.getSession().then(({ data }) => {
-          if (!data.session?.user) return;
-          const userId = data.session.user.id;
-          // Promote the owner marker now that we know who is authenticated —
-          // any future sign-out / account switch will correctly clear.
-          setStoredOwner(userId);
-          supabase
-            .from('progress')
-            .upsert(
-              { user_id: userId, lesson_id: key, completed: true as const, completed_at: new Date().toISOString() },
-              { onConflict: 'user_id,lesson_id' }
-            )
-            .then(({ error }) => {
-              if (!error) setSyncStatus('synced');
-              else setSyncStatus('error');
-            });
+      // The inner promises are RETURNED so the whole chain funnels into the
+      // single `.catch` below: a rejected SDK chunk load, getSession, or upsert
+      // must not surface as an unhandled rejection (THI-310). The lesson is
+      // already persisted to localStorage above (saveProgress), so a remote
+      // failure only downgrades the sync indicator — no data is lost, and the
+      // next sync on auth change / reload reconciles.
+      supabaseLoader
+        .then(({ supabase }) => {
+          if (!supabase) return;
+          return supabase.auth.getSession().then(({ data }) => {
+            if (!data.session?.user) return;
+            const userId = data.session.user.id;
+            // Promote the owner marker now that we know who is authenticated —
+            // any future sign-out / account switch will correctly clear.
+            setStoredOwner(userId);
+            return supabase
+              .from('progress')
+              .upsert(
+                { user_id: userId, lesson_id: key, completed: true as const, completed_at: new Date().toISOString() },
+                { onConflict: 'user_id,lesson_id' }
+              )
+              .then(({ error }) => {
+                setSyncStatus(error ? 'error' : 'synced');
+              });
+          });
+        })
+        .catch(() => {
+          setSyncStatus('error');
         });
-      });
 
       return next;
     });

--- a/src/lib/hooks/useUserRole.ts
+++ b/src/lib/hooks/useUserRole.ts
@@ -43,16 +43,27 @@ async function fetchRole(userId: string): Promise<UserRole | null> {
   }
   cachedRoleUserId = userId;
   cachedRolePromise = (async () => {
-    const { supabase } = await import('@/lib/supabase');
-    if (!supabase) return null;
-    const { data, error } = await supabase.rpc('get_my_role');
-    if (error) {
-      // Don't expose the user-facing error here — the calling component
-      // will render a fallback. Logging the technical error is enough.
-      console.error('[useUserRole] get_my_role RPC failed:', error.message);
+    try {
+      const { supabase } = await import('@/lib/supabase');
+      if (!supabase) return null;
+      const { data, error } = await supabase.rpc('get_my_role');
+      if (error) {
+        // Don't expose the user-facing error here — the calling component
+        // will render a fallback. Logging the technical error is enough.
+        console.error('[useUserRole] get_my_role RPC failed:', error.message);
+        return null;
+      }
+      return data as UserRole | null;
+    } catch (err) {
+      // A rejected SDK chunk load (stale chunk / network) or a thrown RPC must
+      // NOT reject the cached promise: the caller's `.then` (in the effect
+      // below) has no `.catch`, so a rejection would surface as an unhandled
+      // rejection. Degrade to `null` — the most restrictive default (no
+      // elevated role); a genuine stale chunk self-heals on the next reload
+      // via main.tsx. THI-310.
+      console.error('[useUserRole] role resolution failed (non-fatal):', err);
       return null;
     }
-    return data as UserRole | null;
   })();
   return cachedRolePromise;
 }

--- a/src/lib/hooks/useUserRole.ts
+++ b/src/lib/hooks/useUserRole.ts
@@ -43,6 +43,16 @@ async function fetchRole(userId: string): Promise<UserRole | null> {
   }
   cachedRoleUserId = userId;
   cachedRolePromise = (async () => {
+    // Drop the cache after a TRANSIENT failure (RPC error / network reject /
+    // stale-chunk import) so the next <RequireRole> mount retries once the
+    // network recovers — rather than pinning `null` for the whole session and
+    // locking a legitimate institution_admin / super_admin out of their route
+    // until a full reload (security-auditor M1, THI-310). A `null` client
+    // (`!supabase`, missing config) is NOT transient, so it stays cached.
+    const invalidateForRetry = () => {
+      cachedRoleUserId = null;
+      cachedRolePromise = null;
+    };
     try {
       const { supabase } = await import('@/lib/supabase');
       if (!supabase) return null;
@@ -51,6 +61,7 @@ async function fetchRole(userId: string): Promise<UserRole | null> {
         // Don't expose the user-facing error here — the calling component
         // will render a fallback. Logging the technical error is enough.
         console.error('[useUserRole] get_my_role RPC failed:', error.message);
+        invalidateForRetry();
         return null;
       }
       return data as UserRole | null;
@@ -62,6 +73,7 @@ async function fetchRole(userId: string): Promise<UserRole | null> {
       // elevated role); a genuine stale chunk self-heals on the next reload
       // via main.tsx. THI-310.
       console.error('[useUserRole] role resolution failed (non-fatal):', err);
+      invalidateForRetry();
       return null;
     }
   })();

--- a/src/test/authSignoutResilience.test.tsx
+++ b/src/test/authSignoutResilience.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * THI-310 — AuthContext.signOut resilience.
+ *
+ * Two guarantees this locks:
+ *  1. Client-side teardown (THI-186-class cross-account cleanup) + local
+ *     session clear run UNCONDITIONALLY — the previous order awaited the SDK
+ *     loader first, so any failure short-circuited the teardown.
+ *  2. A rejected server-side revocation is caught (`.catch`) rather than
+ *     surfacing as an unhandled promise rejection.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.hoisted` so these mock fns exist before the hoisted vi.mock factories run.
+const { clearAi, clearRole } = vi.hoisted(() => ({
+  clearAi: vi.fn(() => Promise.resolve()),
+  clearRole: vi.fn(),
+}));
+vi.mock('../lib/ai/keyManager', () => ({ clearAiSessionData: clearAi }));
+vi.mock('../lib/hooks/useUserRole', () => ({ clearUserRoleCache: clearRole }));
+
+// SDK resolves, no session, and the revocation call REJECTS (network failure) —
+// exercises the new `.catch` around `auth.signOut()`.
+const signOutReject = vi.fn(() => Promise.reject(new Error('revocation network fail')));
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      signOut: signOutReject,
+    },
+  },
+}));
+
+import { AuthProvider, useAuth } from '../app/context/AuthContext';
+
+function Probe() {
+  const { signOut, initialized } = useAuth();
+  return (
+    <>
+      <span data-testid="ready">{initialized ? 'ready' : 'loading'}</span>
+      <button onClick={() => void signOut()}>logout</button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  clearAi.mockClear();
+  clearRole.mockClear();
+  signOutReject.mockClear();
+});
+
+describe('THI-310 AuthContext.signOut — teardown + revocation rejection are resilient', () => {
+  it('runs client-side teardown and absorbs a rejected revocation without throwing', async () => {
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('ready'));
+
+    fireEvent.click(screen.getByText('logout'));
+
+    // Teardown ran (AI session purge + role cache clear), and the rejected
+    // revocation was attempted but caught — no throw, no unhandled rejection.
+    await waitFor(() => expect(clearAi).toHaveBeenCalledOnce());
+    expect(clearRole).toHaveBeenCalledOnce();
+    await waitFor(() => expect(signOutReject).toHaveBeenCalledOnce());
+  });
+});

--- a/src/test/useUserRoleResilience.test.tsx
+++ b/src/test/useUserRoleResilience.test.tsx
@@ -7,39 +7,61 @@
  * surfacing as an unhandled promise rejection.
  *
  * After the fix the resolution is wrapped in try/catch and degrades to `null`
- * (the most restrictive default: no elevated role). This test drives the catch
- * path via a rejecting RPC and locks the clean `loading=false, role=null`
- * outcome.
+ * (the most restrictive default: no elevated role), AND a transient failure
+ * does not poison the module-level cache — the next mount retries
+ * (security-auditor M1).
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // useAuth supplies the user id that drives fetchRole. A present user is required
-// or the hook short-circuits to null without ever calling the RPC.
-vi.mock('../app/context/AuthContext', () => ({
-  useAuth: () => ({ user: { id: 'user-1' }, initialized: true }),
-}));
+// or the hook short-circuits to null without ever calling the RPC. The `user`
+// object MUST be a stable reference (defined once inside the factory) — the
+// hook's effect deps are `[user, initialized]`, so a fresh object per render
+// would thrash the effect and re-fire fetchRole on every render.
+vi.mock('../app/context/AuthContext', () => {
+  const user = { id: 'user-1' };
+  return { useAuth: () => ({ user, initialized: true }) };
+});
 
-// SDK import resolves, but the RPC rejects (transient network / SDK throw) —
-// the exact path the new try/catch must absorb.
-vi.mock('../lib/supabase', () => ({
-  supabase: {
-    rpc: vi.fn(() => Promise.reject(new Error('network: get_my_role failed'))),
-  },
-}));
+// Expose the RPC mock so each test can program its per-call behaviour.
+const { rpc } = vi.hoisted(() => ({ rpc: vi.fn() }));
+vi.mock('../lib/supabase', () => ({ supabase: { rpc } }));
 
 import { clearUserRoleCache, useUserRole } from '../lib/hooks/useUserRole';
 
 beforeEach(() => {
   // The role cache is module-level; clear it so each test re-runs fetchRole.
   clearUserRoleCache();
+  rpc.mockReset();
 });
 
-describe('THI-310 useUserRole — graceful degradation when the role RPC rejects', () => {
+describe('THI-310 useUserRole — graceful degradation + self-healing cache', () => {
   it('resolves to role=null instead of rejecting when get_my_role throws', async () => {
+    rpc.mockRejectedValue(new Error('network: get_my_role failed'));
+
     const { result } = renderHook(() => useUserRole());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.role).toBeNull();
+  });
+
+  it('retries on the next mount after a transient failure (cache not poisoned)', async () => {
+    // First mount: the RPC keeps rejecting (transient outage).
+    rpc.mockRejectedValue(new Error('transient network'));
+
+    const first = renderHook(() => useUserRole());
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.role).toBeNull();
+    first.unmount();
+
+    // Network recovers. The catch released the module cache, so a fresh mount
+    // re-fetches and recovers the real role rather than staying pinned on the
+    // failed `null`.
+    rpc.mockReset();
+    rpc.mockResolvedValue({ data: 'super_admin', error: null });
+
+    const second = renderHook(() => useUserRole());
+    await waitFor(() => expect(second.result.current.role).toBe('super_admin'));
   });
 });

--- a/src/test/useUserRoleResilience.test.tsx
+++ b/src/test/useUserRoleResilience.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * THI-310 — useUserRole resilience.
+ *
+ * `fetchRole` does `await import('@/lib/supabase')` then awaits the
+ * `get_my_role` RPC. Before the fix, a thrown RPC (network reject) or a
+ * rejected SDK chunk import propagated to the hook's catch-less `.then`,
+ * surfacing as an unhandled promise rejection.
+ *
+ * After the fix the resolution is wrapped in try/catch and degrades to `null`
+ * (the most restrictive default: no elevated role). This test drives the catch
+ * path via a rejecting RPC and locks the clean `loading=false, role=null`
+ * outcome.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// useAuth supplies the user id that drives fetchRole. A present user is required
+// or the hook short-circuits to null without ever calling the RPC.
+vi.mock('../app/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' }, initialized: true }),
+}));
+
+// SDK import resolves, but the RPC rejects (transient network / SDK throw) —
+// the exact path the new try/catch must absorb.
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(() => Promise.reject(new Error('network: get_my_role failed'))),
+  },
+}));
+
+import { clearUserRoleCache, useUserRole } from '../lib/hooks/useUserRole';
+
+beforeEach(() => {
+  // The role cache is module-level; clear it so each test re-runs fetchRole.
+  clearUserRoleCache();
+});
+
+describe('THI-310 useUserRole — graceful degradation when the role RPC rejects', () => {
+  it('resolves to role=null instead of rejecting when get_my_role throws', async () => {
+    const { result } = renderHook(() => useUserRole());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.role).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexte

Reliquat du fix de fiabilité progression #349. Le crash de l'import curriculum a été corrigé, mais le code-verify (doctrine) a révélé **3 autres chaînes async catch-less** dans des contextes critiques — dont une cachant un **bug latent**.

## Changements (3 fichiers source + 2 tests)

| Fichier | Trou | Fix |
|---|---|---|
| `AuthContext.tsx` `signOut` | 🔴 `await supabaseLoader` en premier → si le chunk SDK échoue, `setSession(null)` n'est jamais atteint (le teardown cross-account THI-186 non plus) | teardown + `setSession(null)` **inconditionnels d'abord**, révocation serveur best-effort en try/catch (+ `.catch`) |
| `AuthContext.tsx` init | ⚠️ `getSession().then` sans `.catch` (non chaîné au `.catch` externe) | `.catch` → `setLoading(false)` (pas de spinner bloqué) |
| `ProgressContext.tsx` `completeLesson` | ⚠️ `supabaseLoader.then` + `getSession().then` + `upsert().then` sans `.catch` | promesses chaînées (return) → un seul `.catch` → `syncStatus='error'` (leçon déjà en localStorage, 0 perte) |
| `useUserRole.ts` `fetchRole` | ⚠️ `import()` + RPC sans try/catch → promesse cachée rejette → rejet non géré | try/catch → dégrade en `null` (rôle le plus restrictif) **+ cache auto-réparant** (retry au prochain mount sur échec transitoire, M1) |

Les stale-chunks restent auto-réparés par les 3 couches de `main.tsx` (`vite:preloadError` + `unhandledrejection`) — ces `.catch` couvrent les échecs **non-stale** (réseau/transitoire) qui devenaient des rejets non gérés.

## Gates (tous verts)
- **security-auditor : 9.5/10**, 0 CRITICAL / 0 HIGH — vérifié : ordering teardown THI-186 (corrige un bug latent réel), fail-safe RBAC `null` (aucune élévation), défense stale-chunk préservée, 0 PII dans les logs. M1 (auto-réparation cache) appliqué.
- **feature-dev:code-reviewer : ship**, 0 finding — race cache / `setSyncStatus` / teardown idempotent tous tracés clean.
- **+3 tests** : dégradation `useUserRole`→null, self-heal retry, teardown `signOut` + révocation rejetée absorbée. Suite complète 1933 pass (1 flaky d'intégration prod sous charge — passe en isolation, non lié).

## Validation
- type-check + lint clean
- ⏳ Logic-only (0 changement visuel). Smoke preview à venir + validation @thierry (le flow logout reste à confirmer côté browser connecté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Renforcement des flux d’authentification, de synchronisation de la progression et de résolution des rôles contre les rejets non gérés et les imports asynchrones échoués afin d’améliorer la fiabilité en cas d’erreurs et de chunks obsolètes.

Corrections de bugs :
- Garantir que la déconnexion dans `AuthContext` efface toujours la session locale et l’état de teardown, même si le chunk du SDK Supabase ne parvient pas à se charger ou si la révocation côté serveur échoue (rejet).
- Empêcher `ProgressContext` de faire fuiter des rejets non gérés lors de la validation de leçon en canalisant les erreurs du loader Supabase, de récupération de session et de `upsert` dans un chemin d’erreur unique et géré qui se contente de rétrograder le statut de synchronisation.
- Éviter de laisser l’application bloquée dans un état de chargement en gérant les rejets transitoires de `AuthContext.getSession` et en réinitialisant le flag de chargement.
- S’assurer que `useUserRole` se dégrade de façon élégante vers le rôle le plus restrictif en cas d’échec d’import/RPC Supabase, au lieu d’exposer des rejets non gérés.

Améliorations :
- Rendre le cache du rôle utilisateur auto-réparateur en l’invalidant lors de défaillances transitoires afin que la résolution des rôles soit réessayée lors des montages suivants.

Tests :
- Ajouter des tests de résilience pour la déconnexion d’`AuthContext` afin de vérifier que le teardown s’exécute toujours et que les échecs de révocation sont absorbés sans lancer d’exception.
- Ajouter des tests de résilience pour `useUserRole` afin de couvrir la dégradation vers `null` et l’auto-réparation du cache après des défaillances transitoires.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden auth, progress syncing, and role resolution flows against unhandled rejections and failed async imports to improve reliability in error and stale-chunk scenarios.

Bug Fixes:
- Ensure AuthContext sign-out always clears local session and teardown state even if the Supabase SDK chunk fails to load or server-side revocation rejects.
- Prevent ProgressContext lesson completion from leaking unhandled rejections by funneling Supabase loader, session fetch, and upsert errors into a single handled error path that only downgrades sync status.
- Avoid leaving the app stuck in a loading state by handling transient AuthContext getSession rejections and clearing the loading flag.
- Ensure useUserRole gracefully degrades to the most restrictive role on Supabase import/RPC failures instead of surfacing unhandled rejections.

Enhancements:
- Make the user role cache self-healing by invalidating it on transient failures so role resolution is retried on subsequent mounts.

Tests:
- Add resilience tests for AuthContext sign-out to verify teardown always runs and revocation failures are absorbed without throwing.
- Add resilience tests for useUserRole to cover degradation to null and cache self-healing after transient failures.

</details>