### PR TITLE
security(db): revoke EXECUTE on trigger-only SECURITY DEFINER fns (advisor 0028/0029)

### DIFF
--- a/supabase/migrations/034_revoke_execute_trigger_functions.sql
+++ b/supabase/migrations/034_revoke_execute_trigger_functions.sql
@@ -1,0 +1,84 @@
+-- ─── 034: Revoke EXECUTE on trigger-only SECURITY DEFINER functions (advisor 0028/0029) ───
+-- Supabase Database Advisors flag two SECURITY DEFINER functions in the `public`
+-- schema as callable via `/rest/v1/rpc/*` by the `anon` and `authenticated` roles:
+--
+--   • public.audit_pending_teacher_promotion()   (migration 026, THI-280)
+--   • public.log_support_ticket_status_change()   (migrations 028 + 029)
+--
+-- Both are **trigger-only** — attached to AFTER-UPDATE triggers on `profiles`
+-- and `support_tickets` respectively, and never invoked as `/rest/v1/rpc/<name>`.
+-- A grep of `src/` confirms ZERO `.rpc()` call sites for either (both appear
+-- only inside code comments). PostgreSQL fires a TRIGGER without consulting the
+-- EXECUTE grant on the trigger function, so revoking EXECUTE from every
+-- user-facing role closes the PostgREST exposure surface with ZERO functional
+-- impact.
+--
+-- This is the exact treatment already applied to handle_new_user(),
+-- prevent_role_escalation() and rls_auto_enable() in migrations 014 + 015
+-- (THI-180). Those three predate 026/029; the two functions here were introduced
+-- afterwards and inherited PostgreSQL's default PUBLIC EXECUTE grant (which
+-- anon/authenticated inherit) — hence the fresh advisor hit.
+--
+-- ─── Explicitly NOT touched (deliberate) ────────────────────────────────────
+--   • get_my_role(), get_my_institution_id(), is_teacher_of_class(uuid)
+--     → RLS helpers invoked inside ~15 USING clauses. PostgreSQL requires the
+--       calling role to hold EXECUTE even for a SECURITY DEFINER function used
+--       in a policy expression; revoking would break every protected read with
+--       `permission denied for function`. The clean fix is to move them to a
+--       `private` schema not exposed by PostgREST (Supabase-documented pattern,
+--       confirmed via Context7 /supabase/supabase) — tracked THI-182, separate
+--       audited PR.
+--   • admin_platform_stats(), admin_activity_heatmap(), approve_teacher(uuid),
+--     join_class_by_code(text)
+--     → legitimate authenticated-facing RPCs called by the frontend
+--       (useAdminAnalytics, useJoinClass, usePendingTeachers). They are SECURITY
+--       DEFINER by design (cross-user aggregation / privileged writes) and
+--       self-guard with an internal `get_my_role()` gate that raises
+--       PERMISSION_DENIED for non-privileged callers. The
+--       `authenticated_security_definer_function_executable` warning on these is
+--       acknowledged and correct — revoking `authenticated` would break the
+--       Admin panel, teacher approval and student class-join. Left callable.
+--
+-- Idempotent: each REVOKE + COMMENT is wrapped in a `DO` block guarded on
+-- pg_proc, so a renamed/dropped function makes the block a no-op instead of
+-- failing the whole migration. Safe to re-run across environments.
+--
+-- Refs:
+--   - Supabase advisor lints 0028 + 0029
+--   - Migrations 014 + 015 (THI-180) — same pattern, prior functions
+--   - Migration 026 (audit trigger on profiles) + 028/029 (support-ticket trigger)
+--   - https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable
+--   - THI-182 (backlog) — move RLS helpers to a `private` schema
+
+-- ── 1. audit_pending_teacher_promotion() — AFTER UPDATE trigger on profiles
+--    (migration 026). Fires on pending_teacher → teacher promotions. Never RPC.
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'audit_pending_teacher_promotion'
+      and pg_get_function_identity_arguments(p.oid) = ''
+  ) then
+    execute 'revoke execute on function public.audit_pending_teacher_promotion() from public, anon, authenticated';
+    execute $cmt$comment on function public.audit_pending_teacher_promotion() is
+      'TRIGGER on profiles UPDATE (migration 026, THI-280) — audits pending_teacher → teacher promotions performed via direct REST PATCH (RPC path is de-duplicated via a txn-local flag). SECURITY DEFINER to write admin_audit_log across RLS. EXECUTE retained by postgres (owner) only; revoked from public/anon/authenticated (advisor 0028/0029, migration 034) — invoked by trigger, never RPC.'$cmt$;
+  end if;
+end$$;
+
+-- ── 2. log_support_ticket_status_change() — AFTER UPDATE trigger on
+--    support_tickets (trigger created in migration 028, function hardened in
+--    029). Fires on status change. Never RPC.
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'log_support_ticket_status_change'
+      and pg_get_function_identity_arguments(p.oid) = ''
+  ) then
+    execute 'revoke execute on function public.log_support_ticket_status_change() from public, anon, authenticated';
+    execute $cmt$comment on function public.log_support_ticket_status_change() is
+      'TRIGGER on support_tickets UPDATE (migrations 028 + 029) — logs status changes to admin_audit_log (service_role caller skipped via auth.uid() NULL guard). SECURITY DEFINER for cross-RLS audit write. EXECUTE retained by postgres (owner) only; revoked from public/anon/authenticated (advisor 0028/0029, migration 034) — invoked by trigger, never RPC.'$cmt$;
+  end if;
+end$$;


