### PR TITLE
fix(support): [HOTFIX] closing a ticket violated resolved-consistency constraint

### DIFF
--- a/src/lib/hooks/useSupportTickets.ts
+++ b/src/lib/hooks/useSupportTickets.ts
@@ -119,6 +119,13 @@ export function useSupportTickets(): UseSupportTicketsResult {
   // away mid-flight) — same pattern as ScreenshotViewer below (code-reviewer).
   const isMountedRef = useRef(true);
   useEffect(() => () => { isMountedRef.current = false; }, []);
+  // Mirror `tickets` into a ref so updateStatus can read the current row (to
+  // preserve an existing resolution stamp when closing) WITHOUT taking `tickets`
+  // as a useCallback dep — that would rebuild the callback on every ticket change
+  // and re-render every TicketCard it's passed to (Sourcery PR #377). The ref is
+  // always current by the time a user-triggered updateStatus runs.
+  const ticketsRef = useRef<SupportTicket[]>([]);
+  useEffect(() => { ticketsRef.current = tickets; }, [tickets]);
 
   const refresh = useCallback(async () => {
     if (!user || !supabase) {
@@ -168,7 +175,7 @@ export function useSupportTickets(): UseSupportTicketsResult {
       // already-resolved ticket; stamp now/self when entering a terminal state
       // directly from open/in_progress.
       const isTerminal = next === 'resolved' || next === 'closed';
-      const current = tickets.find((t) => t.id === id);
+      const current = ticketsRef.current.find((t) => t.id === id);
       const patch = {
         status: next,
         resolved_at: isTerminal ? (current?.resolved_at ?? new Date().toISOString()) : null,
@@ -201,7 +208,7 @@ export function useSupportTickets(): UseSupportTicketsResult {
         if (isMountedRef.current) setUpdatingId(null);
       }
     },
-    [user, tickets],
+    [user],
   );
 
   const deleteTicket = useCallback(

--- a/src/lib/hooks/useSupportTickets.ts
+++ b/src/lib/hooks/useSupportTickets.ts
@@ -159,13 +159,20 @@ export function useSupportTickets(): UseSupportTicketsResult {
       setUpdatingId(id);
       setError(null);
 
-      // resolved_* are only meaningful for the resolved state; clear them on any
-      // other transition so a re-opened ticket doesn't keep a stale resolver.
-      const isResolved = next === 'resolved';
+      // 'resolved' AND 'closed' are BOTH terminal states: the DB constraint
+      // `support_tickets_resolved_consistency` requires resolved_at + resolved_by
+      // to be non-null for either, and null for open/in_progress. Clearing them
+      // on a transition to 'closed' violated the constraint → the UPDATE was
+      // rejected and the UI showed "Mise à jour impossible" (closing any ticket
+      // was broken). Preserve an existing resolution stamp when closing an
+      // already-resolved ticket; stamp now/self when entering a terminal state
+      // directly from open/in_progress.
+      const isTerminal = next === 'resolved' || next === 'closed';
+      const current = tickets.find((t) => t.id === id);
       const patch = {
         status: next,
-        resolved_at: isResolved ? new Date().toISOString() : null,
-        resolved_by: isResolved ? user.id : null,
+        resolved_at: isTerminal ? (current?.resolved_at ?? new Date().toISOString()) : null,
+        resolved_by: isTerminal ? (current?.resolved_by ?? user.id) : null,
       };
 
       try {
@@ -194,7 +201,7 @@ export function useSupportTickets(): UseSupportTicketsResult {
         if (isMountedRef.current) setUpdatingId(null);
       }
     },
-    [user],
+    [user, tickets],
   );
 
   const deleteTicket = useCallback(

--- a/src/test/support/useSupportTickets.test.ts
+++ b/src/test/support/useSupportTickets.test.ts
@@ -177,6 +177,46 @@ describe('useSupportTickets — updateStatus', () => {
     expect(result.current.tickets[0].resolved_at).toBeNull();
   });
 
+  it('keeps the original resolved_at + resolved_by when CLOSING an already-resolved ticket', async () => {
+    // Regression: 'closed' is a terminal state too. The DB constraint
+    // support_tickets_resolved_consistency requires resolved_at/by non-null for
+    // 'closed' — clearing them (old isResolved-only logic) violated it and broke
+    // closing any ticket. We must preserve the existing resolution stamp.
+    h.orderMock.mockResolvedValue({
+      data: [ticket({ status: 'resolved', resolved_at: '2026-06-05T04:27:00Z', resolved_by: 'admin-9' })],
+      error: null,
+    });
+    const { result } = renderHook(() => useSupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateStatus('t1', 'closed');
+    });
+
+    expect(h.updateMock).toHaveBeenCalledWith({
+      status: 'closed',
+      resolved_at: '2026-06-05T04:27:00Z',
+      resolved_by: 'admin-9',
+    });
+    expect(result.current.tickets[0].status).toBe('closed');
+    expect(result.current.tickets[0].resolved_at).toBe('2026-06-05T04:27:00Z');
+  });
+
+  it('stamps resolved_at + resolved_by when closing directly from a non-terminal state', async () => {
+    h.orderMock.mockResolvedValue({ data: [ticket({ status: 'open' })], error: null });
+    const { result } = renderHook(() => useSupportTickets());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateStatus('t1', 'closed');
+    });
+
+    const patch = h.updateMock.mock.calls[0][0] as { status: string; resolved_at: string | null; resolved_by: string | null };
+    expect(patch.status).toBe('closed');
+    expect(typeof patch.resolved_at).toBe('string');
+    expect(patch.resolved_by).toBe('admin-1');
+  });
+
   it('maps an RLS denial (42501) to a friendly FR error', async () => {
     h.orderMock.mockResolvedValue({ data: [ticket()], error: null });
     h.eqMock.mockResolvedValue({ error: { code: '42501', message: 'permission denied' } });


### PR DESCRIPTION
## [HOTFIX] Impossible de fermer un ticket support

Bug prod signalé par @thierry : passer un ticket à **« Fermé »** depuis le triage super_admin (`/app/admin`) échoue avec « Mise à jour du statut impossible ». **Aucun ticket ne pouvait être fermé.**

### Cause racine (vérifiée contre le schéma prod)
La contrainte `support_tickets_resolved_consistency` traite **`resolved` ET `closed`** comme états terminaux exigeant `resolved_at` + `resolved_by` **non-null** (et null pour `open`/`in_progress`). Or `updateStatus` ne posait `resolved_*` que pour `resolved` (`isResolved`) → un passage à `closed` envoyait `resolved_at=null` → **violation de contrainte** → UPDATE rejeté (erreur générique, pas 42501).

### Fix
`updateStatus` traite `resolved` **et** `closed` comme terminaux : préserve le stamp de résolution existant en fermant un ticket déjà résolu (ne pas écraser qui/quand), estampille now/self en entrant dans un état terminal depuis `open`/`in_progress`. `tickets` ajouté aux deps du callback pour lire la ligne courante.

### Validation
- Root cause prouvée : lecture de la contrainte en base + ticket réel `21f3df1e` (resolved + resolved_* set → le fix le fermera).
- 2 tests de régression (fermeture préserve le stamp ; fermeture directe estampille).
- type-check ✅ · lint ✅ · **17/17** tests hook support ✅. **Aucun changement DB/RLS** (logique client uniquement).
- code-reviewer + Voie A preview (reproduction de la fermeture en super_admin) avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Garantir que les tickets de support considèrent à la fois les statuts « résolu » et « fermé » comme des états terminaux, avec des métadonnées de résolution cohérentes lors de la mise à jour du statut.

Corrections de bugs :
- Corriger l’échec lors de la fermeture des tickets de support en conservant ou en définissant `resolved_at` et `resolved_by` pour les états terminaux afin de satisfaire la contrainte de cohérence de la base de données.

Tests :
- Ajouter des tests de régression couvrant la fermeture d’un ticket déjà résolu et la fermeture directe depuis un ticket ouvert, afin de vérifier le comportement des métadonnées de résolution.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure support tickets treat both resolved and closed as terminal states with consistent resolution metadata when updating status.

Bug Fixes:
- Fix failure when closing support tickets by preserving or stamping resolved_at and resolved_by for terminal states to satisfy the database consistency constraint.

Tests:
- Add regression tests covering closing an already-resolved ticket and closing directly from an open ticket to verify resolution metadata behavior.

</details>