### PR TITLE
feat(admin): THI-347 — supprimer un ticket support + fix THI-334 (delete policies)

### DIFF
--- a/src/app/components/SupportTicketsSection.tsx
+++ b/src/app/components/SupportTicketsSection.tsx
@@ -15,7 +15,7 @@
  *     THI-297) so a huge image can't blow up the layout.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { CheckCircle2, ImageIcon, Inbox, Loader2 } from 'lucide-react';
+import { CheckCircle2, ImageIcon, Inbox, Loader2, Trash2 } from 'lucide-react';
 
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -37,7 +37,8 @@ import {
 type StatusFilter = 'all' | SupportTicketStatus;
 
 export function SupportTicketsSection() {
-  const { tickets, loading, error, updatingId, updateStatus } = useSupportTickets();
+  const { tickets, loading, error, updatingId, deletingId, updateStatus, deleteTicket } =
+    useSupportTickets();
   const [filter, setFilter] = useState<StatusFilter>('all');
 
   const counts = useMemo(() => {
@@ -120,7 +121,9 @@ export function SupportTicketsSection() {
                 <TicketCard
                   ticket={ticket}
                   updating={updatingId === ticket.id}
+                  deleting={deletingId === ticket.id}
                   onStatusChange={(next) => updateStatus(ticket.id, next)}
+                  onDelete={() => deleteTicket(ticket.id)}
                 />
               </li>
             ))}
@@ -155,11 +158,14 @@ function FilterChip({ active, onClick, children }: FilterChipProps) {
 interface TicketCardProps {
   ticket: SupportTicket;
   updating: boolean;
+  deleting: boolean;
   onStatusChange: (next: SupportTicketStatus) => void;
+  onDelete: () => void;
 }
 
-function TicketCard({ ticket, updating, onStatusChange }: TicketCardProps) {
+function TicketCard({ ticket, updating, deleting, onStatusChange, onDelete }: TicketCardProps) {
   const selectId = `ticket-status-${ticket.id}`;
+  const [confirming, setConfirming] = useState(false);
   return (
     <Card variant="tl-surface" className="px-5 py-4 gap-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -220,6 +226,49 @@ function TicketCard({ ticket, updating, onStatusChange }: TicketCardProps) {
             {`Résolu le ${formatDate(ticket.resolved_at)}`}
           </span>
         )}
+
+        {/* Delete — two-step inline confirm (no native confirm dialog). super_admin
+            purge: spam / obsolete / leftover test rows (THI-347 volet 3, THI-334). */}
+        <div className="ml-auto flex items-center gap-2">
+          {confirming ? (
+            <>
+              <span className="text-xs text-[var(--github-text-secondary)] font-mono">Supprimer ?</span>
+              <Button
+                type="button"
+                variant="ghost-gh"
+                size="sm"
+                className="min-h-11 font-mono text-xs text-[var(--github-red)] hover:text-[var(--github-red)] hover:bg-[var(--github-red)]/10"
+                onClick={onDelete}
+                disabled={deleting}
+                aria-label={`Confirmer la suppression du signalement #${ticket.id.slice(0, 8)}`}
+              >
+                {deleting ? 'Suppression…' : 'Confirmer'}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost-gh"
+                size="sm"
+                className="min-h-11 font-mono text-xs"
+                onClick={() => setConfirming(false)}
+                disabled={deleting}
+              >
+                Annuler
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost-gh"
+              size="sm"
+              className="min-h-11 gap-1.5 font-mono text-xs text-[var(--github-text-secondary)] hover:text-[var(--github-red)]"
+              onClick={() => setConfirming(true)}
+              aria-label={`Supprimer le signalement #${ticket.id.slice(0, 8)}`}
+            >
+              <Trash2 size={14} aria-hidden="true" />
+              Supprimer
+            </Button>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/src/app/components/SupportTicketsSection.tsx
+++ b/src/app/components/SupportTicketsSection.tsx
@@ -251,6 +251,7 @@ function TicketCard({ ticket, updating, deleting, onStatusChange, onDelete }: Ti
                 className="min-h-11 font-mono text-xs"
                 onClick={() => setConfirming(false)}
                 disabled={deleting}
+                aria-label={`Annuler la suppression du signalement #${ticket.id.slice(0, 8)}`}
               >
                 Annuler
               </Button>

--- a/src/lib/hooks/useSupportTickets.ts
+++ b/src/lib/hooks/useSupportTickets.ts
@@ -115,6 +115,10 @@ export function useSupportTickets(): UseSupportTicketsResult {
   // before a pending setUpdatingId has flushed, unlike a closure-captured state.
   const updatingIdRef = useRef<string | null>(null);
   const deletingIdRef = useRef<string | null>(null);
+  // Guard setState against an update/delete resolving after unmount (navigation
+  // away mid-flight) — same pattern as ScreenshotViewer below (code-reviewer).
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
 
   const refresh = useCallback(async () => {
     if (!user || !supabase) {
@@ -147,7 +151,9 @@ export function useSupportTickets(): UseSupportTicketsResult {
         setError(new Error('Authentification requise'));
         return false;
       }
-      if (updatingIdRef.current) return false;
+      // Cross-guard: never run an update while a delete on any row is in flight
+      // (and vice versa) — avoids an UPDATE committing on a row a DELETE removed.
+      if (updatingIdRef.current || deletingIdRef.current) return false;
 
       updatingIdRef.current = id;
       setUpdatingId(id);
@@ -174,14 +180,18 @@ export function useSupportTickets(): UseSupportTicketsResult {
           throw new Error('Mise à jour du statut impossible. Réessaye dans un instant.');
         }
         // Optimistic local patch — the status-change audit trigger fires server-side.
-        setTickets((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+        if (isMountedRef.current) {
+          setTickets((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+        }
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err : new Error('Mise à jour impossible'));
+        if (isMountedRef.current) {
+          setError(err instanceof Error ? err : new Error('Mise à jour impossible'));
+        }
         return false;
       } finally {
         updatingIdRef.current = null;
-        setUpdatingId(null);
+        if (isMountedRef.current) setUpdatingId(null);
       }
     },
     [user],
@@ -193,7 +203,7 @@ export function useSupportTickets(): UseSupportTicketsResult {
         setError(new Error('Authentification requise'));
         return false;
       }
-      if (deletingIdRef.current) return false;
+      if (deletingIdRef.current || updatingIdRef.current) return false;
 
       deletingIdRef.current = id;
       setDeletingId(id);
@@ -213,14 +223,16 @@ export function useSupportTickets(): UseSupportTicketsResult {
           }
           throw new Error('Suppression impossible. Réessaye dans un instant.');
         }
-        setTickets((prev) => prev.filter((t) => t.id !== id));
+        if (isMountedRef.current) setTickets((prev) => prev.filter((t) => t.id !== id));
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err : new Error('Suppression impossible'));
+        if (isMountedRef.current) {
+          setError(err instanceof Error ? err : new Error('Suppression impossible'));
+        }
         return false;
       } finally {
         deletingIdRef.current = null;
-        setDeletingId(null);
+        if (isMountedRef.current) setDeletingId(null);
       }
     },
     [user],

--- a/src/lib/hooks/useSupportTickets.ts
+++ b/src/lib/hooks/useSupportTickets.ts
@@ -48,7 +48,9 @@ export interface UseSupportTicketsResult {
   loading: boolean;
   error: Error | null;
   updatingId: string | null;
+  deletingId: string | null;
   updateStatus: (id: string, next: SupportTicketStatus) => Promise<boolean>;
+  deleteTicket: (id: string) => Promise<boolean>;
   refresh: () => Promise<void>;
 }
 
@@ -108,9 +110,11 @@ export function useSupportTickets(): UseSupportTicketsResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   // Live guard against re-entrant updates: a ref reads the current value even
   // before a pending setUpdatingId has flushed, unlike a closure-captured state.
   const updatingIdRef = useRef<string | null>(null);
+  const deletingIdRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!user || !supabase) {
@@ -183,5 +187,44 @@ export function useSupportTickets(): UseSupportTicketsResult {
     [user],
   );
 
-  return { tickets, loading, error, updatingId, updateStatus, refresh };
+  const deleteTicket = useCallback(
+    async (id: string): Promise<boolean> => {
+      if (!user || !supabase) {
+        setError(new Error('Authentification requise'));
+        return false;
+      }
+      if (deletingIdRef.current) return false;
+
+      deletingIdRef.current = id;
+      setDeletingId(id);
+      setError(null);
+
+      try {
+        // RLS allows DELETE when the row is own OR the caller is super_admin
+        // (migration 033). The hook is used by the super_admin triage UI, so a
+        // 42501/PGRST301 here means an unexpected role drift, not a normal path.
+        const { error: deleteError } = await supabase
+          .from('support_tickets')
+          .delete()
+          .eq('id', id);
+        if (deleteError) {
+          if (deleteError.code === '42501' || deleteError.code === 'PGRST301') {
+            throw new Error('Action non autorisée pour ce compte.');
+          }
+          throw new Error('Suppression impossible. Réessaye dans un instant.');
+        }
+        setTickets((prev) => prev.filter((t) => t.id !== id));
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Suppression impossible'));
+        return false;
+      } finally {
+        deletingIdRef.current = null;
+        setDeletingId(null);
+      }
+    },
+    [user],
+  );
+
+  return { tickets, loading, error, updatingId, deletingId, updateStatus, deleteTicket, refresh };
 }

--- a/src/test/support/SupportTicketsSection.test.tsx
+++ b/src/test/support/SupportTicketsSection.test.tsx
@@ -14,7 +14,9 @@ const h = vi.hoisted(() => ({
     loading: false,
     error: null as Error | null,
     updatingId: null as string | null,
+    deletingId: null as string | null,
     updateStatus: vi.fn(),
+    deleteTicket: vi.fn(),
     refresh: vi.fn(),
   },
   getFresh: vi.fn(),
@@ -48,7 +50,9 @@ beforeEach(() => {
   h.state.loading = false;
   h.state.error = null;
   h.state.updatingId = null;
+  h.state.deletingId = null;
   h.state.updateStatus = vi.fn().mockResolvedValue(true);
+  h.state.deleteTicket = vi.fn().mockResolvedValue(true);
   h.getFresh = vi.fn();
 });
 
@@ -161,5 +165,25 @@ describe('SupportTicketsSection', () => {
     h.state.tickets = [ticket({ status: 'resolved', resolved_at: null })];
     render(<SupportTicketsSection />);
     expect(screen.queryByText(/Résolu le/)).not.toBeInTheDocument();
+  });
+
+  it('deletes a ticket only after the inline two-step confirm', () => {
+    h.state.tickets = [ticket({ id: 'tdel' })];
+    render(<SupportTicketsSection />);
+    // Step 1 — "Supprimer" reveals the confirm but does NOT delete yet.
+    fireEvent.click(screen.getByRole('button', { name: /Supprimer le signalement/ }));
+    expect(h.state.deleteTicket).not.toHaveBeenCalled();
+    // Step 2 — "Confirmer" triggers the delete.
+    fireEvent.click(screen.getByRole('button', { name: /Confirmer la suppression/ }));
+    expect(h.state.deleteTicket).toHaveBeenCalledWith('tdel');
+  });
+
+  it('cancels the delete confirm without deleting', () => {
+    h.state.tickets = [ticket({ id: 'tdel' })];
+    render(<SupportTicketsSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Supprimer le signalement/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Annuler$/ }));
+    expect(h.state.deleteTicket).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Supprimer le signalement/ })).toBeInTheDocument();
   });
 });

--- a/src/test/support/SupportTicketsSection.test.tsx
+++ b/src/test/support/SupportTicketsSection.test.tsx
@@ -182,7 +182,7 @@ describe('SupportTicketsSection', () => {
     h.state.tickets = [ticket({ id: 'tdel' })];
     render(<SupportTicketsSection />);
     fireEvent.click(screen.getByRole('button', { name: /Supprimer le signalement/ }));
-    fireEvent.click(screen.getByRole('button', { name: /^Annuler$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Annuler la suppression/ }));
     expect(h.state.deleteTicket).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: /Supprimer le signalement/ })).toBeInTheDocument();
   });