### PR DESCRIPTION
## Contexte

Supabase Database Advisors signalent des fonctions `SECURITY DEFINER` du schéma `public` exécutables via `/rest/v1/rpc/*` par `anon`/`authenticated` (lints **0028** + **0029**). Cette PR corrige **uniquement** la catégorie 100% sûre.

## Analyse — 3 catégories

| Cat | Fonctions | Décision | Cette PR |
|-----|-----------|----------|----------|
| **A — trigger-only** | `audit_pending_teacher_promotion()`, `log_support_ticket_status_change()` | REVOKE EXECUTE (public+anon+authenticated) | ✅ **corrigé** |
| **B — helpers RLS** | `get_my_role()`, `get_my_institution_id()`, `is_teacher_of_class()` | Déplacer vers schéma `private` (EXECUTE requis en clause USING, revoke = casse RLS) | ⏭️ différé **THI-182** |
| **C — RPC légitimes** | `admin_platform_stats()`, `admin_activity_heatmap()`, `approve_teacher()`, `join_class_by_code()` | Aucune — appelées par le frontend en `authenticated`, auto-protégées par gate `get_my_role()` interne | ➖ *by-design* |

## Pourquoi la Cat A est sans risque
- Les 2 fonctions sont `returns trigger`, attachées à des `AFTER UPDATE` triggers (migrations 026, 028/029), **0 call-site `.rpc()`** dans `src/` (grep vérifié).
- PostgreSQL déclenche un trigger **sans consulter le GRANT EXECUTE** → révoquer ne casse rien.
- Pattern **identique** à ce qui a été fait en migrations **014 + 015** (THI-180) pour les 3 fonctions trigger pré-existantes. Ces 2-ci ont été ajoutées après 015 et ont hérité du grant PUBLIC par défaut.

## Fichiers
- `supabase/migrations/034_revoke_execute_trigger_functions.sql` (idempotent, DO-blocks guardés sur `pg_proc`)

## Effet advisor
- Clôt **4 lignes** advisor (audit_pending + log_support, en anon ET authenticated).
- Restent : 6 lignes Cat B (THI-182) + 4 lignes Cat C (by-design, acceptées).
- Hors scope : `auth_leaked_password_protection` (feature plan Pro, non actionnable en free).

## Validation
- [ ] `security-auditor` gate (doctrine migrations/)
- [ ] Sourcery
- [ ] Migration appliquée en prod + advisors re-scannés (2 warnings disparus, 0 nouveau)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restreindre l’exécution des fonctions `SECURITY DEFINER` réservées aux triggers afin de fermer la faille identifiée par les outils de conseil en sécurité de la base de données, tout en préservant le RLS requis et le comportement RPC de l’application.

Corrections de bugs :
- Révoquer les privilèges `EXECUTE` pour les utilisateurs anonymes et authentifiés sur les deux fonctions `SECURITY DEFINER` réservées aux triggers signalées par les conseillers en sécurité de la base de données, afin d’éliminer leur exposition RPC involontaire sans affecter l’exécution des triggers.

Améliorations :
- Rendre la migration de révocation de privilèges idempotente et sûre sur tous les environnements en conditionnant les modifications à la présence des fonctions.
- Documenter l’exclusion délibérée des fonctions d’aide au RLS et des RPC authentifiés légitimes qui nécessitent leurs privilèges d’exécution actuels.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict execution of trigger-only SECURITY DEFINER functions to close the identified database advisor exposure while preserving required RLS and application RPC behavior.

Bug Fixes:
- Revoke EXECUTE privileges for anonymous and authenticated users on the two trigger-only SECURITY DEFINER functions flagged by database security advisors, eliminating their unintended RPC exposure without affecting trigger execution.

Enhancements:
- Make the privilege revocation migration idempotent and safe across environments by guarding changes against the functions' presence.
- Document the deliberate exclusion of RLS helper functions and legitimate authenticated RPCs that require their current execution privileges.

</details>