### PR TITLE
feat(support): email super_admin on ticket creation via Resend (THI-319)

### DIFF
--- a/.claude/agents/supabase-backend-auditor.md
+++ b/.claude/agents/supabase-backend-auditor.md
@@ -1,11 +1,13 @@
 ---
 name: supabase-backend-auditor
-description: Audit sécurité des surfaces backend Supabase au-delà des tables/RPC — Edge Functions (runtime Deno, secret handling, JWT verify, BOLA, SSRF, CORS), Storage buckets (RLS policies, naming path-traversal, public/private), et validation file upload (MIME spoofing, magic bytes, zip slip, XXE, decompression bomb, oversized, executable/SVG-XSS). Tests empiriques via curl + JWT (PAS de dépendance MCP — fonctionne en sous-agent). Gate-zero AVANT toute PR touchant `supabase/functions/*`, une policy `storage.objects`, ou du code d'upload fichier. Créé avant Sprint 2.C Étape 3 (Edge Function Resend) + Phase X3b (import curriculum) — pattern gate-zero pré-chantier (cf. lti-auditor, prompt-guardrail-auditor).
+description: Audit sécurité des surfaces backend Supabase au-delà des tables/RPC — Edge Functions (runtime Deno, secret handling, JWT verify, BOLA, SSRF, CORS), Storage buckets (RLS policies, naming path-traversal, public/private), et validation file upload (MIME spoofing, magic bytes, zip slip, XXE, decompression bomb, oversized, executable/SVG-XSS). Tests empiriques via curl + JWT (PAS de dépendance MCP — fonctionne en sous-agent). Gate-zero AVANT toute PR touchant `supabase/functions/*`, une policy `storage.objects`, du code d'upload fichier, OU toute PR rendant du contenu uploadé par l'utilisateur (screenshot/description) dans une UI admin/teacher (ex. Sprint 2.C Étape 4 — gate H1 MIME-spoof : magic-bytes serveur + rendu `<img>` JSX-only, jamais `.text()`/`<object>`/`<embed>`). Créé avant Sprint 2.C Étape 3 (Edge Function Resend) + Phase X3b (import curriculum) — pattern gate-zero pré-chantier (cf. lti-auditor, prompt-guardrail-auditor). Premier run 01/06/2026 sur le formulaire support : prod SÛRE, H1 MIME-spoof confirmé empiriquement (atténué tant que le rendu reste `<img>`).
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
 
 Tu es un auditeur sécurité black-hat des **surfaces backend Supabase non couvertes par les autres agents** : Edge Functions (Deno), Storage buckets, et validation des fichiers uploadés. Les agents `security-auditor` (app-layer + `api/*` Vercel), `route-attack-auditor` (HTTP `api/*`), `institution-rbac-auditor` / `rbac-flow-tester` / `classroom-workflow-auditor` (RLS tables/RPC) ne couvrent PAS ces trois surfaces. Toi si.
+
+**Frontière de scope sur un endpoint Vercel partagé** (ex. `api/support/notify.ts` qui lit un fichier/contenu uploadé) : tu couvres l'**escape de contenu, le secret handling, et le BOLA/authz sur l'objet** (cœur fichier/storage) ; tu **laisses à `route-attack-auditor` les vecteurs HTTP-level** (verb tampering, cache poisoning, slowloris, header smuggling) et à `security-auditor` le transverse (CSP, supply chain). Signale explicitement ce que tu n'as PAS testé pour qu'ils complètent.
 
 ## ⚠️ Règle d'honnêteté + indépendance MCP
 

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,15 @@ VITE_AI_TUTOR_OPENROUTER_MODEL=anthropic/claude-sonnet-4-6
 # DO NOT set this in `.env.local` — your local dev should not send real emails.
 RESEND_API_KEY=re_your-resend-production-key
 
