### PR TITLE
fix(lesson): reachable Prev/Next nav from terminal pane on mobile (THI-313)

### DIFF
--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -92,6 +92,63 @@ function BlockRenderer({ block, env = 'linux' }: { block: ContentBlock; env?: En
   }
 }
 
+// Shared Précédent / Suivant (or Dashboard) navigation. Rendered in two places
+// (THI-313): the desktop in-content footer AND a mobile-only persistent footer,
+// so navigation is reachable from BOTH mobile panes (Contenu + Terminal). One
+// definition keeps the two in sync.
+type LessonTarget = { moduleId: string; lessonId: string } | null;
+function LessonNav({
+  prevLesson,
+  nextLesson,
+  onNavigate,
+  onDashboard,
+}: {
+  prevLesson: LessonTarget;
+  nextLesson: LessonTarget;
+  onNavigate: (target: LessonTarget) => void;
+  onDashboard: () => void;
+}) {
+  return (
+    <>
+      <Button
+        type="button"
+        variant="nav-link"
+        size="tl-nav-inline"
+        onClick={() => onNavigate(prevLesson)}
+        disabled={!prevLesson}
+        className="gap-2 -ml-2 disabled:opacity-30"
+      >
+        <ChevronLeft className="size-4" aria-hidden="true" />
+        <span>Précédent</span>
+      </Button>
+
+      {nextLesson ? (
+        <Button
+          type="button"
+          variant="emerald-soft"
+          size="tl-nav-cta"
+          onClick={() => onNavigate(nextLesson)}
+          aria-label="Passer à la leçon suivante"
+        >
+          <span>Suivant</span>
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="emerald-soft"
+          size="tl-nav-cta"
+          onClick={onDashboard}
+          aria-label="Retour au tableau de bord"
+        >
+          <span>Tableau de bord</span>
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </Button>
+      )}
+    </>
+  );
+}
+
 // Separated so the parent can remount it with a key when the lesson changes,
 // resetting all local state without needing useEffect + setState.
 function LessonContent({ mod, lesson, moduleId, lessonId }: {
@@ -156,7 +213,9 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
   const effectiveInstruction =
     lesson.exercise?.instructionByEnv?.[selectedEnv] ?? lesson.exercise?.instruction ?? '';
   const welcomeMessage = lesson.exercise
-    ? [`📚 ${lesson.title}`, ``, `Exercice : ${effectiveInstruction}`, ``]
+    ? exerciseCompleted
+      ? [`📚 ${lesson.title}`, ``, `✓ Exercice déjà complété — « Suivant » pour continuer, ou pratique librement ci-dessous.`, ``]
+      : [`📚 ${lesson.title}`, ``, `Exercice : ${effectiveInstruction}`, ``]
     : [`📚 ${lesson.title}`, ``, `Terminal libre — pratiquez les commandes ci-dessous.`, ``];
 
   return (
@@ -281,43 +340,16 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
             )}
           </div>
 
-          {/* Navigation */}
-          <div className="shrink-0 border-t border-[var(--github-border-primary)] px-5 py-4 flex items-center justify-between">
-            <Button
-              type="button"
-              variant="nav-link"
-              size="tl-nav-inline"
-              onClick={() => handleNavigate(prevLesson)}
-              disabled={!prevLesson}
-              className="gap-2 -ml-2 disabled:opacity-30"
-            >
-              <ChevronLeft className="size-4" aria-hidden="true" />
-              <span>Précédent</span>
-            </Button>
-
-            {nextLesson ? (
-              <Button
-                type="button"
-                variant="emerald-soft"
-                size="tl-nav-cta"
-                onClick={() => handleNavigate(nextLesson)}
-                aria-label="Passer à la leçon suivante"
-              >
-                <span>Suivant</span>
-                <ChevronRight className="size-4" aria-hidden="true" />
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="emerald-soft"
-                size="tl-nav-cta"
-                onClick={() => navigate('/app')}
-                aria-label="Retour au tableau de bord"
-              >
-                <span>Tableau de bord</span>
-                <ChevronRight className="size-4" aria-hidden="true" />
-              </Button>
-            )}
+          {/* Navigation — desktop only. On mobile the content pane is hidden
+              when the terminal pane is active, so navigation lives in the
+              persistent mobile footer below (THI-313). */}
+          <div className="hidden lg:flex shrink-0 border-t border-[var(--github-border-primary)] px-5 py-4 items-center justify-between">
+            <LessonNav
+              prevLesson={prevLesson}
+              nextLesson={nextLesson}
+              onNavigate={handleNavigate}
+              onDashboard={() => navigate('/app')}
+            />
           </div>
         </div>
 
@@ -352,6 +384,19 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
             environment={selectedEnv}
           />
         </div>
+      </div>
+
+      {/* Mobile-only persistent navigation (THI-313). The desktop nav lives
+          inside the content pane, which is hidden when the terminal pane is
+          active on mobile — without this footer, Précédent/Suivant would be
+          unreachable from the terminal view. shrink-0 so it never scrolls away. */}
+      <div className="lg:hidden shrink-0 border-t border-[var(--github-border-primary)] px-4 py-3 flex items-center justify-between bg-[var(--github-bg)] pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <LessonNav
+          prevLesson={prevLesson}
+          nextLesson={nextLesson}
+          onNavigate={handleNavigate}
+          onDashboard={() => navigate('/app')}
+        />
       </div>
     </div>
   );

