### PR TITLE
chore(mcp): pin this project's MCP servers to the folder's account

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref=jdnukbpkjyyyjpuwgxhv",
+        "--read-only"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What breaks without this

MCP servers are declared machine-wide and the popular ones authenticate by OAuth,
so this project inherits whichever account was connected last. Nothing local pins
it.

Measured across the machine on 25 August 2026: **eight MCP servers declared
machine-wide** across four configuration files — Linear, Coda, Notion, GitHub,
Supabase among them — and **zero of twenty-two projects** carrying a
project-scoped declaration.

## What this file does

Written by `ctx mcp -Client claude`. It resolves the Supabase `project-ref` from
**this folder**, so the assistant reaches this project's database rather than
whichever account happened to be connected.

**No secret is in it.** The token comes from the environment `work` fills from the
folder — the file carries a project reference and nothing else. That is why it can
be committed, and it *has* to be: uncommitted, it protects one machine and
vanishes on the next clone.

Read-only by default.

## Only this file

Every other modified file in the working tree was left untouched and unstaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Épingler le serveur MCP Supabase du projet au contexte spécifique à son dossier, sans enregistrer les identifiants.

Nouvelles fonctionnalités :
- Ajouter une configuration MCP limitée au projet qui associe le serveur Supabase au contexte de base de données de ce projet.

Corrections de bugs :
- Empêcher l’authentification MCP d’utiliser par inadvertance le compte à l’échelle de la machine auquel la connexion a été établie le plus récemment.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin the project's Supabase MCP server to its folder-specific project context without committing credentials.

New Features:
- Add a project-scoped MCP configuration that pins the Supabase server to this project's database context.

Bug Fixes:
- Prevent MCP authentication from inadvertently using whichever machine-wide account was connected most recently.

</details>