### PR TITLE
docs(security): catch-up audit log — Sprint 2.C + 04/06 break-ins

### DIFF
--- a/docs/security-audit-log.md
+++ b/docs/security-audit-log.md
@@ -8,8 +8,8 @@ This log is updated after each security audit and serves as institutional memory
 ## Rattrapage traçabilité — runs Sprint 2.C + break-ins agents (consolidé 4 juin 2026)
 
 **Date**: 4 juin 2026 (consolidation rétroactive)
-**Auteur**: CC Terminal Learning (Opus 4.8) — drift détecté au startup : ce log n'avait pas été appendé depuis le 17 mai alors que ~5 runs `security-auditor` 9.x/10 ont eu lieu pendant Sprint 2.C.
-**Méthode**: consolidation depuis les décisions `_index.md` (Obsidian) + memos session + PRs mergées. **Scores non ré-exécutés** — repris des verdicts d'origine (traçabilité, pas nouveau run).
+**Auteur**: CC Terminal Learning (Opus 4.8) — drift détecté au démarrage : ce log n'avait pas été appendé depuis le 17 mai alors que ~5 runs `security-auditor` 9.x/10 ont eu lieu pendant Sprint 2.C.
+**Méthode**: consolidation depuis les décisions `_index.md` (Obsidian) + memos de session + PRs mergées. **Scores non ré-exécutés** — repris des verdicts d'origine (traçabilité, pas nouveau run).
 
 ### Runs Sprint 2.C (système support)
 
@@ -21,13 +21,13 @@ This log is updated after each security audit and serves as institutional memory
 | 2 juin | `security-auditor` (« Mes signalements » `/app/support`, isolation RLS REST+JWT prouvée) | 9.6/10 | #366 | THI-325 |
 | 2 juin | `supabase-backend-auditor` (verdict **inline** — agent non chargé runtime, YAML cassé) | H1 MIME-spoof signalé | #364 | THI-326 |
 
