### PR TITLE
fix(mobile): THI-342 — textarea 16px on mobile (iOS auto-zoom) + UserMenu tap-target floor

### DIFF
--- a/src/app/components/auth/UserMenu.tsx
+++ b/src/app/components/auth/UserMenu.tsx
@@ -136,7 +136,7 @@ export function UserMenu({ syncStatus, variant = 'card', extraActions, secondary
   // Se déconnecter. Langage couleur : liens = neutre→emerald au survol,
   // Se déconnecter = rouge (cohérent avec l'existant).
   const itemClass =
-    'flex items-center w-full justify-start gap-2.5 px-4 py-3 text-sm text-[var(--github-text-primary)] font-mono hover:bg-emerald-500/10 hover:text-emerald-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-inset';
+    'flex items-center w-full justify-start min-h-11 gap-2.5 px-4 py-3 text-sm text-[var(--github-text-primary)] font-mono hover:bg-emerald-500/10 hover:text-emerald-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-inset';
 
   const menuItems = (
     <div className="py-1" role="none">

--- a/src/app/components/support/SupportTicketModal.tsx
+++ b/src/app/components/support/SupportTicketModal.tsx
@@ -210,6 +210,9 @@ export function SupportTicketModal({ userId, onClose }: SupportTicketModalProps)
               >
                 Description
               </label>
+              {/* text-base (16px) on mobile prevents iOS Safari focus auto-zoom (any
+                  input < 16px triggers it), the cause of the THI-342 viewport overflow
+                  after focus. md:text-sm restores 14px on desktop (MessageInput pattern). */}
               <textarea
                 id={descId}
                 value={description}
@@ -219,7 +222,7 @@ export function SupportTicketModal({ userId, onClose }: SupportTicketModalProps)
                 required
                 aria-describedby={descHintId}
                 placeholder="Que s'est-il passé ? Ce que tu faisais, ce qui n'a pas marché, et ce que tu attendais. Plus c'est précis, plus on peut aider vite."
-                className="w-full rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] px-3 py-2 text-sm text-[var(--github-text-primary)] placeholder:text-[var(--github-text-secondary)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+                className="w-full rounded-lg border border-[var(--github-border-primary)] bg-[var(--github-bg-secondary)] px-3 py-2 text-base md:text-sm text-[var(--github-text-primary)] placeholder:text-[var(--github-text-secondary)] outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
               />
               <p id={descHintId} className="mt-1 text-xs text-[var(--github-text-secondary)]">
                 {trimmedLength < DESCRIPTION_MIN


### PR DESCRIPTION
## THI-342 — le formulaire de signalement déborde sur mobile

Corrige le bug signalé dans le ticket support `21f3df1e` : le formulaire « Signaler un problème » débordait du viewport sur iPhone.

### Cause racine (diagnostiquée par `mobile-responsive-auditor`)
Le `<textarea>` de description était en `text-sm` (14px). **Sur iOS Safari, tout champ < 16px déclenche un auto-zoom au focus** — ce zoom élargit la viewport logique puis la dézoome, provoquant le débordement observé.

### Fix
- **`SupportTicketModal.tsx`** : `text-sm` → `text-base md:text-sm` (16px sur mobile = plus d'auto-zoom, 14px restauré sur desktop). Même pattern que `MessageInput.tsx`.
- **`UserMenu.tsx`** (nit du même audit) : plancher `min-h-11` (44px Apple HIG) explicite sur les items du dropdown. Ils franchissaient déjà 44px via le padding ; le plancher garantit la cible tactile contre un futur refactor. **0 changement visuel desktop.**

### Hors scope (volontaire)
Le nit sidebar `pb-[max(1rem,env(...))]` proposé par l'audit est **écarté** : il ajouterait 16px de padding bottom **sur desktop aussi** (où `env()=0`) = régression desktop. Le `env(safe-area-inset-bottom)` actuel reste correct (0 desktop, 34px iPhone notché).

### Validation
- `text-base md:text-sm` = className-only, **0 logique touchée**.
- type-check ✅ · lint ✅ · **109 tests** support/auth ✅.
- Gates : `ui-auditor` + `feature-dev:code-reviewer` + Voie A mobile 390px (à venir avant merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajuster la taille de la zone de texte du formulaire mobile et les zones cliquables des éléments du menu utilisateur pour améliorer l’ergonomie et l’accessibilité sur iOS.

Corrections de bugs :
- Empêcher le zoom automatique de Safari iOS de provoquer un dépassement de la fenêtre d’affichage sur la zone de texte de description du ticket de support en utilisant une taille de police de 16px sur mobile.

Améliorations :
- Imposer une hauteur minimale pour les éléments du menu déroulant utilisateur afin de maintenir des zones de tap suffisantes sur tous les appareils.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust mobile form textarea sizing and user menu item tap targets to improve iOS usability and accessibility.

Bug Fixes:
- Prevent iOS Safari auto-zoom causing viewport overflow on the support ticket description textarea by using a 16px font size on mobile.

Enhancements:
- Enforce a minimum height on user menu dropdown items to maintain adequate tap targets across devices.

</details>