--- a/src/app/components/LessonPage.tsx
+++ b/src/app/components/LessonPage.tsx
@@ -390,7 +390,7 @@ function LessonContent({ mod, lesson, moduleId, lessonId }: {
           inside the content pane, which is hidden when the terminal pane is
           active on mobile — without this footer, Précédent/Suivant would be
           unreachable from the terminal view. shrink-0 so it never scrolls away. */}
-      <div className="lg:hidden shrink-0 border-t border-[var(--github-border-primary)] px-4 py-3 flex items-center justify-between bg-[var(--github-bg)] pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+      <div className="lg:hidden shrink-0 border-t border-[var(--github-border-primary)] px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] flex items-center justify-between bg-[var(--github-bg)]">
         <LessonNav
           prevLesson={prevLesson}
           nextLesson={nextLesson}

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -207,11 +207,14 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role, liftAboveMobile
 
   if (!enabled) return null;
 
-  // On touch viewports inside a lesson, raise the FAB above the terminal mobile
-  // key bar (~57px) so it never overlaps it. Desktop / non-lesson pages keep the
-  // standard bottom-right corner anchor.
+  // On touch viewports inside a lesson, raise the FAB above the bottom chrome:
+  // the terminal mobile key bar (~57px) AND the persistent lesson nav footer
+  // (THI-313, ~68px non-notch / ~90px notch PWA). +5rem (80px) keeps a clear
+  // gap above the footer nav on notched iPhones in standalone mode (≈24px),
+  // not just the ≈8px that +4rem left. Desktop / non-lesson pages keep the
+  // standard bottom-right corner anchor. (Real-iPhone validation pending.)
   const fabBottomClass = liftAboveMobileBar