--- a/src/test/support/useSupportTickets.test.ts
+++ b/src/test/support/useSupportTickets.test.ts
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
   orderMock: vi.fn(),
   updateMock: vi.fn(),
   eqMock: vi.fn(),
+  deleteMock: vi.fn(),
+  deleteEqMock: vi.fn(),
   createSignedUrlMock: vi.fn(),
   auth: { user: { id: 'admin-1' } as { id: string } | null, initialized: true },
 }));
@@ -59,11 +61,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.auth.user = { id: 'admin-1' };
   h.auth.initialized = true;
-  h.fromMock.mockReturnValue({ select: h.selectMock, update: h.updateMock });
+  h.fromMock.mockReturnValue({ select: h.selectMock, update: h.updateMock, delete: h.deleteMock });
   h.selectMock.mockReturnValue({ order: h.orderMock });
   h.updateMock.mockReturnValue({ eq: h.eqMock });
+  h.deleteMock.mockReturnValue({ eq: h.deleteEqMock });
   h.orderMock.mockResolvedValue({ data: [], error: null });
   h.eqMock.mockResolvedValue({ error: null });
+  h.deleteEqMock.mockResolvedValue({ error: null });
   h.createSignedUrlMock.mockResolvedValue({ data: { signedUrl: `${SIGN_BASE}/u1/new.png?token=fresh` }, error: null });
 });
 