-### Break-ins agents (4 juin — session démarrage)
+### Break-in des agents (4 juin — démarrage de session)
 
 | Run | Verdict | Suite |
 |---|---|---|
 | `supabase-backend-auditor` — re-run WS3 (1er run sous-agent réel post-fix #365) | ⚠️ SHIP — prod SÛRE, H1 MIME-spoof confirmé empiriquement & atténué (rendu `<img>` JSX-only) | THI-339 (PR #368, triggers élargis aux routes `api/*`) |
 | `user-forensics-auditor` — sonde chargement (post-#365) | ✅ chargement runtime confirmé (Sonnet 4.6) | — |
-| `legal-compliance-auditor` — break-in #1 | **6.5/10** — base B2C OK, **non prêt B2B mineurs** (3 HIGH : consentement parental <13 BE, DPA Art. 28, claim `/privacy` trompeur) | THI-340 (umbrella) |
+| `legal-compliance-auditor` — break-in #1 | **6.5/10** — base B2C OK, **non prêt pour le B2B mineurs** (3 HIGH : consentement parental <13 BE, DPA Art. 28, claim `/privacy` trompeur) | THI-340 (umbrella) |
 
 ### Note de contexte
 

--- a/docs/security-audit-log.md
+++ b/docs/security-audit-log.md
@@ -5,6 +5,39 @@ This log is updated after each security audit and serves as institutional memory
 
 ---
 
+## Rattrapage traçabilité — runs Sprint 2.C + break-ins agents (consolidé 4 juin 2026)
+
+**Date**: 4 juin 2026 (consolidation rétroactive)
+**Auteur**: CC Terminal Learning (Opus 4.8) — drift détecté au startup : ce log n'avait pas été appendé depuis le 17 mai alors que ~5 runs `security-auditor` 9.x/10 ont eu lieu pendant Sprint 2.C.
+**Méthode**: consolidation depuis les décisions `_index.md` (Obsidian) + memos session + PRs mergées. **Scores non ré-exécutés** — repris des verdicts d'origine (traçabilité, pas nouveau run).
+
+### Runs Sprint 2.C (système support)
+
+| Date | Run | Score / Verdict | PR | Ticket |
+|---|---|---|---|---|
+| 1 juin | `security-auditor` (route Resend `api/support/notify.ts`) | 9.2/10, 0 CRIT/HIGH | #360 | THI-319 |
+| 1 juin | `route-attack-auditor` (notify endpoint, curl live) | SHIP, tout PASS | #360 | THI-319 |
+| 2 juin | `security-auditor` (triage signalements `/app/admin`) | 9.5/10 | #364 | THI-320 |
+| 2 juin | `security-auditor` (« Mes signalements » `/app/support`, isolation RLS REST+JWT prouvée) | 9.6/10 | #366 | THI-325 |
+| 2 juin | `supabase-backend-auditor` (verdict **inline** — agent non chargé runtime, YAML cassé) | H1 MIME-spoof signalé | #364 | THI-326 |
+
+### Break-ins agents (4 juin — session démarrage)
+
+| Run | Verdict | Suite |
+|---|---|---|
+| `supabase-backend-auditor` — re-run WS3 (1er run sous-agent réel post-fix #365) | ⚠️ SHIP — prod SÛRE, H1 MIME-spoof confirmé empiriquement & atténué (rendu `<img>` JSX-only) | THI-339 (PR #368, triggers élargis aux routes `api/*`) |
+| `user-forensics-auditor` — sonde chargement (post-#365) | ✅ chargement runtime confirmé (Sonnet 4.6) | — |
+| `legal-compliance-auditor` — break-in #1 | **6.5/10** — base B2C OK, **non prêt B2B mineurs** (3 HIGH : consentement parental <13 BE, DPA Art. 28, claim `/privacy` trompeur) | THI-340 (umbrella) |
+
+### Note de contexte
+
+THI-326 a prouvé (cause racine js-yaml) que `supabase-backend-auditor` + `user-forensics-auditor` n'étaient **pas chargés au runtime** (un `:` + espace cassait leur frontmatter YAML) jusqu'au fix PR #365 — d'où le verdict « inline » du 2 juin pour `supabase-backend-auditor`. Les deux sont **confirmés invocables le 4 juin** (WS3 clos).
+
+**Last Updated**: 4 juin 2026
+**Next Review**: prochain run `security-auditor` (THI-234 widgets analytics — nouvelles RPC cross-user `SECURITY DEFINER`)
+
+---
+
 ## Validation Voie B post-merge THI-207 (#246) -- 17 mai 2026 ~21h CEST
 
 **Date**: 17 mai 2026 (soirée)


### PR DESCRIPTION
## Contexte

Drift de traçabilité détecté au **startup du 04/06** : `docs/security-audit-log.md` n'avait pas été appendé depuis le **17 mai**, alors que ~5 runs `security-auditor` (9.x/10) ont eu lieu pendant **Sprint 2.C** (système support). Le log est la mémoire institutionnelle sécurité — laisser ce trou = perte de l'historique des scores.

## Changement

1 entrée de rattrapage insérée en tête (ordre anti-chronologique du fichier) :
- **Runs Sprint 2.C** : security-auditor 9.2 (THI-319) / 9.5 (THI-320) / 9.6 (THI-325), route-attack (THI-319), supabase-backend inline (THI-326).
- **Break-ins 04/06** : supabase-backend WS3 re-run (⚠️ SHIP, H1 confirmé/atténué → THI-339), user-forensics sonde (✅ chargé), legal-compliance #1 (6.5/10, 3 HIGH B2B → THI-340).

**Scores NON ré-exécutés** — consolidés depuis les décisions Obsidian `_index.md` + PRs mergées (traçabilité, pas nouveau run). Mention explicite dans l'entrée.

## Validation

- **Voie C** — docs-only (`docs/security-audit-log.md` uniquement), 0 fichier `src/`/`api/`/`supabase/`/runtime. Smoke test preview à confirmer post-deploy.
- Pas de `feature-dev:code-reviewer` (exemption docs-only per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Mettre à jour le journal d’audit de sécurité avec une entrée rétroactive consolidant les exécutions d’audit manquantes du Sprint 2.C et la session d’intrusion du 4 juin.

Documentation :
- Ajouter une entrée consolidée dans le journal d’audit pour les exécutions de l’auditeur de sécurité du Sprint 2.C et les tests backend/routes associés, y compris les scores et les tickets/PR associés.
- Documenter les réexécutions de l’agent d’intrusion du 4 juin, leurs résultats et les tâches de suivi, y compris les conclusions liées à la conformité légale et les liens vers les tickets.
- Consigner des notes contextuelles sur les auditeurs précédemment non chargés, leur cause racine et la correction, et définir les métadonnées « dernière mise à jour/prochaine révision » à jour dans le journal.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the security audit log with a retroactive entry consolidating missing Sprint 2.C audit runs and the 4 June break-in session.

Documentation:
- Add a consolidated audit-log entry for Sprint 2.C security auditor runs and related backend/route tests, including scores and associated tickets/PRs.
- Document the 4 June break-in agent reruns, outcomes, and follow-up tasks, including legal-compliance findings and ticket links.
- Record contextual notes on previously unloaded auditors, their root cause and fix, and set updated last-updated/next-review metadata in the log.

</details>