### PR TITLE
fix(sentry): drop crawler/bot events to cut noise (THI-317)

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -37,6 +37,17 @@ export function createScrubString(patterns: typeof SCRUB_PATTERNS) {
   };
 }
 
+// Crawler / bot detection for Sentry noise filtering. Bots execute the SPA's JS
+// only partially and trip guards that never fire for real users (e.g. Applebot
+// resolving the curriculum dynamic import with an incomplete module namespace —
+// THI-316 guard). Exported so the pattern is unit-tested. The `bot` token covers
+// Googlebot / bingbot / Applebot / etc.; the rest catch crawlers that don't use
+// it (Yahoo Slurp, Google Mediapartners, facebookexternalhit).
+const CRAWLER_UA_RX = /bot|crawl|spider|slurp|mediapartners|facebookexternalhit/i;
+export function isCrawlerUserAgent(ua: string | undefined | null): boolean {
+  return !!ua && CRAWLER_UA_RX.test(ua);
+}
+
 export function initSentry() {
   if (!dsn) return;
 
@@ -50,6 +61,13 @@ export function initSentry() {
     // Don't send events in development unless DSN is explicitly set
     enabled: import.meta.env.PROD,
     beforeSend(event: Sentry.ErrorEvent) {
+      // Drop events from crawlers / bots (see isCrawlerUserAgent). Verified
+      // Applebot-only via Sentry (2 events / 7d, 0 real users) before adding
+      // this filter; no real-user telemetry is lost.
+      if (typeof navigator !== 'undefined' && isCrawlerUserAgent(navigator.userAgent)) {
+        return null;
+      }
+
       // Drop EvalError: CSP correctly blocking eval() calls — not app bugs
       const evalErr = 'Eval' + 'Error';
       if (event.exception?.values?.some((e) => e.type === evalErr)) return null;

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -40,10 +40,15 @@ export function createScrubString(patterns: typeof SCRUB_PATTERNS) {
 // Crawler / bot detection for Sentry noise filtering. Bots execute the SPA's JS
 // only partially and trip guards that never fire for real users (e.g. Applebot
 // resolving the curriculum dynamic import with an incomplete module namespace —
-// THI-316 guard). Exported so the pattern is unit-tested. The `bot` token covers
-// Googlebot / bingbot / Applebot / etc.; the rest catch crawlers that don't use
-// it (Yahoo Slurp, Google Mediapartners, facebookexternalhit).
-const CRAWLER_UA_RX = /bot|crawl|spider|slurp|mediapartners|facebookexternalhit/i;
+// THI-316 guard). Exported so the pattern is unit-tested.
+//
+// NB: we match an explicit list of crawler NAMES rather than a bare `bot`
+// substring — `bot` would false-positive on real devices like "Cubot" (an
+// Android brand). A `\bbot\b` word boundary doesn't work either: in "Googlebot"
+// the "bot" suffix has no boundary before it, so it would MISS the real bots.
+// Hence the curated name list + generic crawler keywords. (code-reviewer THI-317)
+const CRAWLER_UA_RX =
+  /applebot|googlebot|bingbot|yandex(?:bot)?|duckduckbot|baiduspider|ahrefsbot|semrushbot|petalbot|bytespider|gptbot|claudebot|ccbot|crawler|crawl|spider|slurp|mediapartners|facebookexternalhit|telegrambot|discordbot|whatsapp/i;
 export function isCrawlerUserAgent(ua: string | undefined | null): boolean {
   return !!ua && CRAWLER_UA_RX.test(ua);
 }

--- a/src/test/sentryBotFilter.test.ts
+++ b/src/test/sentryBotFilter.test.ts
@@ -18,10 +18,20 @@ describe('isCrawlerUserAgent — Sentry bot noise filter (THI-317)', () => {
     expect(isCrawlerUserAgent('facebookexternalhit/1.1')).toBe(true);
   });
 
+  it('detects AI crawlers (GPTBot / ClaudeBot)', () => {
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; GPTBot/1.0; +https://openai.com/gptbot)')).toBe(true);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)')).toBe(true);
+  });
+
   it('does NOT flag real desktop / mobile browsers', () => {
     expect(isCrawlerUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15')).toBe(false);
     expect(isCrawlerUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1')).toBe(false);
     expect(isCrawlerUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36')).toBe(false);
+  });
+
+  it('does NOT flag real devices whose name merely contains "bot" (e.g. Cubot)', () => {
+    // code-reviewer THI-317: a bare `bot` substring would false-positive here.
+    expect(isCrawlerUserAgent('Mozilla/5.0 (Linux; Android 10; Cubot Note 20 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36')).toBe(false);
   });
 
   it('handles empty / undefined / null safely', () => {

--- a/src/test/sentryBotFilter.test.ts
+++ b/src/test/sentryBotFilter.test.ts
@@ -1,0 +1,32 @@
+/**
+ * THI-317 — Sentry crawler/bot noise filter.
+ *
+ * Standalone test file (NOT added to sentry.test.ts) on purpose: that file holds
+ * synthetic API-key fixtures for the scrubber, and the pre-commit credential
+ * hook scans whole staged files — re-staging it would false-positive. This file
+ * contains only User-Agent strings (no secrets), so it commits cleanly.
+ */
+import { describe, it, expect } from 'vitest';
+import { isCrawlerUserAgent } from '@/lib/sentry';
+
+describe('isCrawlerUserAgent — Sentry bot noise filter (THI-317)', () => {
+  it('detects common crawlers', () => {
+    expect(isCrawlerUserAgent('Mozilla/5.0 (Macintosh) AppleWebKit/600 (KHTML, like Gecko) Applebot/0.1')).toBe(true);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')).toBe(true);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)')).toBe(true);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)')).toBe(true);
+    expect(isCrawlerUserAgent('facebookexternalhit/1.1')).toBe(true);
+  });
+
+  it('does NOT flag real desktop / mobile browsers', () => {
+    expect(isCrawlerUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15')).toBe(false);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1')).toBe(false);
+    expect(isCrawlerUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36')).toBe(false);
+  });
+
+  it('handles empty / undefined / null safely', () => {
+    expect(isCrawlerUserAgent('')).toBe(false);
+    expect(isCrawlerUserAgent(undefined)).toBe(false);
+    expect(isCrawlerUserAgent(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Contexte
Follow-up THI-316. Sentry a remonté la garde « curriculum bundle resolved with an incomplete module namespace » → vérifié via Sentry MCP : **2 events / 7j, 100% Applebot, 0 vrai utilisateur**. Les bots exécutent le JS partiellement → déclenchent des gardes inoffensives pour de vrais users → bruit qui grossira avec le crawl SEO.

## Fix
- `isCrawlerUserAgent(ua)` exporté + testé, appelé **en tête de `beforeSend`** → drop des events bots avant tout traitement.
- **Ne touche PAS le scrubber PII/secrets** — pur filtre de bruit en amont. 0 télémétrie vrai-user perdue ; navigateurs desktop/mobile réels non matchés (testé).
- Tests dans `sentryBotFilter.test.ts` **dédié** (UA only) — pas dans `sentry.test.ts` (ses fixtures synthétiques font faux-positif le hook credentials au re-stage ; **hook respecté, pas de `--no-verify`**).

## Gates
feature-dev:code-reviewer + CI + smoke. Changement **non-visuel** (config error-reporting) → pas de Voie A. security-auditor non requis (hors scrubber/auth/crypto). **Pas de merge sans ton go** (sentry security-adjacent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)