### PR TITLE
feat(support): "Mes signalements" read-only user view at /app/support (THI-325)

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { useFocusTrap } from '../../lib/hooks/useFocusTrap';
 import { useUserRole } from '../../lib/hooks/useUserRole';
 import {
   Terminal, LayoutDashboard, BookOpen, Settings,
-  ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock, School, ShieldCheck, ShieldUser, Briefcase, LifeBuoy,
+  ChevronDown, ChevronRight, CheckCircle2, Circle, X, Menu, Home, Lock, School, ShieldCheck, ShieldUser, Briefcase, LifeBuoy, Inbox,
 } from 'lucide-react';
 import { UserMenu } from './auth/UserMenu';
 import { useAuth } from '../context/AuthContext';
@@ -413,6 +413,22 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               <LifeBuoy size={16} />
               <span className="flex-1 text-left">Aide & feedback</span>
             </Button>
+          )}
+          {user && (
+            <NavLink
+              to="/app/support"
+              onClick={onClose}
+              className={({ isActive }) =>
+                `flex items-center gap-2.5 min-h-11 px-3 py-2 rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 ${
+                  isActive
+                    ? 'bg-[#21262d] text-[var(--github-text-primary)]'
+                    : 'text-[var(--github-text-secondary)] hover:bg-[var(--github-border-secondary)] hover:text-[var(--github-text-primary)]'
+                }`
+              }
+            >
+              <Inbox size={16} />
+              Mes signalements
+            </NavLink>
           )}
         </nav>
 

--- a/src/app/components/SupportTicketsSection.tsx
+++ b/src/app/components/SupportTicketsSection.tsx
@@ -25,43 +25,16 @@ import {
   useSupportTickets,
   type SupportTicket,
 } from '@/lib/hooks/useSupportTickets';