@@ -188,5 +192,39 @@ describe('useSupportTickets — updateStatus', () => {
     expect(result.current.error?.message).toContain('autorisée');
     // Optimistic patch must NOT have applied on failure.
     expect(result.current.tickets[0].status).toBe('open');
+  });
+});
+
+describe('useSupportTickets — deleteTicket', () => {
+  it('removes the ticket from the list optimistically on success', async () => {
+    h.orderMock.mockResolvedValue({ data: [ticket({ id: 't1' }), ticket({ id: 't2' })], error: null });
+    const { result } = renderHook(() => useSupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.deleteTicket('t1');
+    });
+
+    expect(ok).toBe(true);
+    expect(h.deleteMock).toHaveBeenCalled();
+    expect(h.deleteEqMock).toHaveBeenCalledWith('id', 't1');
+    expect(result.current.tickets.map((t) => t.id)).toEqual(['t2']);
+  });
+
+  it('maps an RLS denial (42501) to a friendly error and keeps the ticket', async () => {
+    h.orderMock.mockResolvedValue({ data: [ticket({ id: 't1' })], error: null });
+    h.deleteEqMock.mockResolvedValue({ error: { code: '42501', message: 'denied' } });
+    const { result } = renderHook(() => useSupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.deleteTicket('t1');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error?.message).toContain('autorisée');
+    expect(result.current.tickets).toHaveLength(1);
   });
 });