-    ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] [@media(pointer:coarse)]:bottom-[calc(max(1rem,env(safe-area-inset-bottom))+4rem)]'
+    ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] [@media(pointer:coarse)]:bottom-[calc(max(1rem,env(safe-area-inset-bottom))+5rem)]'
     : 'bottom-[max(1rem,env(safe-area-inset-bottom))]';
 
   return (

--- a/src/app/components/ai/AiTutorPanel.tsx
+++ b/src/app/components/ai/AiTutorPanel.tsx
@@ -207,14 +207,16 @@ export function AiTutorPanel({ lang = 'fr', lessonContext, role, liftAboveMobile
 
   if (!enabled) return null;
 
-  // On touch viewports inside a lesson, raise the FAB above the bottom chrome:
-  // the terminal mobile key bar (~57px) AND the persistent lesson nav footer
-  // (THI-313, ~68px non-notch / ~90px notch PWA). +5rem (80px) keeps a clear
-  // gap above the footer nav on notched iPhones in standalone mode (≈24px),
-  // not just the ≈8px that +4rem left. Desktop / non-lesson pages keep the
-  // standard bottom-right corner anchor. (Real-iPhone validation pending.)
+  // Inside a lesson, raise the FAB above the bottom chrome: the terminal mobile
+  // key bar (~57px, touch only) AND the persistent lesson nav footer (THI-313,
+  // shown on every `<lg` viewport). The lift is keyed on the SAME breakpoint as
+  // that footer (`lg:hidden`) — NOT on `pointer:coarse` — because the footer
+  // also shows on narrow fine-pointer viewports (a resized desktop window),
+  // where a coarse-only lift left the FAB overlapping the "Suivant" button.
+  // +5rem (80px) clears the footer with a comfortable gap; reset to the corner
+  // anchor at `lg` (no footer there). Real-iPhone PWA validation still pending.
   const fabBottomClass = liftAboveMobileBar
-    ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] [@media(pointer:coarse)]:bottom-[calc(max(1rem,env(safe-area-inset-bottom))+5rem)]'
+    ? 'bottom-[calc(max(1rem,env(safe-area-inset-bottom))+5rem)] lg:bottom-[max(1rem,env(safe-area-inset-bottom))]'
     : 'bottom-[max(1rem,env(safe-area-inset-bottom))]';
 
   return (


### PR DESCRIPTION
## Problème (signalé + code-vérifié @thierry)

Sur mobile (`<lg`), `LessonPage` bascule entre **Contenu** et **Terminal** (défaut = Terminal). La nav **Précédent/Suivant** vivait **uniquement dans le panneau Contenu** → depuis le terminal, impossible d'avancer sans rebasculer + scroller. Friction sur ~50% du trafic.

## Fix (LessonPage.tsx uniquement, 0 changement desktop)
- **`LessonNav`** extrait (Précédent / Suivant | Tableau de bord) — composant partagé, **DRY**.
- Nav in-content → **`hidden lg:flex`** (desktop strictement inchangé).
- **Footer nav `lg:hidden`** persistant au niveau racine → atteignable depuis **les 2 panneaux mobiles**. `pb-[max(.75rem,env(safe-area-inset-bottom))]` pour le home indicator iPhone (PWA).
- **Cue leçon complétée** : si l'exercice est déjà fait, le terminal affiche « ✓ Exercice déjà complété — Suivant pour continuer » au lieu de l'instruction (le cas exact qui a dérouté @thierry sur une leçon re-visitée).

## Gates prévus
ui-auditor + mobile-responsive-auditor + feature-dev:code-reviewer + **Voie A mobile 390px** (0 overflow, nav atteignable terminal + contenu, desktop préservé).

THI-313. Concern UI séparé de l'audit contenu/validateurs (ticket B à venir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Rendre la navigation de leçon accessible depuis les volets contenu et terminal sur mobile tout en préservant le comportement sur ordinateur.

Nouvelles fonctionnalités :
- Afficher une barre de navigation mobile persistante en bas pour les leçons afin que les actions Prev/Suivant/Dashboard soient toujours accessibles depuis les vues contenu et terminal.
- Afficher un message d’indication de complétion dans le terminal lorsque l’exercice en cours a déjà été terminé.

Améliorations :
- Extraire la navigation de leçon partagée dans un composant réutilisable `LessonNav` utilisé à la fois par les mises en page bureau et mobile.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make lesson navigation reachable from both content and terminal panes on mobile while preserving desktop behavior.

New Features:
- Show a persistent mobile footer navigation for lessons so Prev/Suivant/Dashboard actions are always accessible from both content and terminal views.
- Display a completion cue message in the terminal when the current exercise has already been completed.

Enhancements:
- Extract shared lesson navigation into a reusable LessonNav component used by both desktop and mobile layouts.

</details>