-import type { SupportTicketStatus, SupportTicketType } from '@/app/types/database';
-
-const STATUS_ORDER: SupportTicketStatus[] = ['open', 'in_progress', 'resolved', 'closed'];
-
-const STATUS_LABELS: Record<SupportTicketStatus, string> = {
-  open: 'En attente',
-  in_progress: 'En cours',
-  resolved: 'Résolu',
-  closed: 'Fermé',
-};
-
-type BadgeVariant = 'pill-amber' | 'pill-blue' | 'pill-emerald' | 'pill-muted';
-
-const STATUS_BADGE: Record<SupportTicketStatus, BadgeVariant> = {
-  open: 'pill-amber',
-  in_progress: 'pill-blue',
-  resolved: 'pill-emerald',
-  closed: 'pill-muted',
-};
-
-const TYPE_LABELS: Record<SupportTicketType, string> = {
-  bug: 'Bug',
-  suggestion: 'Suggestion',
-  question: 'Question',
-};
+import type { SupportTicketStatus } from '@/app/types/database';
+import {
+  TICKET_STATUS_ORDER as STATUS_ORDER,
+  TICKET_STATUS_LABELS as STATUS_LABELS,
+  TICKET_STATUS_BADGE as STATUS_BADGE,
+  TICKET_TYPE_LABELS as TYPE_LABELS,
+  formatTicketDate as formatDate,
+} from '@/lib/support/ticketDisplay';
 
 type StatusFilter = 'all' | SupportTicketStatus;
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('fr-FR', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
 
 export function SupportTicketsSection() {
   const { tickets, loading, error, updatingId, updateStatus } = useSupportTickets();

--- a/src/app/components/support/MySupportTickets.tsx
+++ b/src/app/components/support/MySupportTickets.tsx
@@ -1,0 +1,143 @@
+/**
+ * MySupportTickets — THI-325 Sprint 2.C Étape 5 (« Mes signalements », /app/support).
+ *
+ * Read-only view of the signed-in user's own support tickets + their status.
+ * Counterpart of the super_admin triage (SupportTicketsSection / AdminPanel).
+ * RLS (`support_tickets: user select own`, migration 028) scopes the fetch to
+ * the caller's rows — defense in depth on top of the RequireAuth gate.
+ *
+ * v1 scope (THI-325) : list only. No screenshot render — a regular user has no
+ * storage select policy on support_screenshots (migration 030 = super_admin
+ * only), and rendering uploaded content is supabase-backend-auditor's gate;
+ * we show a "capture jointe" marker instead. No status mutation (read-only).
+ */
+import { Link } from 'react-router';
+import { Helmet } from 'react-helmet-async';
+import { CheckCircle2, ImageIcon, Inbox } from 'lucide-react';
+
+import { RequireAuth } from '../auth/RequireAuth';
+import { Badge } from '../ui/badge';
+import { Card } from '../ui/card';
+import { useMySupportTickets } from '@/lib/hooks/useMySupportTickets';
+import type { SupportTicket } from '@/lib/hooks/useSupportTickets';
+import {
+  TICKET_STATUS_BADGE,
+  TICKET_STATUS_LABELS,
+  TICKET_TYPE_LABELS,
+  formatTicketDate,
+} from '@/lib/support/ticketDisplay';
+
+export function MySupportTickets() {
+  return (
+    <RequireAuth
+      fallback={
+        <main className="flex-1 px-6 py-12 max-w-3xl mx-auto">
+          <p className="text-[var(--github-text-secondary)] text-sm font-mono">
+            Vous devez être connecté pour voir vos signalements.{' '}
+            <Link to="/" className="text-emerald-400 hover:text-emerald-300 underline">
+              Retour à l&apos;accueil
+            </Link>
+          </p>
+        </main>
+      }
+    >
+      <MySupportTicketsContent />
+    </RequireAuth>
+  );
+}
+
+function MySupportTicketsContent() {
+  const { tickets, loading, error } = useMySupportTickets();
+
+  return (
+    <main className="flex-1 w-full px-6 py-10 max-w-3xl mx-auto">
+      <Helmet>
+        <title>Mes signalements — Terminal Learning</title>
+        {/* Private user page — never index. */}
+        <meta name="robots" content="noindex" />
+      </Helmet>
+
+      <header className="mb-6">
+        <h1 className="text-xl font-semibold text-[var(--github-text-primary)]">Mes signalements</h1>
+        <p className="mt-1 text-sm text-[var(--github-text-secondary)]">
+          Les bugs, suggestions et questions que tu nous as envoyés, et leur statut.
+        </p>
+      </header>
+
+      <div aria-live="polite" aria-busy={loading}>
+        {error && (
+          <Card
+            variant="tl-surface"
+            className="mb-4 px-4 py-3 border-[var(--github-red)]/40 bg-[var(--github-red)]/5"
+            role="alert"
+          >
+            <p className="text-sm text-[var(--github-red)] font-mono">{error.message}</p>
+          </Card>
+        )}
+
+        {loading ? (
+          <p className="text-sm text-[var(--github-text-secondary)] font-mono">Chargement…</p>
+        ) : tickets.length === 0 ? (
+          <Card variant="tl-surface" className="px-5 py-10 text-center gap-3">
+            <span className="text-emerald-400 mx-auto" aria-hidden="true">
+              <Inbox size={28} />
+            </span>
+            <p className="text-sm text-[var(--github-text-primary)]">
+              Aucun signalement pour l&apos;instant.
+            </p>
+            <p className="text-xs text-[var(--github-text-secondary)]">
+              Utilise « Aide &amp; feedback » dans le menu pour nous signaler un bug ou une idée.
+            </p>
+          </Card>
+        ) : (
+          <ul className="space-y-3" role="list">
+            {tickets.map((ticket) => (
+              <li key={ticket.id}>
+                <MyTicketCard ticket={ticket} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function MyTicketCard({ ticket }: { ticket: SupportTicket }) {
+  return (
+    <Card variant="tl-surface" className="px-5 py-4 gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2 min-w-0">
+          <Badge variant="pill-muted">{TICKET_TYPE_LABELS[ticket.type]}</Badge>
+          <Badge variant={TICKET_STATUS_BADGE[ticket.status]}>
+            {TICKET_STATUS_LABELS[ticket.status]}
+          </Badge>
+        </div>
+        <p className="text-xs text-[var(--github-text-secondary)] font-mono shrink-0">
+          {formatTicketDate(ticket.created_at)}
+        </p>
+      </div>
+
+      {/* Description — JSX text node (React-escaped). break-words keeps a long
+          unbroken string from overflowing on narrow viewports. */}
+      <p className="text-sm text-[var(--github-text-primary)] whitespace-pre-wrap break-words [word-break:break-word]">
+        {ticket.description}
+      </p>
+
+      {/* v1 : marker only, never render the uploaded image (see file header). */}
+      {ticket.screenshot_url && (
+        <p className="inline-flex items-center gap-1.5 text-xs text-[var(--github-text-secondary)] font-mono">
+          <ImageIcon size={13} aria-hidden="true" />
+          Capture jointe
+        </p>
+      )}
+
+      {ticket.status === 'resolved' && ticket.resolved_at && (
+        <p className="inline-flex items-center gap-1 text-xs text-emerald-400 font-mono">
+          <CheckCircle2 size={12} aria-hidden="true" />
+          {`Résolu le ${formatTicketDate(ticket.resolved_at)}`}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -44,6 +44,9 @@ const TeacherDashboard = lazyWithRetry(() =>
 const JoinClass = lazyWithRetry(() =>
   import('./components/JoinClass').then(({ JoinClass }) => ({ default: JoinClass }))
 );
+const MySupportTickets = lazyWithRetry(() =>
+  import('./components/support/MySupportTickets').then(({ MySupportTickets }) => ({ default: MySupportTickets }))
+);
 const Changelog = lazyWithRetry(() =>
   import('./components/Changelog').then(({ Changelog }) => ({ default: Changelog }))
 );
@@ -76,6 +79,7 @@ export const router = createBrowserRouter([
       { path: 'institution', Component: InstitutionAdminPanel },
       { path: 'teacher', Component: TeacherDashboard },
       { path: 'join', Component: JoinClass },
+      { path: 'support', Component: MySupportTickets },
     ],
   },
 

--- a/src/lib/hooks/useMySupportTickets.ts
+++ b/src/lib/hooks/useMySupportTickets.ts
@@ -1,0 +1,68 @@
+/**
+ * useMySupportTickets — THI-325 Sprint 2.C Étape 5 (« Mes signalements »).
+ *
+ * Read-only counterpart of `useSupportTickets` (super_admin triage). Fetches the
+ * tickets visible to the current authenticated user; RLS does the scoping: the
+ * `support_tickets: user select own` policy (migration 028) means the plain
+ * PostgREST query returns ONLY the caller's own rows — never another user's.
+ * (A super_admin would see all via their select-all policy, but this hook is
+ * mounted on the user-facing /app/support page, gated by RequireAuth.)
+ *
+ * No mutation surface: the user cannot change status (no update policy for own
+ * rows) — this hook intentionally exposes no updateStatus.
+ *
+ * Screenshots are NOT re-minted here: a regular user has no storage select
+ * policy on support_screenshots (migration 030 grants super_admin only), so the
+ * view shows a "capture jointe" marker rather than the image (THI-325 v1).
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuth } from '@/app/context/AuthContext';
+import { supabase } from '@/lib/supabase';
+import { TICKET_COLUMNS, type SupportTicket } from '@/lib/hooks/useSupportTickets';
+
+export interface UseMySupportTicketsResult {
+  tickets: SupportTicket[];
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMySupportTickets(): UseMySupportTicketsResult {
+  const { user, initialized } = useAuth();
+  const [tickets, setTickets] = useState<SupportTicket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!user || !supabase) {
+      setTickets([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error: fetchError } = await supabase
+        .from('support_tickets')
+        .select(TICKET_COLUMNS)
+        .order('created_at', { ascending: false });
+      if (fetchError) throw new Error(fetchError.message);
+      setTickets((data ?? []) as SupportTicket[]);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Chargement des signalements impossible'));
+      setTickets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!initialized) return;
+    /* eslint-disable react-hooks/set-state-in-effect -- async fetch on mount, setState after await (same pattern as useSupportTickets) */
+    void refresh();
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [initialized, refresh]);
+
+  return { tickets, loading, error, refresh };
+}

--- a/src/lib/hooks/useSupportTickets.ts
+++ b/src/lib/hooks/useSupportTickets.ts
@@ -35,7 +35,7 @@ export interface SupportTicket {
   resolved_by: string | null;
 }
 
-const TICKET_COLUMNS =
+export const TICKET_COLUMNS =
   'id, user_id, type, description, screenshot_url, status, created_at, resolved_at, resolved_by';
 
 // Fresh signed URL TTL when the super_admin opens a screenshot. Short by design:

--- a/src/lib/support/ticketDisplay.ts
+++ b/src/lib/support/ticketDisplay.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared display helpers for support tickets (Sprint 2.C).
+ *
+ * Extracted from SupportTicketsSection (super_admin triage, THI-320) so the
+ * user-facing « Mes signalements » view (THI-325) renders identical status /
+ * type labels, badge colours and date formatting without duplicating the maps.
+ * Single source of truth for ticket presentation across admin + user surfaces.
+ */
+import type { SupportTicketStatus, SupportTicketType } from '@/app/types/database';
+
+export type TicketBadgeVariant = 'pill-amber' | 'pill-blue' | 'pill-emerald' | 'pill-muted';
+
+export const TICKET_STATUS_ORDER: SupportTicketStatus[] = [
+  'open',
+  'in_progress',
+  'resolved',
+  'closed',
+];
+
+export const TICKET_STATUS_LABELS: Record<SupportTicketStatus, string> = {
+  open: 'En attente',
+  in_progress: 'En cours',
+  resolved: 'Résolu',
+  closed: 'Fermé',
+};
+
+export const TICKET_STATUS_BADGE: Record<SupportTicketStatus, TicketBadgeVariant> = {
+  open: 'pill-amber',
+  in_progress: 'pill-blue',
+  resolved: 'pill-emerald',
+  closed: 'pill-muted',
+};
+
+export const TICKET_TYPE_LABELS: Record<SupportTicketType, string> = {
+  bug: 'Bug',
+  suggestion: 'Suggestion',
+  question: 'Question',
+};
+
+export function formatTicketDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/src/lib/support/ticketDisplay.ts
+++ b/src/lib/support/ticketDisplay.ts
@@ -37,12 +37,14 @@ export const TICKET_TYPE_LABELS: Record<SupportTicketType, string> = {
   question: 'Question',
 };
 
+// Intl.DateTimeFormat (not Date.toLocaleDateString with time options, which is
+// semantically date-only) — explicit + unambiguous output across environments.
 export function formatTicketDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('fr-FR', {
+  return new Intl.DateTimeFormat('fr-FR', {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
-  });
+  }).format(new Date(iso));
 }

--- a/src/test/support/MySupportTickets.test.tsx
+++ b/src/test/support/MySupportTickets.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for MySupportTickets — THI-325 Étape 5 (« Mes signalements », /app/support).
+ *
+ * Covers:
+ *  - unauthenticated → RequireAuth fallback (never the ticket list)
+ *  - authenticated + loading → loading state
+ *  - authenticated + empty → empty-state copy
+ *  - authenticated + tickets → type/status labels, description, "capture jointe"
+ *    marker (no <img>), "Résolu le …" line
+ *  - authenticated + error → error message surfaced
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SupportTicket } from '@/lib/hooks/useSupportTickets';
+import type { UseMySupportTicketsResult } from '@/lib/hooks/useMySupportTickets';
+
+const authState: { user: { id: string } | null; initialized: boolean } = {
+  user: { id: 'u1' },
+  initialized: true,
+};
+
+const hookState: UseMySupportTicketsResult = {
+  tickets: [],
+  loading: false,
+  error: null,
+  refresh: vi.fn(),
+};
+
+vi.mock('@/app/context/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user, initialized: authState.initialized }),
+}));
+
+vi.mock('@/lib/hooks/useMySupportTickets', () => ({
+  useMySupportTickets: () => hookState,
+}));
+
+const { MySupportTickets } = await import('@/app/components/support/MySupportTickets');
+
+function ticket(overrides: Partial<SupportTicket> = {}): SupportTicket {
+  return {
+    id: 't1',
+    user_id: 'u1',
+    type: 'bug',
+    description: 'Le terminal ne répond plus',
+    screenshot_url: null,
+    status: 'open',
+    created_at: '2026-06-01T10:00:00Z',
+    resolved_at: null,
+    resolved_by: null,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <MySupportTickets />
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+}
+
+beforeEach(() => {
+  authState.user = { id: 'u1' };
+  authState.initialized = true;
+  hookState.tickets = [];
+  hookState.loading = false;
+  hookState.error = null;
+});
+
+describe('MySupportTickets — auth guard', () => {
+  it('renders the RequireAuth fallback (not the list) for an anonymous visitor', () => {
+    authState.user = null;
+    renderPage();
+    expect(screen.getByText(/vous devez être connecté pour voir vos signalements/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /retour à l'accueil/i })).toBeInTheDocument();
+    expect(screen.queryByText(/mes signalements/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('MySupportTickets — authenticated', () => {
+  it('shows the loading state while fetching', () => {
+    hookState.loading = true;
+    renderPage();
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when the user has no tickets', () => {
+    hookState.tickets = [];
+    renderPage();
+    expect(screen.getByText(/aucun signalement pour l'instant/i)).toBeInTheDocument();
+  });
+
+  it('renders a ticket with type, status label and description', () => {
+    hookState.tickets = [ticket({ type: 'suggestion', status: 'in_progress', description: 'Ajouter un mode clair' })];
+    renderPage();
+    expect(screen.getByText('Suggestion')).toBeInTheDocument();
+    expect(screen.getByText('En cours')).toBeInTheDocument();
+    expect(screen.getByText('Ajouter un mode clair')).toBeInTheDocument();
+  });
+
+  it('shows a "capture jointe" marker (no image) when a screenshot is attached', () => {
+    hookState.tickets = [ticket({ screenshot_url: 'https://x.supabase.co/storage/v1/object/sign/support_screenshots/u1/a.png?token=t' })];
+    renderPage();
+    expect(screen.getByText(/capture jointe/i)).toBeInTheDocument();
+    // v1 must NOT render the uploaded image inline.
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('shows the resolution date for a resolved ticket', () => {
+    hookState.tickets = [ticket({ status: 'resolved', resolved_at: '2026-06-02T09:00:00Z' })];
+    renderPage();
+    expect(screen.getByText('Résolu')).toBeInTheDocument();
+    expect(screen.getByText(/résolu le/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a fetch error', () => {
+    hookState.error = new Error('Chargement des signalements impossible');
+    renderPage();
+    expect(screen.getByText('Chargement des signalements impossible')).toBeInTheDocument();
+  });
+});

--- a/src/test/support/useMySupportTickets.test.ts
+++ b/src/test/support/useMySupportTickets.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for useMySupportTickets — THI-325 Étape 5 (« Mes signalements »).
+ *
+ * RLS (`support_tickets: user select own`, migration 028) does the scoping
+ * server-side; here we verify the client contract of the read-only hook:
+ *   - fetch on mount, newest first, from the support_tickets table
+ *   - stays empty (no query) when there is no authenticated user
+ *   - surfaces a fetch error
+ *   - exposes NO mutation surface (read-only — no updateStatus)
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  selectMock: vi.fn(),
+  orderMock: vi.fn(),
+  auth: { user: { id: 'u1' } as { id: string } | null, initialized: true },
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: h.fromMock },
+}));
+
+vi.mock('@/app/context/AuthContext', () => ({
+  useAuth: () => ({ user: h.auth.user, initialized: h.auth.initialized }),
+}));
+
+const { useMySupportTickets } = await import('@/lib/hooks/useMySupportTickets');
+
+function ticket(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    user_id: 'u1',
+    type: 'bug',
+    description: 'It broke',
+    screenshot_url: null,
+    status: 'open',
+    created_at: '2026-06-01T10:00:00Z',
+    resolved_at: null,
+    resolved_by: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.auth.user = { id: 'u1' };
+  h.auth.initialized = true;
+  h.fromMock.mockReturnValue({ select: h.selectMock });
+  h.selectMock.mockReturnValue({ order: h.orderMock });
+  h.orderMock.mockResolvedValue({ data: [], error: null });
+});
+
+describe('useMySupportTickets', () => {
+  it('loads the user own tickets on mount (RLS-scoped, newest first)', async () => {
+    h.orderMock.mockResolvedValue({ data: [ticket({ id: 't2' }), ticket({ id: 't1' })], error: null });
+    const { result } = renderHook(() => useMySupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tickets).toHaveLength(2);
+    expect(h.fromMock).toHaveBeenCalledWith('support_tickets');
+    expect(h.orderMock).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('stays empty (no query) when there is no authenticated user', async () => {
+    h.auth.user = null;
+    const { result } = renderHook(() => useMySupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tickets).toEqual([]);
+    expect(h.fromMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a fetch error and clears the list', async () => {
+    h.orderMock.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const { result } = renderHook(() => useMySupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.tickets).toEqual([]);
+  });
+
+  it('exposes a read-only surface (refresh, no updateStatus)', async () => {
+    const { result } = renderHook(() => useMySupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(typeof result.current.refresh).toBe('function');
+    expect((result.current as unknown as Record<string, unknown>).updateStatus).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## THI-325 — Sprint 2.C étape 5 (« Mes signalements »)

Ferme la boucle du système de support : un utilisateur connecté voit **ses propres** signalements (bug/suggestion/question) + statut — le pendant du triage super_admin (THI-320).

### Changements
- **Route `/app/support`** (lazy) + entrée Sidebar « Mes signalements » (auth-gated, `{user && …}`).
- **`useMySupportTickets`** — hook **read-only**. La RLS `support_tickets: user select own` (migration 028) auto-scope le fetch au caller. **0 backend, 0 migration.** Aucune surface de mutation.
- **`MySupportTickets`** — page wrappée `RequireAuth` (fallback anon), Helmet `noindex` (page privée), badges statut/type, description, états vide/loading/error.
- **DRY** : maps label/badge statut+type + format date extraits dans `src/lib/support/ticketDisplay.ts`, consommés par la section admin ET la nouvelle page (source unique).

### Décision de scope v1 (sécurité)
**Pas de rendu inline du screenshot** : un user régulier n'a pas de policy storage select sur `support_screenshots` (migration 030 = super_admin only), et le rendu d'uploadé est le périmètre de `supabase-backend-auditor` (non invocable cette session — fix #365 effectif en session fraîche). → indicateur « capture jointe » sans `<img>`. Différé en sous-tâche.

### Tests
`useMySupportTickets` (fetch/empty/error/read-only) + `MySupportTickets` (fallback auth, loading, empty, rendu ticket, « capture jointe » sans img, error). **Suite full 2045 passed**, type-check + lint clean.

### Gates (en cours)
- `security-auditor` — isolation RLS read (REST+JWT, 2 personas) : un user ne voit QUE ses tickets.
- `ui-auditor` — shadcn/tokens/a11y.
- `feature-dev:code-reviewer` — en dernier sur le diff stabilisé.
- **route-attack-auditor N/A** : `/app/support` est une route SPA client (fallback index.html), pas un endpoint `api/*`.

Validation **Voie A** (desktop + mobile 390px) à suivre avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)