--- a/src/test/supportTickets.integration.test.ts
+++ b/src/test/supportTickets.integration.test.ts
@@ -437,14 +437,46 @@ describe('support_tickets — status/resolved coherence (migration 029)', () => 
 
 // ─── Test 12: super_admin DELETE policy (M2 RGPD Art. 17) ────────────────────
 
-describe('support_tickets — super_admin DELETE policy (migration 029)', () => {
-  it.skipIf(SKIP)('student cannot DELETE own ticket (no user delete policy)', async () => {
+describe('support_tickets — DELETE policies (029 super_admin + 033 user-own)', () => {
+  it.skipIf(SKIP)('student CAN delete own ticket (migration 033 — THI-334 teardown + RGPD Art. 17)', async () => {
     const { data: ticket } = await studentClient
       .from('support_tickets')
       .insert({
         user_id: studentUserId,
         type: 'bug',
-        description: 'Ticket for student DELETE denial test.',
+        description: 'Ticket for student self-DELETE test.',
+      })
+      .select('id')
+      .single();
+    expect(ticket?.id).toBeTruthy();
+    const ticketId = ticket!.id;
+    // Not pushed to createdTicketIds — this test deletes it itself.
+
+    // migration 033 added a "user delete own" policy → the owner can now erase.
+    const { data, error } = await studentClient
+      .from('support_tickets')
+      .delete()
+      .eq('id', ticketId)
+      .select('id');
+
+    expect(error).toBeNull();
+    expect(data?.length ?? 0).toBe(1); // own row actually deleted
+
+    const { data: verify } = await superAdminClient
+      .from('support_tickets')
+      .select('id')
+      .eq('id', ticketId)
+      .maybeSingle();
+    expect(verify).toBeNull();
+  });
+
+  it.skipIf(SKIP)("a non-owner non-admin user CANNOT delete another user's ticket (isolation)", async () => {
+    const { data: ticket } = await studentClient
+      .from('support_tickets')
+      .insert({
+        user_id: studentUserId,
+        type: 'bug',
+        description: 'Ticket for cross-user DELETE isolation test.',
       })
       .select('id')
       .single();
@@ -452,17 +484,17 @@ describe('support_tickets — super_admin DELETE policy (migration 029)', () => 
     const ticketId = ticket!.id;
     createdTicketIds.push(ticketId);
 
-    // Student attempts DELETE — RLS DELETE only matches super_admin.
-    const { data, error } = await studentClient
+    // teacher = different user, not super_admin → matches neither DELETE policy
+    // (user-delete-own needs user_id = auth.uid(); super_admin-delete-all needs role).
+    const { data, error } = await teacherClient
       .from('support_tickets')
       .delete()
       .eq('id', ticketId)
       .select('id');
 
-    expect(error).toBeNull(); // RLS does not throw, returns empty set.
-    expect(data?.length ?? 0).toBe(0); // 0 rows actually deleted.
+    expect(error).toBeNull(); // RLS returns an empty set, no throw.
+    expect(data?.length ?? 0).toBe(0); // 0 rows deleted — isolation preserved.
 
-    // Verify via super_admin that the row still exists.
     const { data: verify } = await superAdminClient
       .from('support_tickets')
       .select('id')

--- a/supabase/migrations/033_support_tickets_delete_policies.sql
+++ b/supabase/migrations/033_support_tickets_delete_policies.sql
@@ -1,0 +1,45 @@
+-- Migration 033 — support_tickets DELETE policies
+-- THI-347 volet 3 (super_admin purge) + fix THI-334 root cause (test teardown).
+--
+-- Migration 028 granted select/insert/update to `authenticated` but NOT delete,
+-- and defined no DELETE policy at all. Two consequences:
+--   1. THI-347 volet 3 : super_admin cannot delete a ticket from the triage UI
+--      (spam / obsolete / test rows) — only raw SQL could remove a row.
+--   2. THI-334 root cause : the support integration tests' afterAll teardown
+--      (`client.from('support_tickets').delete().in('id', createdIds)`, run as the
+--      test student) silently fails (no DELETE grant/policy) → test rows pile up in
+--      prod and fire a super_admin email on each `vitest` run.
+--
+-- Fix : grant delete + two DELETE policies. RLS OR-combines policies of the same
+-- command, so a row is deletable if the caller owns it OR is super_admin.
+--   - user delete own       → unblocks the test teardown (student deletes its own
+--     rows) AND gives users the RGPD Art.17 right to erase their own reports.
+--   - super_admin delete all → triage purge (THI-347 volet 3).
+--
+-- Security : both predicates are self-scoped (auth.uid()) or role-gated
+-- (get_my_role()); no cross-user surface. `anon` stays revoked (migration 028
+-- line 65 `revoke all ... from anon`). Deleting a row does NOT remove its storage
+-- screenshot object — orphan cleanup is deferred (bucket is private + super_admin
+-- read-only, so an orphan is inert; tracked for a later storage GC pass).
+
+grant delete on public.support_tickets to authenticated;
+
+-- drop-if-exists keeps this migration re-appliable (idempotent) on a fresh env.
+drop policy if exists "support_tickets: user delete own" on public.support_tickets;
+create policy "support_tickets: user delete own"
+  on public.support_tickets
+  for delete
+  to authenticated
+  using (user_id = auth.uid());
+
+drop policy if exists "support_tickets: super_admin delete all" on public.support_tickets;
+create policy "support_tickets: super_admin delete all"
+  on public.support_tickets
+  for delete
+  to authenticated
+  using (public.get_my_role() = 'super_admin');
+
+comment on policy "support_tickets: user delete own" on public.support_tickets is
+  'THI-347/THI-334. User erases own report (RGPD Art.17) + unblocks integration-test teardown DELETE.';
+comment on policy "support_tickets: super_admin delete all" on public.support_tickets is
+  'THI-347 volet 3. super_admin purges any ticket from the triage UI (spam/obsolete/test rows).';

--- a/supabase/migrations/033_support_tickets_delete_policies.sql
+++ b/supabase/migrations/033_support_tickets_delete_policies.sql
@@ -1,20 +1,23 @@
 -- Migration 033 — support_tickets DELETE policies
 -- THI-347 volet 3 (super_admin purge) + fix THI-334 root cause (test teardown).
 --
--- Migration 028 granted select/insert/update to `authenticated` but NOT delete,
--- and defined no DELETE policy at all. Two consequences:
---   1. THI-347 volet 3 : super_admin cannot delete a ticket from the triage UI
---      (spam / obsolete / test rows) — only raw SQL could remove a row.
+-- Migration 028 created the table; migration 029 (security hardening) already added
+-- the `super_admin delete all` DELETE policy + `grant delete to authenticated`. What
+-- was STILL missing: a `user delete own` DELETE policy — the ONLY genuinely new policy
+-- this migration adds. Two consequences of its absence:
+--   1. THI-347 volet 3 : super_admin could already delete via REST (029) but the
+--      triage UI had no delete button — this PR adds the button (backend was ready).
 --   2. THI-334 root cause : the support integration tests' afterAll teardown
 --      (`client.from('support_tickets').delete().in('id', createdIds)`, run as the
---      test student) silently fails (no DELETE grant/policy) → test rows pile up in
---      prod and fire a super_admin email on each `vitest` run.
+--      test student) silently failed — no `user delete own` policy → test rows piled
+--      up in prod and fired a super_admin email on each `vitest` run.
 --
--- Fix : grant delete + two DELETE policies. RLS OR-combines policies of the same
--- command, so a row is deletable if the caller owns it OR is super_admin.
+-- This migration adds `user delete own` and re-states (drop+recreate, idempotent)
+-- `super_admin delete all` from 029 so the file is self-contained on a fresh env.
+-- RLS OR-combines DELETE policies → a row is deletable if owned OR caller super_admin.
 --   - user delete own       → unblocks the test teardown (student deletes its own
 --     rows) AND gives users the RGPD Art.17 right to erase their own reports.
---   - super_admin delete all → triage purge (THI-347 volet 3).
+--   - super_admin delete all → triage purge (THI-347 volet 3) — origin: migration 029.
 --
 -- Security : both predicates are self-scoped (auth.uid()) or role-gated
 -- (get_my_role()); no cross-user surface. `anon` stays revoked (migration 028


### PR DESCRIPTION
## THI-347 volet 3 — Supprimer un ticket support (+ fix THI-334 racine)

Le panneau admin pouvait filtrer/changer le statut d'un ticket mais **pas le supprimer** (les tickets de test ne se purgeaient que par SQL → THI-334). Cette PR ajoute la suppression **et fixe THI-334 à la racine**.

### Backend (migration 033, déjà appliquée prod)
- Migration 029 avait déjà `super_admin delete all`. Il manquait **`user delete own`** → je l'ajoute. RLS OR-combine :
  - **`user delete own`** (`user_id = auth.uid()`) → débloque le **teardown des tests d'intégration** (le student supprimait ses lignes en `afterAll`, ça échouait silencieusement = **THI-334**) + droit **RGPD Art. 17** (un user efface ses propres signalements).
  - **`super_admin delete all`** → purge triage (déjà présent).
- Idempotent (drop-if-exists), `anon` reste revoqué.

### Frontend
- `useSupportTickets.deleteTicket(id)` — retrait optimiste, 42501/PGRST301 → message FR.
- `SupportTicketsSection` : bouton **Supprimer** par ticket, **confirmation inline 2 étapes** (pas de dialog natif). super_admin purge spam/obsolète/test.

### Tests
- Hook : deleteTicket succès + mapping refus RLS.
- UI : confirm 2 étapes appelle deleteTicket ; annuler non.
- **Integration (REST+JWT)** : « student cannot delete » inversé → **« student CAN delete own »** (033) + **NOUVEAU test d'isolation** (un non-owner non-admin → 0 ligne). **16/16, teardown purge → fini la pollution.**

### Gates
`supabase-backend-auditor` (policy DELETE) + `ui-auditor` (bouton) + `feature-dev:code-reviewer` en cours + Voie A super_admin à suivre.

Closes THI-334 (root cause). THI-347 volet 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)