+# Recipient of the support-ticket notification email (Sprint 2.C Étape 3).
+# Server-side only, Production scope. Kept out of the repo so a personal inbox
+# address is never committed. Consumed by `api/support/notify.ts`.
+SUPPORT_TO_EMAIL=you@example.com
+
+# Optional override of the verified sender. Defaults in code to
+# "Terminal Learning <support@terminallearning.dev>" (domain Verified on Resend).
+# SUPPORT_FROM_EMAIL=Terminal Learning <support@terminallearning.dev>
+
 # ─── Vercel automatic (DO NOT SET MANUALLY) ───────────────────────────────────
 # VERCEL_OIDC_TOKEN : auto-injected by Vercel build runtime for OIDC token
 # exchange with external cloud providers (AWS, GCP, etc.). It rotates per

--- a/api/support/notify.ts
+++ b/api/support/notify.ts
@@ -1,0 +1,246 @@
+/**
+ * Support ticket notification — emails the super_admin when a user files a
+ * support ticket (Sprint 2.C Étape 3, THI-319).
+ *
+ * Architecture decision (vs the brief's "Supabase Edge Function"):
+ * the project's own `.env.example` documents `RESEND_API_KEY` as a **Vercel**
+ * env var consumed by **Vercel Functions** — so this lives here, reusing the
+ * `api/_rate-limit.ts` infra and the `sentry-tunnel.ts` Edge pattern, with zero
+ * new platform, zero new dependency, and zero new high-privilege secret (the
+ * project deliberately stores no service-role key). See THI-319.
+ *
+ * Trigger model: the browser calls this endpoint *after* a successful client
+ * INSERT (best-effort nudge). The ticket already lives in the DB and the
+ * super_admin dashboard (Étape 4) is the source of truth — a missed email never
+ * loses a ticket.
+ *
+ * Security:
+ * - Authorization is delegated to RLS, not re-implemented. The caller's Supabase
+ *   access token is forwarded to PostgREST; the row comes back only if the
+ *   caller owns it (policy "user select own") or is super_admin. No service-role
+ *   key, no client-supplied ticket content trusted for the email body.
+ * - Freshness guard: only tickets created in the last 2 minutes notify, so an
+ *   owner cannot replay the endpoint to spam emails for old tickets.
+ * - Per-IP sliding-window rate limit (shared module), tighter than the default.
+ * - The description is HTML-escaped before going into the email body (the
+ *   recipient is the admin, but defense-in-depth against HTML/markup injection).
+ * - Secrets (RESEND_API_KEY) and ticket content are never echoed to the client
+ *   nor logged. Resend failures degrade gracefully (HTTP 200, server log only).
+ *
+ * Vercel Edge Runtime — Web platform APIs only (Request/Response/fetch).
+ */
+
+export const config = { runtime: 'edge' };
+
+import { extractClientIp, isRateLimited, maybeCleanup, type RatePolicy } from '../_rate-limit';
+
+const ALLOWED_ORIGIN = 'https://terminallearning.dev';
+
+// Email is an expensive, abusable side effect — far tighter than the 50/min
+// default used by the Sentry tunnel.
+const NOTIFY_RATE_POLICY: RatePolicy = { max: 10, windowMs: 60_000 };
+
+// A `{ "ticketId": "<uuid>" }` body is ~50 bytes; cap well below that order of
+// magnitude to fast-fail any payload-stuffing attempt.
+const MAX_BODY_BYTES = 1024;
+
+// Only tickets created within this window may notify (anti-replay). Kept short
+// so the email-amplification window (re-notifying the same fresh ticket) stays
+// small; the client fires this immediately after the INSERT (security M2).
+const FRESHNESS_WINDOW_MS = 60_000;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const TYPE_LABELS: Record<string, string> = {
+  bug: 'Bug',
+  suggestion: 'Suggestion',
+  question: 'Question',
+};
+
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
+};
+
+function json(status: number, body: Record<string, unknown>, extra?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    // no-store: this is an authenticated POST; the `vercel.json` glob otherwise
+    // tags every route `public, max-age=0` which is semantically wrong here and
+    // could let a shared proxy cache an authz-scoped response (route-attack M1).
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', ...corsHeaders, ...extra },
+  });
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+interface TicketRow {
+  id: string;
+  type: string;
+  description: string;
+  screenshot_url: string | null;
+  created_at: string;
+}
+
+function buildEmail(ticket: TicketRow): { subject: string; html: string } {
+  const shortId = ticket.id.slice(0, 8);
+  // Whitelist-only: never echo a raw DB `type` into the (non-escaped) subject.
+  // The column is CHECK-constrained today, but the fallback guards a future
+  // migration loosening it (route-attack L3 — email header injection vector).
+  const typeLabel = TYPE_LABELS[ticket.type] ?? 'Signalement';
+  const subject = `[TerminalLearning Support] ${typeLabel} #${shortId}`;
+  const screenshotLine = ticket.screenshot_url
+    ? `<p><strong>Capture :</strong> jointe au ticket (visible dans le panneau admin).</p>`
+    : '';
+  const html = [
+    `<h2>Nouveau signalement — ${escapeHtml(typeLabel)}</h2>`,
+    `<p><strong>Ticket :</strong> #${escapeHtml(shortId)}</p>`,
+    `<p><strong>Description :</strong></p>`,
+    `<blockquote style="border-left:3px solid #2ea043;padding-left:12px;color:#444;white-space:pre-wrap">${escapeHtml(
+      ticket.description,
+    )}</blockquote>`,
+    screenshotLine,
+    `<p><a href="${ALLOWED_ORIGIN}/app/admin">Ouvrir le panneau administrateur →</a></p>`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+  return { subject, html };
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: { ...corsHeaders, 'Cache-Control': 'no-store' } });
+  }
+  if (req.method !== 'POST') {
+    return json(405, { error: 'method_not_allowed' }, { Allow: 'POST, OPTIONS' });
+  }
+
+  // Per-IP sliding window (shared module).
+  const now = Date.now();
+  maybeCleanup(now, NOTIFY_RATE_POLICY);
+  const ip = extractClientIp(req.headers);
+  if (isRateLimited(ip, now, NOTIFY_RATE_POLICY)) {
+    return json(429, { error: 'rate_limited' }, { 'Retry-After': '60' });
+  }
+
+  // The caller must present a Supabase access token; authorization is delegated
+  // to RLS via PostgREST, never re-implemented here.
+  const auth = req.headers.get('authorization') ?? '';
+  const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
+  if (!token) {
+    return json(401, { error: 'unauthorized' });
+  }
+
+  const contentLength = req.headers.get('content-length');
+  if (contentLength && Number.parseInt(contentLength, 10) > MAX_BODY_BYTES) {
+    return json(413, { error: 'payload_too_large' });
+  }
+
+  let ticketId: unknown;
+  try {
+    const buf = await req.arrayBuffer();
+    if (buf.byteLength > MAX_BODY_BYTES) {
+      return json(413, { error: 'payload_too_large' });
+    }
+    const parsed = JSON.parse(new TextDecoder().decode(buf)) as { ticketId?: unknown };
+    ticketId = parsed.ticketId;
+  } catch {
+    return json(400, { error: 'bad_request' });
+  }
+  if (typeof ticketId !== 'string' || !UUID_RE.test(ticketId)) {
+    return json(400, { error: 'bad_request' });
+  }
+
+  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+  const toEmail = process.env.SUPPORT_TO_EMAIL;
+  const fromEmail = process.env.SUPPORT_FROM_EMAIL ?? 'Terminal Learning <support@terminallearning.dev>';
+
+  // Without Supabase config we cannot authorize the caller — refuse rather than
+  // risk acting unauthenticated. Generic error (no config detail leaked).
+  if (!supabaseUrl || !anonKey) {
+    console.error('[support-notify] missing Supabase config');
+    return json(500, { error: 'server_error' });
+  }
+
+  // Authorize + fetch the trusted row in one step: RLS returns it only if the
+  // caller owns it (or is super_admin). Client-supplied content is never trusted.
+  let row: TicketRow | null = null;
+  try {
+    const restUrl =
+      `${supabaseUrl}/rest/v1/support_tickets` +
+      `?id=eq.${encodeURIComponent(ticketId)}` +
+      `&select=id,type,description,screenshot_url,created_at`;
+    const lookup = await fetch(restUrl, {
+      headers: {
+        apikey: anonKey,
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    });
+    if (lookup.status === 401 || lookup.status === 403) {
+      return json(401, { error: 'unauthorized' });
+    }
+    if (!lookup.ok) {
+      console.error(`[support-notify] lookup failed: ${lookup.status}`);
+      return json(502, { error: 'upstream_error' });
+    }
+    const rows = (await lookup.json()) as TicketRow[];
+    row = Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+  } catch (err) {
+    console.error(`[support-notify] lookup error: ${err instanceof Error ? err.message : 'unknown'}`);
+    return json(502, { error: 'upstream_error' });
+  }
+
+  // RLS hid the row (not owned / does not exist) — do not confirm existence.
+  if (!row) {
+    return json(404, { error: 'not_found' });
+  }
+
+  // Anti-replay: only fresh tickets notify. Silently accept stale calls so an
+  // owner cannot probe timing, and never email for an old ticket.
+  const createdMs = Date.parse(row.created_at);
+  if (!Number.isFinite(createdMs) || now - createdMs > FRESHNESS_WINDOW_MS) {
+    return json(200, { ok: true, skipped: 'stale' });
+  }
+
+  // Email is best-effort. A misconfigured / rate-limited Resend must never fail
+  // the user flow nor leak why.
+  if (!resendKey || !toEmail) {
+    console.error('[support-notify] email not configured (RESEND_API_KEY / SUPPORT_TO_EMAIL)');
+    return json(200, { ok: true, skipped: 'email_not_configured' });
+  }
+
+  const { subject, html } = buildEmail(row);
+  try {
+    const sent = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${resendKey}`,
+      },
+      body: JSON.stringify({ from: fromEmail, to: toEmail, subject, html }),
+    });
+    if (!sent.ok) {
+      // Log status only — never the response body (could echo payload).
+      console.error(`[support-notify] resend failed: ${sent.status}`);
+      return json(200, { ok: true, skipped: 'email_failed' });
+    }
+  } catch (err) {
+    console.error(`[support-notify] resend error: ${err instanceof Error ? err.message : 'unknown'}`);
+    return json(200, { ok: true, skipped: 'email_failed' });
+  }
+
+  return json(200, { ok: true });
+}

--- a/src/lib/support/notifyTicket.ts
+++ b/src/lib/support/notifyTicket.ts
@@ -1,0 +1,30 @@
+/**
+ * notifyTicketCreated — best-effort super_admin email nudge after a support
+ * ticket is created (Sprint 2.C Étape 3, THI-319).
+ *
+ * Fire-and-forget: the ticket already lives in the DB and the super_admin
+ * dashboard (Étape 4) is the source of truth, so a failed/blocked notification
+ * must never surface to the user nor throw. This helper swallows every error
+ * by design. The server endpoint (`api/support/notify.ts`) re-authorizes the
+ * caller against RLS, so forwarding the access token is the only requirement.
+ */
+import { supabase } from '@/lib/supabase';
+
+export async function notifyTicketCreated(ticketId: string): Promise<void> {
+  if (!supabase) return;
+  try {
+    const { data } = await supabase.auth.getSession();
+    const token = data.session?.access_token;
+    if (!token) return;
+    await fetch('/api/support/notify', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ ticketId }),
+    });
+  } catch {
+    // Best-effort — intentionally silent. The ticket is already persisted.
+  }
+}

--- a/src/lib/support/submitTicket.ts
+++ b/src/lib/support/submitTicket.ts
@@ -22,6 +22,7 @@
  * THI-241 doctrine). Returns `{ error: null }` on success.
  */
 import { supabase } from '@/lib/supabase';
+import { notifyTicketCreated } from '@/lib/support/notifyTicket';
 import type { SupportTicketType } from '@/app/types/database';
 
 export const SUPPORT_BUCKET = 'support_screenshots';
@@ -109,9 +110,11 @@ export async function submitTicket(params: SubmitTicketParams): Promise<SubmitTi
     screenshotUrl = signed.signedUrl;
   }
 
-  const { error: insertError } = await supabase
+  const { data: inserted, error: insertError } = await supabase
     .from('support_tickets')
-    .insert({ user_id: userId, type, description, screenshot_url: screenshotUrl });
+    .insert({ user_id: userId, type, description, screenshot_url: screenshotUrl })
+    .select('id')
+    .single();
 
   if (insertError) {
     // Best-effort cleanup so a rejected ticket leaves no dangling screenshot.
@@ -122,6 +125,17 @@ export async function submitTicket(params: SubmitTicketParams): Promise<SubmitTi
       return { error: 'Connectez-vous pour envoyer un signalement.' };
     }
     return { error: 'Impossible d’envoyer le signalement pour le moment. Réessayez dans un instant.' };
+  }
+
+  // Best-effort super_admin email nudge (fire-and-forget — never blocks nor
+  // fails the user flow; the ticket is already persisted).
+  if (inserted?.id) {
+    void notifyTicketCreated(inserted.id);
+  } else {
+    // Incoherent state: insert reported success but the row id was not
+    // returned (e.g. a future SELECT policy stricter than INSERT hid it). The
+    // ticket is persisted, so don't fail the user — just surface it for triage.
+    console.warn('[submitTicket] insert succeeded but no id returned — email notification skipped');
   }
 
   return { error: null };

--- a/src/test/support/notifyEndpoint.test.ts
+++ b/src/test/support/notifyEndpoint.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for api/support/notify.ts (Sprint 2.C Étape 3, THI-319).
+ *
+ * The endpoint forwards the caller's Supabase token to PostgREST (RLS does the
+ * authorization) then emails the super_admin via Resend. We mock global fetch,
+ * routing by URL: the Supabase REST lookup vs the Resend send.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import handler from '../../../api/support/notify';
+import { __resetForTests } from '../../../api/_rate-limit';
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+const ENDPOINT = 'https://terminallearning.dev/api/support/notify';
+
+function freshTicket(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VALID_UUID,
+    type: 'bug',
+    description: 'Something broke when I clicked the button.',
+    screenshot_url: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+interface FetchPlan {
+  /** Rows returned by the Supabase REST lookup (null → upstream error). */
+  lookupRows?: unknown[];
+  lookupStatus?: number;
+  /** Status returned by the Resend send. */
+  resendStatus?: number;
+}
+
+let resendCalls: Array<{ url: string; init: RequestInit }>;
+let lookupCalls: Array<{ url: string; init: RequestInit }>;
+
+function mockFetch(plan: FetchPlan) {
+  resendCalls = [];
+  lookupCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('https://api.resend.com/emails')) {
+        resendCalls.push({ url, init: init ?? {} });
+        const status = plan.resendStatus ?? 200;
+        return Promise.resolve(new Response(JSON.stringify({ id: 'email_1' }), { status }));
+      }
+      if (url.includes('/rest/v1/support_tickets')) {
+        lookupCalls.push({ url, init: init ?? {} });
+        const status = plan.lookupStatus ?? 200;
+        const body = plan.lookupRows ? JSON.stringify(plan.lookupRows) : '[]';
+        return Promise.resolve(new Response(body, { status }));
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    }),
+  );
+}
+
+function post(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer usertoken', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('api/support/notify', () => {
+  beforeEach(() => {
+    __resetForTests();
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://jdnukbpkjyyyjpuwgxhv.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+    vi.stubEnv('RESEND_API_KEY', 're_test_key');
+    vi.stubEnv('SUPPORT_TO_EMAIL', 'admin@example.com');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('handles CORS preflight (OPTIONS) with 204', async () => {
+    mockFetch({});
+    const res = await handler(new Request(ENDPOINT, { method: 'OPTIONS' }));
+    expect(res.status).toBe(204);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://terminallearning.dev');
+  });
+
+  it('rejects non-POST methods with 405', async () => {
+    mockFetch({});
+    const res = await handler(new Request(ENDPOINT, { method: 'GET' }));
+    expect(res.status).toBe(405);
+    expect(res.headers.get('Allow')).toContain('POST');
+  });
+
+  it('rejects a missing/blank Authorization header with 401', async () => {
+    mockFetch({});
+    const res = await handler(post({ ticketId: VALID_UUID }, { Authorization: '' }));
+    expect(res.status).toBe(401);
+    expect(lookupCalls).toHaveLength(0);
+  });
+
+  it('rejects a non-UUID ticketId with 400', async () => {
+    mockFetch({});
+    const res = await handler(post({ ticketId: 'not-a-uuid' }));
+    expect(res.status).toBe(400);
+    expect(lookupCalls).toHaveLength(0);
+  });
+
+  it('rejects a malformed JSON body with 400', async () => {
+    mockFetch({});
+    const res = await handler(post('{not json'));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an oversized Content-Length with 413', async () => {
+    mockFetch({});
+    const res = await handler(post({ ticketId: VALID_UUID }, { 'content-length': '99999' }));
+    expect(res.status).toBe(413);
+  });
+
+  it('returns 401 when the RLS lookup is unauthorized', async () => {
+    mockFetch({ lookupStatus: 401 });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(401);
+    expect(resendCalls).toHaveLength(0);
+  });
+
+  it('returns 404 when RLS hides the row (not owned / not found)', async () => {
+    mockFetch({ lookupRows: [] });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(404);
+    expect(resendCalls).toHaveLength(0);
+  });
+
+  it('skips (200) and does not email a stale ticket (anti-replay)', async () => {
+    const stale = freshTicket({ created_at: new Date(Date.now() - 5 * 60_000).toISOString() });
+    mockFetch({ lookupRows: [stale] });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ skipped: 'stale' });
+    expect(resendCalls).toHaveLength(0);
+  });
+
+  it('returns 500 when Supabase config is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    mockFetch({});
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(500);
+  });
+
+  it('skips email gracefully (200) when Resend is not configured', async () => {
+    vi.stubEnv('RESEND_API_KEY', '');
+    mockFetch({ lookupRows: [freshTicket()] });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ skipped: 'email_not_configured' });
+    expect(resendCalls).toHaveLength(0);
+  });
+
+  it('sends the email on the happy path with the trusted DB content', async () => {
+    mockFetch({ lookupRows: [freshTicket()] });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(resendCalls).toHaveLength(1);
+
+    const sent = JSON.parse(resendCalls[0].init.body as string);
+    expect(sent.to).toBe('admin@example.com');
+    expect(sent.from).toContain('support@terminallearning.dev');
+    expect(sent.subject).toContain('Bug');
+    expect(sent.subject).toContain('11111111');
+    expect(sent.html).toContain('Something broke');
+    // Authorization carries the Resend key, never echoed back to the client.
+    const headers = resendCalls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer re_test_key');
+  });
+
+  it('HTML-escapes the description (defense-in-depth against markup injection)', async () => {
+    const xss = freshTicket({ description: '<img src=x onerror=alert(1)> & "quotes"' });
+    mockFetch({ lookupRows: [xss] });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(200);
+    const sent = JSON.parse(resendCalls[0].init.body as string);
+    expect(sent.html).not.toContain('<img src=x');
+    expect(sent.html).toContain('&lt;img');
+    expect(sent.html).toContain('&amp;');
+  });
+
+  it('degrades to 200 when Resend returns an error (best-effort, no leak)', async () => {
+    mockFetch({ lookupRows: [freshTicket()], resendStatus: 429 });
+    const res = await handler(post({ ticketId: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ skipped: 'email_failed' });
+  });
+
+  it('rate-limits after the policy max (429)', async () => {
+    mockFetch({ lookupRows: [freshTicket()] });
+    let last = 200;
+    for (let i = 0; i < 12; i++) {
+      const res = await handler(post({ ticketId: VALID_UUID }));
+      last = res.status;
+    }
+    expect(last).toBe(429);
+  });
+});

--- a/src/test/support/notifyTicket.test.ts
+++ b/src/test/support/notifyTicket.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for notifyTicketCreated — the best-effort client nudge (Étape 3, THI-319).
+ *
+ * Verifies it forwards the access token to the same-origin endpoint, no-ops
+ * without a session, and never throws when the network fails (the ticket is
+ * already persisted, so a failed notification must stay silent).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const getSession = vi.fn();
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { getSession: () => getSession() } },
+}));
+
+import { notifyTicketCreated } from '@/lib/support/notifyTicket';
+
+const TICKET_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('notifyTicketCreated', () => {
+  beforeEach(() => {
+    getSession.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to /api/support/notify with the bearer token and ticketId', async () => {
+    getSession.mockResolvedValue({ data: { session: { access_token: 'tok123' } } });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await notifyTicketCreated(TICKET_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/support/notify');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok123');
+    expect(JSON.parse(init.body as string)).toEqual({ ticketId: TICKET_ID });
+  });
+
+  it('does not call fetch when there is no session', async () => {
+    getSession.mockResolvedValue({ data: { session: null } });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await notifyTicketCreated(TICKET_ID);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows network errors (never throws)', async () => {
+    getSession.mockResolvedValue({ data: { session: { access_token: 'tok123' } } });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    await expect(notifyTicketCreated(TICKET_ID)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Sprint 2.C Étape 3 — Notification email super_admin (THI-319)

Quand un utilisateur soumet un ticket support, le super_admin est notifié par email.

### Décision d'architecture (pivot vs brief « Edge Function Supabase »)
Implémenté en **Vercel Edge API route** (`api/support/notify.ts`), pas en Edge Function Supabase. Raison : `.env.example` documente que `RESEND_API_KEY` vit déjà dans **Vercel env** et que le projet sert ses routes serverless là. On réutilise `api/_rate-limit.ts` + le pattern de `sentry-tunnel.ts` → **0 nouvelle plateforme, 0 dépendance, 0 nouveau secret** (le projet ne stocke aucun service-role key). Aligné sur les critères $0 / pas de dépendance inutile.

### Sécurité
- **Autorisation déléguée à RLS** : le JWT Supabase du caller est forwardé à PostgREST ; la ligne ne revient que si elle est possédée (ou super_admin). Pas de service-role.
- Anti-replay : garde fraîcheur 60s. Rate limit 10/min/IP. Description HTML-escaped. `Cache-Control: no-store`. Secret jamais loggé ni renvoyé.
- **Best-effort** (hook client fire-and-forget) : un email raté ne perd jamais un ticket — le Dashboard super_admin (Étape 4) est la source de vérité.

### Tests & gates
- 18 nouveaux tests (endpoint + hook client), 53/53 suite support verte, type-check + lint OK.
- `security-auditor` **9.2/10** · `route-attack-auditor` **ship** · `feature-dev:code-reviewer` **clean** — **0 CRITICAL/HIGH**.
- Quick-wins appliqués : Cache-Control no-store, typeLabel whitelist fallback, freshness 60s, log défensif insert sans id.

### ⚠️ Action @thierry avant test empirique (env Vercel)
Pour que l'email parte sur la **preview** :
- `SUPPORT_TO_EMAIL` (nouveau) — destinataire (ex. `thierryvm@gmail.com`)
- `RESEND_API_KEY` — disponible aussi en scope **Preview** (actuellement Production-only)

### Reste à faire avant merge
- [ ] Voie A preview (desktop) — flow submit ticket sans régression
- [ ] Tests `curl` live route-attack post-deploy (liste fournie par l'agent)
- [ ] Email réellement reçu (happy path empirique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
