### PR TITLE
fix(auth): [HOTFIX] await sign-out so the persisted session is cleared before nav

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -100,26 +100,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSession(null);
     await teardownClientState();
 
-    // Server-side token revocation is fire-and-forget (deliberately NOT awaited)
-    // so logout navigation stays snappy — the local session is already gone.
+    // AWAIT the real sign-out — do NOT fire-and-forget (HOTFIX 2026-06-01).
+    // `supabase.auth.signOut()` is what removes the PERSISTED session token from
+    // localStorage. The previous fire-and-forget version returned before that
+    // ran, so the caller (UserMenu) navigated to the landing while the token
+    // still existed — `autoRefreshToken` + `onAuthStateChange` then restored the
+    // session and the user stayed logged in on the landing after clicking
+    // "Se déconnecter" (reported by @thierry). Awaiting closes that window so the
+    // token is gone before navigation. The instant UI feedback is still given by
+    // `setSession(null)` above, so the brief network wait isn't user-visible.
     // scope:'global' is required for OAuth (GitHub, Google): scope:'local' leaves
     // the server session active, re-signing the user via onAuthStateChange.
-    // A failed chunk load or a rejected/errored revocation must not surface as an
-    // unhandled rejection. https://supabase.com/docs/reference/javascript/auth-signout
-    void (async () => {
-      try {
-        const { supabase } = await supabaseLoader;
-        if (!supabase) return;
-        const { error } = await supabase.auth.signOut({ scope: 'global' });
-        if (error) {
-          // Token may still be valid server-side until expiry. Not fatal:
-          // local session is already cleared and the user is logged out.
-          console.error('[auth] signOut revocation failed:', error.message);
-        }
-      } catch (err) {
-        console.error('[auth] signOut revocation threw (non-fatal):', err);
-      }
-    })();
+    // Errors are logged, not thrown — local state is already cleared.
+    // https://supabase.com/docs/reference/javascript/auth-signout
+    try {
+      const { supabase } = await supabaseLoader;
+      if (!supabase) return;
+      const { error } = await supabase.auth.signOut({ scope: 'global' });
+      if (error) console.error('[auth] signOut revocation failed:', error.message);
+    } catch (err) {
+      console.error('[auth] signOut revocation threw (non-fatal):', err);
+    }
   }, []);
 
   return (

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -100,24 +100,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSession(null);
     await teardownClientState();
 
-    // AWAIT the real sign-out — do NOT fire-and-forget (HOTFIX 2026-06-01).
-    // `supabase.auth.signOut()` is what removes the PERSISTED session token from
-    // localStorage. The previous fire-and-forget version returned before that
-    // ran, so the caller (UserMenu) navigated to the landing while the token
-    // still existed — `autoRefreshToken` + `onAuthStateChange` then restored the
-    // session and the user stayed logged in on the landing after clicking
-    // "Se déconnecter" (reported by @thierry). Awaiting closes that window so the
-    // token is gone before navigation. The instant UI feedback is still given by
-    // `setSession(null)` above, so the brief network wait isn't user-visible.
-    // scope:'global' is required for OAuth (GitHub, Google): scope:'local' leaves
-    // the server session active, re-signing the user via onAuthStateChange.
-    // Errors are logged, not thrown — local state is already cleared.
-    // https://supabase.com/docs/reference/javascript/auth-signout
+    // Await the revocation so the persisted session token is cleared BEFORE the
+    // caller navigates — a fire-and-forget revoke let autoRefreshToken restore
+    // the session on the next page (incident detail in the commit message +
+    // ticket). Bounded by a timeout so a hung network never leaves signOut
+    // pending: gotrue-js removes the local token before its network call, so
+    // proceeding on timeout is safe. scope:'global' is required for OAuth.
     try {
       const { supabase } = await supabaseLoader;
       if (!supabase) return;
-      const { error } = await supabase.auth.signOut({ scope: 'global' });
-      if (error) console.error('[auth] signOut revocation failed:', error.message);
+      await Promise.race([
+        supabase.auth.signOut({ scope: 'global' }).then(({ error }) => {
+          if (error) console.error('[auth] signOut revocation failed:', error.message);
+        }),
+        new Promise<void>((resolve) => setTimeout(resolve, 4000)),
+      ]);
     } catch (err) {
       console.error('[auth] signOut revocation threw (non-fatal):', err);
     }


### PR DESCRIPTION
## Incident
@thierry (01/06/2026) : cliquer **« Se déconnecter »** dans `/app` le laisse **connecté sur la landing page**. Console propre (« Aucun problème ») → la révocation ne plante pas, c'est un problème de **timing**.

## Root cause
`signOut` lançait la révocation serveur `supabase.auth.signOut({scope:'global'})` en **fire-and-forget** (approche THI-310, « snappy »). `await signOut()` rendait donc la main **avant** que le SDK n'efface le **token persisté en localStorage**. Le caller (`UserMenu`) navigait alors vers la landing SPA pendant que le token existait encore → `autoRefreshToken` + `onAuthStateChange((_e,s) => setSession(s))` **restauraient la session**.

## Fix (1 fichier, 1 fonction)
`AuthContext.signOut` : la révocation passe de fire-and-forget à **`await`**. Le token est effacé (+ timer autoRefresh stoppé, `SIGNED_OUT` émis) **avant** que le caller navigue. Feedback UI instantané préservé par `setSession(null)` en tête. Erreurs loggées, pas throw.

## Gates
- security-auditor : **8.5/10**, 0 CRITICAL / 0 HIGH — renforce la posture THI-186 (un token périmé ne survit plus au clic logout). M1 (timeout réseau, optionnel) + L1 (UserMenu await-before-navigate ✓ déjà le cas) non bloquants.
- authSignoutResilience.test.tsx ✓ passe.
- ⏳ Voie A empirique via compte test (login → logout → vérifier déconnecté sur landing).

Hotfix scope chirurgical (1 fichier). Concern séparé de THI-313 (#354, flux leçon mobile, en pause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Corrections de bugs :
- Correction du flux de déconnexion où les utilisateurs pouvaient rester connectés sur la page d’accueil en raison d’une opération de déconnexion « fire-and-forget » qui laissait le jeton de session persistant temporairement valide.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix logout flow where users could remain logged in on the landing page due to fire-and-forget sign-out that left the persisted session token temporarily valid.

</details>