### PR TITLE
fix(ui): THI-346 — dropdown menu avatar, scrollbar redondante (suppression cap 440px)

### DIFF
--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -227,7 +227,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions, secondary
             role="menu"
             aria-orientation="vertical"
             aria-label={`Menu utilisateur ${displayName}`}
-            className="absolute right-0 top-full mt-2 z-50 w-60 bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] rounded-xl shadow-2xl overflow-y-auto max-h-[min(440px,calc(100dvh-200px))]"
+            className="absolute right-0 top-full mt-2 z-50 w-60 bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100dvh-200px)]"
           >
             {dropdownHeader}
             {menuItems}
@@ -278,7 +278,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions, secondary
           role="menu"
           aria-orientation="vertical"
           aria-label={`Menu utilisateur ${displayName}`}
-          className="absolute bottom-full left-0 right-0 mb-2 z-50 bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] rounded-xl shadow-2xl overflow-y-auto max-h-[min(440px,calc(100dvh-200px))]"
+          className="absolute bottom-full left-0 right-0 mb-2 z-50 bg-[var(--github-border-secondary)] border border-[var(--github-border-primary)] rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100dvh-200px)]"
         >
           {dropdownHeader}
           {menuItems}


### PR DESCRIPTION
## THI-346 — Scroll du dropdown menu avatar (follow-up THI-341)

**Bug @thierry (2× signalé)** : le dropdown du menu avatar affichait une scrollbar **qui double celle de la sidebar Modules** → visuellement cassé.

**Cause** : le fix anti-clip F-02 de THI-341 utilisait `max-h-[min(440px,calc(100dvh-200px))]`. Pour un **super_admin**, le menu fait ~454px (header + 8 items à `py-3`), juste **au-dessus du cap 440px** → scrollbar **systématique sur tous les viewports** (les rôles avec moins d'items ne scrollaient pas).

**Fix** (1 ligne, 2 dropdowns) : retirer le cap fixe `440px` → `max-h-[calc(100dvh-200px)]`. Le dropdown prend sa **taille naturelle** et ne scrolle **que** quand il ne tient vraiment pas (écrans courts), tout en gardant le filet anti-clip.

### Voie A empirique (super_admin, 8 items)
| Format | Scroll dropdown | Débordement |
|---|---|---|
| 1280×800 (desktop) | ✅ aucun | ✅ fits |
| 768×1024 (tablette) | ✅ aucun | ✅ fits |
| 390×844 (mobile) | ✅ aucun | ✅ fits |
| 1280×600 (écran court) | scroll **sécurité** (nécessaire) | ✅ fits, pas de clip |

Screenshot desktop : `.tmp/thi346-dropdown-desktop.png` (8 items, 0 scrollbar interne).

`type-check` + `lint` clean, `auth.test` 16/16 (UserMenu, inchangés). Gate `mobile-responsive-auditor` en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)